### PR TITLE
Add network stats monitoring to open-source dynolog

### DIFF
--- a/src/KernelCollector.cpp
+++ b/src/KernelCollector.cpp
@@ -9,6 +9,8 @@
 #include <string.h>
 #include <sys/prctl.h>
 
+#include <iostream>
+
 namespace dynolog {
 
 inline int64_t ticksToMs(int64_t ticks) {
@@ -19,6 +21,7 @@ KernelCollector::KernelCollector() : KernelCollectorBase() {}
 void KernelCollector::step() {
   uptime_ = readUptime();
   readCpuStats();
+  readNetworkStats();
 }
 
 void KernelCollector::log(Logger& log) {
@@ -62,6 +65,17 @@ void KernelCollector::log(Logger& log) {
           fmt::format("cpu_i_node{}", i),
           nodeCpuTime_[i].i / node_ticks * 100.0);
     }
+  }
+
+  for (const auto& [devName, devRxtx] : rxtxDelta_) {
+    log.log(fmt::format("rx_bytes_{}", devName), devRxtx.rxBytes);
+    log.log(fmt::format("rx_packets_{}", devName), devRxtx.rxPackets);
+    log.log(fmt::format("rx_errors_{}", devName), devRxtx.rxErrors);
+    log.log(fmt::format("rx_drops_{}", devName), devRxtx.rxDrops);
+    log.log(fmt::format("tx_bytes_{}", devName), devRxtx.txBytes);
+    log.log(fmt::format("tx_packets_{}", devName), devRxtx.txPackets);
+    log.log(fmt::format("tx_errors_{}", devName), devRxtx.txErrors);
+    log.log(fmt::format("tx_drops_{}", devName), devRxtx.txDrops);
   }
 
   log.setTimestamp();

--- a/src/KernelCollector.h
+++ b/src/KernelCollector.h
@@ -20,9 +20,6 @@ class KernelCollector : public KernelCollectorBase {
   void step();
 
   void log(Logger& logger);
-
- private:
-  bool first_ = true;
 };
 
 } // namespace dynolog

--- a/src/KernelCollectorBase.cpp
+++ b/src/KernelCollectorBase.cpp
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,8 +9,19 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "KernelCollectorBase.h"
 
-#include <pfs/procfs.hpp>
 #include <chrono>
