### PR TITLE
calculate rate for bperf metrics

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -224,7 +224,9 @@ class Monitor {
 
     for (auto& [k, cr] : bperf_count_readers_) {
       HBT_THROW_ASSERT_IF(cr == nullptr);
-      rvs.emplace(k, cr->read(skip_offset));
+      if (cr->isEnabled()) {
+        rvs.emplace(k, cr->read(skip_offset));
+      }
     }
     return rvs;
   }


### PR DESCRIPTION
Summary: use MetricFrame to record raw values reading from bperf and calculate the rate when report

Differential Revision: D37816904

