### PR TITLE
log fbpkg info to ipt json file

### DIFF
--- a/hbt/src/mon/MonData.h
+++ b/hbt/src/mon/MonData.h
@@ -652,6 +652,7 @@ namespace detail {
 // this filtering is a bottleneck. For now we take simple, readable approach to
 // filtering.
 std::vector<ModuleInfo> getFileBackedExecutableModules(
+    const std::filesystem::path& root_path,
     std::vector<pfs::mem_region>& mem_regions);
 } // namespace detail
 

--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -123,9 +123,12 @@ class Monitor {
     pfs::procfs pfs;
 
     for (auto pid : pids) {
+      auto root_path =
+          std::filesystem::path("/proc") / std::to_string(pid) / "root";
       try {
         auto maps = pfs.get_task(pid).get_maps();
-        module_info.emplace(pid, detail::getFileBackedExecutableModules(maps));
+        module_info.emplace(
+            pid, detail::getFileBackedExecutableModules(root_path, maps));
       } catch (const pfs::parser_error& ex) {
         HBT_LOG_ERROR() << "Exception parsing the memory maps file for PID "
                         << pid << ". Message " << ex.what();
@@ -145,7 +148,9 @@ class Monitor {
 
     for (auto pid : pids) {
       auto maps = pfs.get_task(pid).get_maps();
-      auto modules = detail::getFileBackedExecutableModules(maps);
+      auto root_path =
+          std::filesystem::path("/proc") / std::to_string(pid) / "root";
+      auto modules = detail::getFileBackedExecutableModules(root_path, maps);
       func(pid, modules);
     }
   }

--- a/hbt/src/mon/tests/MonDataTest.cpp
+++ b/hbt/src/mon/tests/MonDataTest.cpp
@@ -53,7 +53,7 @@ TEST_F(ModuleCollectionTest, Collect) {
   pfs::procfs pfs(path.string());
 
   auto maps = pfs.get_task(1234).get_maps();
-  auto modules = detail::getFileBackedExecutableModules(maps);
+  auto modules = detail::getFileBackedExecutableModules("/", maps);
   ASSERT_EQ(modules.size(), EXPECTED_NUM_MODULES);
 
   for (size_t i = 0; i < EXPECTED_NUM_MODULES; i++) {


### PR DESCRIPTION
Summary:
1) handle chroot

twagent typically use chroot to construct task container. use /proc/<pid>/root instead of / as root directory so we can correctly find binary file referred in the /proc/<pid>/maps

2) try to parse fbpkg info from elf header if present and log fbpkg info to json file

Reviewed By: jj10306

Differential Revision: D39167538