+#include <sstream>
+#include <string>
+#include <vector>
+
+DEFINE_bool(
+    filter_nic_interfaces,
+    false,
+    "Filter NIC interfaces based on list specified with '-allow_interface_prefixes'");
+DEFINE_string(
+    allow_interface_prefixes,
+    "eno,ens,enp,enx,eth",
+    "Comma-separated list of NIC interface prefixes allowed for monitoring");
 
 namespace dynolog {
 
@@ -19,12 +31,20 @@ namespace dynolog {
 //   2. Must not use Meta specific infrastructure.
 //   3. Try to leverage std:: instead of folly:: library.
 
-KernelCollectorBase::KernelCollectorBase(const std::string& root)
+KernelCollectorBase::KernelCollectorBase(const std::string& rootDir)
     : uptime_(readUptime()),
-      pfs_(root),
+      rootDir_(rootDir),
+      pfs_(rootDir_ + "/proc"),
       numCpuSockets_(1), // TODO discover sockets from /proc/cpuinfo
-      cpuCoresTotal_(pfs_.get_stat().cpus.per_item.size()) {
+      cpuCoresTotal_(pfs_.get_stat().cpus.per_item.size()),
+      filterInteraces_(FLAGS_filter_nic_interfaces) {
   perCoreCpuTime_.resize(cpuCoresTotal_);
+
+  std::istringstream iss(FLAGS_allow_interface_prefixes);
+  std::string prefix;
+  while (std::getline(iss, prefix, ',')) {
+    nicInterfacePrefixes_.push_back(prefix);
+  }
 }
 
 time_t KernelCollectorBase::readUptime() {
@@ -85,6 +105,80 @@ void KernelCollectorBase::readCpuStats() {
     nodeCpuTime_[node] += coreCpu;
     core++;
   }
+}
+
+void KernelCollectorBase::readNetworkStats() {
+  auto devices = pfs_.get_net().get_dev();
+
+  std::map<std::string, struct RxTx> rxtxNew_;
+
+  size_t nicDevCount = 0;
+  for (const auto& device : devices) {
+    if (!isMonitoringInterfaceActive(device.interface)) {
+      continue;
+    }
+
+    nicDevCount++;
+
+    auto& devRxtx = rxtxNew_[device.interface];
+
+    devRxtx.rxBytes = device.rx_bytes;
+    devRxtx.rxPackets = device.rx_packets;
+    devRxtx.rxErrors = device.rx_errs;
+    devRxtx.rxDrops = device.rx_drop;
+    devRxtx.txBytes = device.tx_bytes;
+    devRxtx.txPackets = device.tx_packets;
+    devRxtx.txErrors = device.tx_errs;
+    devRxtx.txDrops = device.tx_drop;
+  }
+
+  updateNetworkStatsDelta(rxtxNew_);
+
+  if (nicDevCount == 0) {
+    LOG_EVERY_N(WARNING, 10) << "No NIC devices being monitored.";
+  } else if (!first_ && nicDevCount != nicDevCount_) {
+    LOG(WARNING) << "Number of NIC devices changed, previously " << nicDevCount_
+                 << " and now " << nicDevCount;
+  }
+  nicDevCount_ = nicDevCount;
+}
+
+bool KernelCollectorBase::isMonitoringInterfaceActive(std::string interface) {
+  if (interface.length() >= IFNAMSIZ) {
+    LOG(ERROR) << "invalid device name found: " << interface;
+    // Device name is too long to be valid, so consider the line malformed and
+    // not monitor interface
+    return false;
+  }
+
+  if (!filterInteraces_) {
+    // Device name is valid and no prefix filtering, so always return true
+    return true;
+  }
+
+  for (const auto& prefix : nicInterfacePrefixes_) {
+    if (interface.find(prefix) == 0) {
+      // Device name is valid length and matches a prefix
+      return true;
+    }
+  }
+
+  // Device name is valid but does not match any prefixes
+  return false;
+}
+
+void KernelCollectorBase::updateNetworkStatsDelta(
+    const std::map<std::string, struct RxTx>& rxtxNew) {
+  rxtxDelta_.clear();
+  for (const auto& [devName, devRxtxNew] : rxtxNew) {
+    if (rxtx_.find(devName) == rxtx_.end()) {
+      // New device not in last sample, so rxtxDelta_ will be zeros.
+      rxtxDelta_[devName] = RxTx{};
+    } else {
+      rxtxDelta_[devName] = devRxtxNew - rxtx_[devName];
+    }
+  }
+  rxtx_ = rxtxNew;
 }
 
 } // namespace dynolog

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -33,6 +33,10 @@ void JsonLogger::logFloat(const std::string& key, float val) {
   json_[key] = fmt::format("{:.3f}", val);
 }
 
+void JsonLogger::logUint(const std::string& key, uint64_t val) {
+  json_[key] = val;
+}
+
 void JsonLogger::finalize() {
   LOG(INFO) << "Logging : " << json_.size() << " values";
   LOG(INFO) << "time = " << timestampStr() << " data = " << sampleJson().dump();

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -28,12 +28,17 @@ class Logger {
   // Logs a floating point value
   virtual void logFloat(const std::string& key, float val) = 0;
 
+  // Logs an unsigned integer value
+  virtual void logUint(const std::string& key, uint64_t val) = 0;
+
   virtual void finalize() = 0;
 
   template <typename T>
   void log(const std::string& key, T val) {
     if (std::is_same<T, int64_t>::value) {
       logInt(key, val);
+    } else if (std::is_same<T, uint64_t>::value) {
+      logUint(key, val);
     } else if (std::is_same<T, float>::value) {
       logFloat(key, val);
     } else {
@@ -51,6 +56,8 @@ class JsonLogger : public Logger {
   void logInt(const std::string& key, int64_t val) override;
 
   void logFloat(const std::string& key, float val) override;
+
+  void logUint(const std::string& key, uint64_t val) override;
 
   void finalize() override;
 

--- a/src/Types.h
+++ b/src/Types.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <net/if.h>
 #include <time.h>
 
 #define MAX_CPU_SOCKETS 8
@@ -54,6 +55,37 @@ struct CpuTime {
 
   TIC_t total() const {
     return u + n + s + i + w + x + y + z;
+  }
+};
+
+struct RxTx {
+  uint64_t rxBytes, rxPackets;
+  uint64_t rxErrors, rxDrops;
+  uint64_t txBytes, txPackets;
+  uint64_t txErrors, txDrops;
+
+  RxTx operator-(const RxTx& prev) const {
+    return RxTx{
+        .rxBytes = rxBytes - prev.rxBytes,
+        .rxPackets = rxPackets - prev.rxPackets,
+        .rxErrors = rxErrors - prev.rxErrors,
+        .rxDrops = rxDrops - prev.rxDrops,
+        .txBytes = txBytes - prev.txBytes,
+        .txPackets = txPackets - prev.txPackets,
+        .txErrors = txErrors - prev.txErrors,
+        .txDrops = txDrops - prev.txDrops,
+    };
+  }
+
+  void operator+=(const RxTx& other) {
+    rxBytes += other.rxBytes;
+    rxPackets += other.rxPackets;
+    rxErrors += other.rxErrors;
+    rxDrops += other.rxDrops;
+    txBytes += other.txBytes;
+    txPackets += other.txPackets;
+    txErrors += other.txErrors;
+    txDrops += other.txDrops;
   }
 };
 

--- a/tests/root/proc/net/dev
+++ b/tests/root/proc/net/dev
@@ -1,0 +1,5 @@
+Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+  eth0: 17566262828804 18353492234    0 6734908 1316  1316          0  30710543 4485442728479 11129776879    0    0    0     0       0          0
+  eth1: 5651376349 3826963    0    0    0     0          0    452906  8626730  100254    0    0    0     0       0          0
+    lo: 15218789826969 2393400479    0    0    0     0          0         0 15218789826969 2393400479    0    0    0     0       0          0


### PR DESCRIPTION
Summary: Add network stats to dynolog in the same manner as CPU stats were added.

Differential Revision: D39520864

