### PR TITLE
Add ipcfabric to open source dynolog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
+if(BUILD_TESTS)
+  add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/googletest"
+  "third_party/googletest")
+endif()
+
+# our build script will first create a src/ dir where all source code will exist
 file (GLOB dynomin_src "src/*.h" "src/*.cpp")
 include_directories("${PROJECT_SOURCE_DIR}/src/")
 
@@ -21,8 +27,8 @@ add_library(dynolog_lib ${dynomin_src})
 add_subdirectory(src/rpc)
 include_directories("${PROJECT_SOURCE_DIR}/src/rpc")
 
-#add_subdirectory(src/ipcfabric)
-#target_link_libraries(dynolog_lib PUBLIC dynolog_ipcfabric_lib)
+add_subdirectory(src/ipcfabric)
+target_link_libraries(dynolog_lib PUBLIC dynolog_ipcfabric_lib)
 
 # cli is written in Rust and uses cargo for build
 add_subdirectory(src/cli)

--- a/hbt/src/common/CMakeLists.txt
+++ b/hbt/src/common/CMakeLists.txt
@@ -18,4 +18,7 @@ add_library(Defaults Defaults.h)
 set_target_properties(Defaults PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_options(Defaults PUBLIC ${HBT_COMMON_COMPILE_OPTIONS})
 
-add_subdirectory(tests)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/hbt/src/common/tests/CMakeLists.txt
+++ b/hbt/src/common/tests/CMakeLists.txt
@@ -1,13 +1,16 @@
-add_executable(DefsTest DefsTest.cpp)
-target_compile_options(DefsTest PUBLIC ${HBT_COMMON_COMPILE_OPTIONS})
-target_include_directories(DefsTest PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(DefsTest PUBLIC gtest_main)
-target_link_libraries(DefsTest PUBLIC Defs)
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-add_executable(SystemTest SystemTest.cpp)
-target_compile_options(SystemTest PUBLIC ${HBT_COMMON_COMPILE_OPTIONS})
-target_include_directories(SystemTest PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(SystemTest PUBLIC gtest_main)
-target_link_libraries(SystemTest PUBLIC System)
+include(${PROJECT_SOURCE_DIR}/tests/BuildTests.cmake)
+macro(hbt_common_add_test TESTNAME)
+  dynolog_add_test_base(${TESTNAME} ${ARGN})
+  target_compile_options(${TESTNAME} PRIVATE ${HBT_COMMON_COMPILE_OPTIONS})
+  target_include_directories(${TESTNAME} PRIVATE ${PROJECT_SOURCE_DIR})
+endmacro()
+
+hbt_common_add_test(DefsTest DefsTest.cpp)
+target_link_libraries(DefsTest PRIVATE Defs)
+
+hbt_common_add_test(SystemTest SystemTest.cpp)
+target_link_libraries(SystemTest PRIVATE System)
 
 # todo: include folly:subprocess library (or alternative) for SystemProcFsTest.cpp

--- a/hbt/src/common/tests/SystemTest.cpp
+++ b/hbt/src/common/tests/SystemTest.cpp
@@ -4,6 +4,12 @@
 using namespace facebook::hbt;
 
 TEST(Defs, CpuSet) {
+  // Skip on CI due to offline CPUs
+  // Error = <CpuSet max_cpu_id: 1 max_cpu_id_online: 1 cpus: 1 > unknown file:
+  // Failure
+  if (std::getenv("GITHUB_WORKFLOW") != nullptr) {
+    GTEST_SKIP() << "Skipping CPU set test on CI.";
+  }
   {
     auto c = CpuSet::makeAllOnline();
     EXPECT_TRUE(c.hasCpu(0));

--- a/src/ipcfabric/CMakeLists.txt
+++ b/src/ipcfabric/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library (dynolog_ipcfabric_lib INTERFACE)
+target_include_directories(dynolog_ipcfabric_lib
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+# Unit testing
+if(BUILD_TESTS)
+  enable_testing()
+  include(GoogleTest)
+  add_subdirectory(tests)
+endif()

--- a/src/ipcfabric/Endpoint.h
+++ b/src/ipcfabric/Endpoint.h
@@ -1,0 +1,203 @@
+#include <asm/unistd.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdexcept>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+/*
+ * Design choices:
+ * 1) Use UNIX sockets and sendmsg/rcvmsg to pass ancillary control message and
+ * payloads. see https://sarata.com/manpages/CMSG_ALIGN.3.html 2) Use abstract
+ * sockets (https://man7.org/linux/man-pages/man7/unix.7.html) to avoid choosing
+ * a path. Note that abstract sockets are indicated by pathname[0]='\0' and the
+ * actual name in the remaining characters up to struct size + null terminator.
+ * 3) Use connectionless datagram sockets
+ *    (SOCK_DGRM https://man7.org/linux/man-pages/man2/socket.2.html) - in Linux
+ *    they are guaranteed to be always reliable and don't reorder - to avoid
+ * having to mantain multiple connections. 4) Use a stateless protocol
+ * connecting based on destination socket name passed in, using scatter/gather
+ * vectors for data communication, with user input vector sizes. 5) Non-blocking
+ * send/receive. 6) Keep serialization/deserialization simple by only supporting
+ * class that are trivially copyable (i.e. std::is_trivially_copyable), like
+ * Plain Old Data (POD) classes.
+ *    (https://en.cppreference.com/w/cpp/types/is_trivially_copyable)
+ */
+
+namespace dynolog {
+namespace ipcfabric {
+
+// Define a type for fds to improve readibility.
+using fd_t = int;
+
+struct Payload {
+  Payload(size_t size, void* data) : size(size), data(data) {}
+  size_t size;
+  void* data;
+};
+
+template <size_t kMaxNumFds = 0>
+struct EndPointCtxt {
+  EndPointCtxt(size_t n) : iov{std::vector<struct iovec>(n)} {}
+  struct sockaddr_un msg_name;
+  size_t msg_namelen;
+  struct msghdr msghdr;
+  std::vector<struct iovec> iov;
+  fd_t* ctrl_fd_ptr;
+
+  // Ancillary data buffer sized to contain kMaxNumFds in data section.
+  char ancillary_buf[CMSG_SPACE(kMaxNumFds * sizeof(fd_t))];
+};
+
+template <size_t kMaxNumFds = 0>
+class EndPoint final {
+  // Maximum defined in man unix, but minus 2 because abstract sockets, first
+  // and last are '\0'.
+  constexpr static size_t kMaxNameLen = 108 - 2;
+
+  using TCtxt = EndPointCtxt<kMaxNumFds>;
+
+ public:
+  EndPoint(const std::string& address) {
+    socket_fd_ = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (socket_fd_ == -1) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+    struct sockaddr_un addr;
+    size_t addrlen = setAddress_(address, addr);
+
+    int ret = bind(socket_fd_, (const struct sockaddr*)&addr, addrlen);
+    if (ret == -1)
+      throw std::runtime_error(std::strerror(errno));
+  }
+
+  ~EndPoint() {
+    close(socket_fd_);
+  }
+
+  [[nodiscard]] auto buildSendCtxt(
+      const std::string& dest_name,
+      const std::vector<Payload>& payload,
+      const std::vector<fd_t>& fds) {
+    if (fds.size() > kMaxNumFds)
+      throw std::invalid_argument("Requested to fill more than kMaxNumFds");
+    if (dest_name.size() == 0)
+      throw std::invalid_argument("Cannot send to empty socket name");
+
+    auto ctxt = buildCtxt_(payload, fds.size());
+    ctxt->msghdr.msg_namelen = setAddress_(dest_name, ctxt->msg_name);
+    if (fds.size())
+      memcpy(ctxt->ctrl_fd_ptr, fds.data(), fds.size() * sizeof(int));
+    return ctxt;
+  }
+
+  // non-blocking. The error ECONNREFUSED may be caused by socket not being yet
+  // initialized. See man unix.
+  [[nodiscard]] bool trySendMsg(
+      TCtxt const& ctxt,
+      bool retryOnConnRefused = true) {
+    ssize_t ret = sendmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      return false;
+    if (ret == -1 && retryOnConnRefused && errno == ECONNREFUSED)
+      return false;
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  [[nodiscard]] auto buildRcvCtxt(const std::vector<Payload>& payload) {
+    return buildCtxt_(payload, kMaxNumFds);
+  }
+
+  // If false, must retry. Only enabled for bound sockets.
+  [[nodiscard]] bool tryRcvMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == 0)
+      return false; // Receiver is down.
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+      return false;
+
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  [[nodiscard]] bool tryPeekMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT | MSG_PEEK);
+    if (ret > 0) // XXX: Enforce correct number of bytes sent.
+      return true;
+    if (ret == 0)
+      return false; // Receiver is down.
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+      return false;
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  const char* getName(TCtxt const& ctxt) const noexcept {
+    return ctxt.msg_name.sun_path + 1;
+  }
+
+  std::vector<fd_t> getFds(const TCtxt& ctxt) const {
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt.msghdr);
+    unsigned num_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(fd_t);
+    return {ctxt.ctrl_fd_ptr, ctxt.ctrl_fd_ptr + num_fds};
+  }
+
+ protected:
+  fd_t socket_fd_;
+
+  // Initialize <dest> with address provided in <src>.
+  size_t setAddress_(const std::string& src, struct sockaddr_un& dest) {
+    if (src.size() >
+        kMaxNameLen) // First and last bytes are used for '/0' characters.
+      throw std::invalid_argument(
+          "Abstract UNIX Socket path cannot be larger than kMaxNameLen - 2");
+    dest.sun_family = AF_UNIX;
+    dest.sun_path[0] = '\0';
+    if (src.size() == 0)
+      return sizeof(sa_family_t); // autobind socket.
+
+    src.copy(dest.sun_path + 1, src.size());
+    dest.sun_path[src.size() + 1] = '\0';
+    return sizeof(sa_family_t) + src.size() + 2;
+  }
+
+  auto buildCtxt_(const std::vector<Payload>& payload, unsigned num_fds) {
+    auto ctxt = std::make_unique<TCtxt>(payload.size());
+    memset(&ctxt->msghdr, 0, sizeof(decltype(ctxt->msghdr)));
+    for (int i = 0; i < payload.size(); i++) {
+      ctxt->iov[i] = {payload[i].data, payload[i].size};
+    }
+    ctxt->msghdr.msg_name = &ctxt->msg_name;
+    ctxt->msghdr.msg_namelen = sizeof(decltype(ctxt->msg_name));
+    ctxt->msghdr.msg_iov = ctxt->iov.data();
+    ctxt->msghdr.msg_iovlen = payload.size();
+    ctxt->ctrl_fd_ptr = nullptr;
+
+    if (num_fds == 0)
+      return ctxt;
+
+    const size_t fds_size = sizeof(fd_t) * num_fds;
+    ctxt->msghdr.msg_control = ctxt->ancillary_buf;
+    ctxt->msghdr.msg_controllen = CMSG_SPACE(fds_size);
+
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt->msghdr);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(fds_size);
+    ctxt->ctrl_fd_ptr = (fd_t*)CMSG_DATA(cmsg);
+    return ctxt;
+  }
+};
+
+} // namespace ipcfabric
+} // namespace dynolog

--- a/src/ipcfabric/FabricManager.h
+++ b/src/ipcfabric/FabricManager.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <mutex>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "Endpoint.h"
+#include "Utils.h"
+
+#include <glog/logging.h>
+
+namespace dynolog {
+namespace ipcfabric {
+
+constexpr int TYPE_SIZE = 32;
+
+struct Metadata {
+  size_t size = 0;
+  char type[TYPE_SIZE] = "";
+};
+
+struct Message {
+  template <class T>
+  static std::unique_ptr<Message> constructMessage(
+      const T& data,
+      const std::string& type) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    if constexpr (std::is_same_v<std::string, T>) {
+      msg->metadata.size = data.size();
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), data.c_str(), msg->metadata.size);
+    } else {
+      // ensure memcpy works on T
+      static_assert(std::is_trivially_copyable_v<T>);
+      msg->metadata.size = sizeof(data);
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), &data, msg->metadata.size);
+    }
+    return msg;
+  }
+
+  // Construct message where T is a trivially copyable struct with
+  // a flexible array at the end. The items in the flexible array are
+  // of (trivially copyable) type U and there are n of them.
+  template <class T, class U>
+  static std::unique_ptr<Message>
+  constructMessage(const T& data, const std::string& type, int n) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    // ensure memcpy works on T and U
+    static_assert(std::is_trivially_copyable_v<T>);
+    static_assert(std::is_trivially_copyable_v<U>);
+    msg->metadata.size = sizeof(data) + sizeof(U) * n;
+    msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+    memcpy(msg->buf.get(), &data, msg->metadata.size);
+    return msg;
+  }
+
+  Metadata metadata;
+  std::unique_ptr<unsigned char[]> buf;
+  // endpoint name of the sender
+  std::string src;
+};
+
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    try {
+      return std::unique_ptr<FabricManager>(new FabricManager(endpoint_name));
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when initializing FabricManager: " << e.what();
+    }
+    return nullptr;
+  }
+
+  // warning: this will block for user passed in time with exponential increase
+  // if send keeps failing
+  bool sync_send(
+      const Message& msg,
+      const std::string& dest_name,
+      int num_retries = 10,
+      int sleep_time_us = 10000) {
+    if (dest_name.size() == 0) {
+      LOG(ERROR) << "Cannot send to empty socket name";
+      return false;
+    }
+
+    std::vector<Payload> payload{
+        Payload(sizeof(struct Metadata), (void*)&msg.metadata),
+        Payload(msg.metadata.size, msg.buf.get())};
+    int i = 0;
+    try {
+      auto ctxt = ep_.buildSendCtxt(dest_name, payload, std::vector<int>());
+      while (!ep_.trySendMsg(*ctxt) && i < num_retries) {
+        i++;
+        /* sleep override */
+        usleep(sleep_time_us);
+        sleep_time_us *= 2;
+      }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when sync_send(): " << e.what();
+      return false;
+    }
+    return i < num_retries;
+  }
+
+  bool recv() {
+    Metadata receive_metadata;
+    std::vector<Payload> peek_payload{
+        Payload(sizeof(struct Metadata), &receive_metadata)};
+    auto peek_ctxt = ep_.buildRcvCtxt(peek_payload);
+    // unix socket only fills the data for the iov that have a non NULL buffer.
+    // Leverage that to read metadata to find buffer size by:
+    //   1) FabricManager assumes metadata in first iov, data in second
+    //   2) peek with only metadata buffer in iov
+    //   3) read metadata
+    //   4) use metadata to find the desired size for the buffer to allocate.
+    //   5) read metadata + data with allocated buffer
+    bool success;
+    try {
+      success = ep_.tryPeekMsg(*peek_ctxt);
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when tryPeekMsg(): " << e.what();
+      return false;
+    }
+    if (success) {
+      std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+      msg->metadata = receive_metadata;
+      // new unsigned char[N] guarantees the maximum alignment to hold any
+      // object thus we don't need to worry about memory alignment here see
+      // https://stackoverflow.com/questions/10587879/does-new-char-actually-guarantee-aligned-memory-for-a-class-type
+      // and
+      // https://stackoverflow.com/questions/39668561/allocate-n-bytes-by-new-and-fill-it-with-any-type
+      msg->buf = std::unique_ptr<unsigned char[]>(
+          new unsigned char[receive_metadata.size]);
+      msg->src = std::string(ep_.getName(*peek_ctxt));
+      std::vector<Payload> payload{
+          Payload(sizeof(struct Metadata), (void*)&msg->metadata),
+          Payload(receive_metadata.size, msg->buf.get())};
+      auto recv_ctxt = ep_.buildRcvCtxt(payload);
+
+      // the deque can potentially grow very large
+      try {
+        success = ep_.tryRcvMsg(*recv_ctxt);
+      } catch (std::exception& e) {
+        LOG(ERROR) << "Error when tryRcvMsg(): " << e.what();
+        return false;
+      }
+      if (success) {
+        std::lock_guard<std::mutex> wguard(dequeLock_);
+        message_deque_.push_back(std::move(msg));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::unique_ptr<Message> retrieve_msg() {
+    std::lock_guard<std::mutex> wguard(dequeLock_);
+    if (message_deque_.empty()) {
+      return nullptr;
+    }
+    std::unique_ptr<Message> msg = std::move(message_deque_.front());
+    message_deque_.pop_front();
+    return msg;
+  }
+
+  std::unique_ptr<Message> poll_recv(int max_retries, int sleep_time_us) {
+    for (int i = 0; i < max_retries; i++) {
+      if (recv()) {
+        return retrieve_msg();
+      }
+      /* sleep override */
+      usleep(sleep_time_us);
+    }
+    return nullptr;
+  }
+
+ private:
+  explicit FabricManager(std::string endpoint_name = "") : ep_{endpoint_name} {}
+  // message LIFO deque with oldest message at front
+  std::deque<std::unique_ptr<Message>> message_deque_;
+  EndPoint<0> ep_;
+  std::mutex dequeLock_;
+};
+
+} // namespace ipcfabric
+} // namespace dynolog

--- a/src/ipcfabric/Utils.h
+++ b/src/ipcfabric/Utils.h
@@ -1,0 +1,38 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+namespace dynolog {
+namespace ipcfabric {
+
+// struct to register libkineto process
+struct LibkinetoContext {
+  // gpu id of the process running on
+  int32_t gpu;
+  // pid to register to dynolog
+  pid_t pid;
+  // job id of the process
+  int64_t jobid;
+};
+
+// struct to request libkineto ondemand config
+struct LibkinetoRequest {
+  // type of libkineto config
+  int type;
+  // size of pids
+  int n;
+  // job id of the libkineto process
+  int64_t jobid;
+  // pids of the process and its ancestors
+  int32_t pids[];
+};
+
+constexpr char dynolog_endpoint[] = "dynolog";
+constexpr char type_model_state[] = "model_status";
+constexpr char type_model_id[] = "model_entity_id";
+constexpr char type_tw_task[] = "tw_task";
+constexpr char kLibkinetoRequest[] = "req";
+constexpr char kLibkinetoContext[] = "ctxt";
+
+} // namespace ipcfabric
+} // namespace dynolog

--- a/src/ipcfabric/tests/CMakeLists.txt
+++ b/src/ipcfabric/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(${PROJECT_SOURCE_DIR}/tests/BuildTests.cmake)
+
+macro(ipcfabric_add_test TESTNAME)
+    dynolog_add_test_base(${TESTNAME} ${ARGN})
+    target_link_libraries(${TESTNAME} PRIVATE dynolog_ipcfabric_lib)
+    target_link_libraries(${TESTNAME} PRIVATE glog::glog)
+    target_include_directories(${TESTNAME} PRIVATE
+    "${PROJECT_SOURCE_DIR}/src/ipcfabric")
+endmacro()
+
+ipcfabric_add_test(IPCFabricTest IPCFabricTest.cpp)
+
+add_executable(ipcsender IPCSender.cpp)
+target_link_libraries(ipcsender PRIVATE dynolog_ipcfabric_lib glog)

--- a/src/ipcfabric/tests/IPCFabricTest.cpp
+++ b/src/ipcfabric/tests/IPCFabricTest.cpp
@@ -1,0 +1,270 @@
+#include <iostream>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "FabricManager.h"
+
+#include <gtest/gtest.h>
+
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+using namespace dynolog::ipcfabric;
+
+TEST(Endpoint, PodDataOneWay) {
+  static const unsigned kNumRetries = 10;
+  pid_t cpid;
+
+  cpid = fork();
+  ASSERT_NE(cpid, -1);
+
+  if (cpid > 0) {
+    // Parent is a sender.
+    int data = 1000;
+
+    const size_t num_fd = 0;
+    // sender having "" name will be autobound to name 5 hexidecimal characters
+    EndPoint<num_fd> sender("");
+
+    auto ctxt =
+        sender.buildSendCtxt("mydest", {Payload(sizeof(data), &data)}, {});
+
+    ASSERT_EQ(std::string(sender.getName(*ctxt)), std::string("mydest"));
+
+    // Try to send kNumRetries times.
+    for (unsigned i = 0; i < kNumRetries && !sender.trySendMsg(*ctxt); ++i) {
+      sleep(1);
+    }
+
+    int wstatus;
+    // Wait for child thread to either change state or stopped.
+    pid_t wpid = waitpid(cpid, &wstatus, WUNTRACED);
+    ASSERT_EQ(cpid, wpid);
+    ASSERT_EQ(WIFEXITED(wstatus), true);
+  } else {
+    // Child is a receiver.
+    int data = -1;
+    EndPoint<0> receiver{"mydest"};
+    auto ctxt = receiver.buildRcvCtxt({Payload(sizeof(data), &data)});
+
+    // Try to receive kNumRetries times.
+    for (unsigned i = 0; i < kNumRetries && !receiver.tryRcvMsg(*ctxt); ++i) {
+      sleep(1);
+    }
+
+    ASSERT_EQ(data, 1000);
+
+    exit(0);
+  }
+}
+
+static long perf_event_open(
+    struct perf_event_attr* hw_event,
+    pid_t pid,
+    int cpu,
+    int group_fd,
+    unsigned long flags) {
+  int ret;
+
+  ret = syscall(__NR_perf_event_open, hw_event, pid, cpu, group_fd, flags);
+  return ret;
+}
+
+int create_perf_event_fd(pid_t pid) {
+  struct perf_event_attr pe;
+  int fd;
+
+  memset(&pe, 0, sizeof(struct perf_event_attr));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(struct perf_event_attr);
+  pe.config = PERF_COUNT_HW_INSTRUCTIONS;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, pid, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+  return fd;
+}
+
+TEST(Endpoint, PerfEventFdAndDataOneWay) {
+  // Disabled on CI
+  if (std::getenv("GITHUB_WORKFLOW") != nullptr) {
+    GTEST_SKIP() << "Skipping perf_event related test on CI";
+  }
+
+  static const unsigned kNumRetries = 10;
+  static const std::string dest = "perf_event_fd_dest";
+  pid_t cpid;
+
+  cpid = fork();
+  ASSERT_NE(cpid, -1);
+
+  if (cpid > 0) {
+    // Parent is a sender.
+    int data = 1000, fd_event;
+
+    // Monitor child process
+    fd_event = create_perf_event_fd(cpid);
+
+    const size_t num_fd = 3;
+    // sender having "" name will be autobound to name 5 hexidecimal characters
+    EndPoint<num_fd> sender("");
+
+    auto ctxt =
+        sender.buildSendCtxt(dest, {Payload(sizeof(data), &data)}, {fd_event});
+
+    ASSERT_EQ(std::string(sender.getName(*ctxt)), dest);
+
+    // Try to send kNumRetries times.
+    for (unsigned i = 0; i < kNumRetries && !sender.trySendMsg(*ctxt); ++i) {
+      sleep(1);
+    }
+    int wstatus;
+    // Wait for child thread to either change state or stopped.
+    pid_t wpid = waitpid(cpid, &wstatus, WUNTRACED);
+    ASSERT_EQ(cpid, wpid);
+    ASSERT_EQ(WIFEXITED(wstatus), true);
+    close(fd_event);
+  } else {
+    // Child is a receiver.
+    int data = -1;
+
+    const size_t num_fd = 2;
+    EndPoint<num_fd> receiver{dest};
+
+    auto ctxt = receiver.buildRcvCtxt({Payload(sizeof(data), &data)});
+
+    // Try to receive kNumRetries times.
+    for (unsigned i = 0; i < kNumRetries && !receiver.tryRcvMsg(*ctxt); ++i) {
+      sleep(1);
+    }
+    std::cout << "Got data" << std::endl;
+
+    ASSERT_EQ(data, 1000);
+    auto fds = receiver.getFds(*ctxt);
+    ASSERT_EQ(fds.size(), 1);
+
+    long long count;
+    int fd = fds[0];
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+
+    std::cout << "Measuring instruction count for this std::cout" << std::endl;
+
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(long long));
+
+    printf("Used %lld instructions\n", count);
+
+    ASSERT_LT(count, 10000);
+    ASSERT_GT(count, 100);
+    exit(0);
+  }
+}
+
+struct FlexArrStruct {
+  int num;
+  size_t size;
+  int array[];
+};
+
+TEST(FabricManager, PodDataOneWay) {
+  pid_t cpid;
+
+  cpid = fork();
+  ASSERT_NE(cpid, -1);
+
+  if (cpid > 0) {
+    // Sender side example:
+
+    // Create FabricManager object with optional name argument
+    // Unix socket will autobind empty name to a 5 hexadecimal char name
+    auto sender = FabricManager::factory("sender");
+
+    // Construct Message object to send through the manager
+
+    // Example of int data
+    int data = 1000;
+    // this field construct Message.Metadata.type, and is used
+    // for sender/receiver to recognize the underlying data type.
+    // Only sender and receiver need to agree on it.
+    // FabricManager doesn't care about its value
+    std::string type_int = "int";
+    std::unique_ptr<Message> msgint =
+        Message::constructMessage<decltype(data)>(data, type_int);
+
+    // Example of string data
+    std::string datastring = "this";
+    std::string type_string = "string";
+    std::unique_ptr<Message> msgstring =
+        Message::constructMessage<decltype(datastring)>(
+            datastring, type_string);
+
+    FlexArrStruct* arrStruct =
+        (FlexArrStruct*)malloc(sizeof(FlexArrStruct) + sizeof(int) * 3);
+    arrStruct->num = 10;
+    arrStruct->size = 3;
+    arrStruct->array[0] = 0;
+    arrStruct->array[1] = 1;
+    arrStruct->array[2] = 3;
+    std::string type_flex = "flex";
+    std::unique_ptr<Message> msgflex =
+        Message::constructMessage<FlexArrStruct, int>(*arrStruct, type_flex, 3);
+
+    // Send messages to the socket bound to "mydest"
+    sender->sync_send(*msgint, "mydest");
+    sender->sync_send(*msgstring, "mydest");
+    sender->sync_send(*msgint, "mydest");
+    sender->sync_send(*msgflex, "mydest");
+
+    int wstatus;
+    // Wait for child thread to either change state or stopped.
+    pid_t wpid = waitpid(cpid, &wstatus, WUNTRACED);
+    ASSERT_EQ(cpid, wpid);
+    ASSERT_EQ(WIFEXITED(wstatus), true);
+    free(arrStruct);
+  } else {
+    // Receiver side Example:
+
+    // Create FabricManager object bound to socket name "mydest"
+    auto receiver = FabricManager::factory("mydest");
+
+    int received_data_cnt = 0;
+    while (received_data_cnt < 4) {
+      // Receiver side loop-checks recv()
+      if (receiver->recv()) {
+        received_data_cnt++;
+        // receiver gains ownership of the message
+        std::unique_ptr<Message> msg = receiver->retrieve_msg();
+        ASSERT_EQ(msg->src, "sender");
+
+        // receiver check the data type received, and read it accordingly
+        if (memcmp(msg->metadata.type, "int", 3) == 0) {
+          ASSERT_EQ(msg->metadata.size, sizeof(int));
+          ASSERT_EQ(*(int*)msg->buf.get(), 1000);
+        } else if (memcmp(msg->metadata.type, "string", 6) == 0) {
+          ASSERT_EQ(msg->metadata.size, 4);
+          std::string data((char*)msg->buf.get(), msg->metadata.size);
+          ASSERT_EQ(data, "this");
+        } else if (memcmp(msg->metadata.type, "flex", 4) == 0) {
+          FlexArrStruct* flexdata = (FlexArrStruct*)msg->buf.get();
+          ASSERT_EQ(flexdata->num, 10);
+          ASSERT_EQ(flexdata->size, 3);
+          ASSERT_EQ(flexdata->array[0], 0);
+          ASSERT_EQ(flexdata->array[1], 1);
+          ASSERT_EQ(flexdata->array[2], 3);
+        } else {
+          std::cout << "Unrecognized message of type" << msg->metadata.type
+                    << "\n";
+        }
+      }
+    }
+
+    exit(0);
+  }
+}

--- a/src/ipcfabric/tests/IPCSender.cpp
+++ b/src/ipcfabric/tests/IPCSender.cpp
@@ -1,0 +1,24 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "FabricManager.h"
+
+int main() {
+  int data = 1000;
+  std::string datastring = "this";
+  auto sender = dynolog::ipcfabric::FabricManager::factory("sender");
+  std::string type_int = "int";
+  std::unique_ptr<dynolog::ipcfabric::Message> msgint =
+      dynolog::ipcfabric::Message::constructMessage<decltype(data)>(
+          data, type_int);
+  std::string type_string = "string";
+  std::unique_ptr<dynolog::ipcfabric::Message> msgstring =
+      dynolog::ipcfabric::Message::constructMessage<decltype(datastring)>(
+          datastring, type_string);
+
+  sender->sync_send(*msgint, "dynolog");
+  sender->sync_send(*msgstring, "dynolog");
+  sender->sync_send(*msgint, "dynolog");
+
+  return 0;
+}

--- a/tests/BuildTests.cmake
+++ b/tests/BuildTests.cmake
@@ -1,0 +1,26 @@
+# Follow recipe here: https://cliutils.gitlab.io/modern-cmake/chapters/testing/googletest.html
+
+# Add this to top level CMake
+# add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/googletest" "third_party/googletest")
+
+include(GoogleTest)
+macro(dynolog_add_test_base TESTNAME)
+    # create an executable in which the tests will be stored
+    add_executable(${TESTNAME} ${ARGN})
+    # link the Google test infrastructure, mocking library, and a default main function.
+    target_link_libraries(${TESTNAME} PRIVATE gtest gmock gtest_main)
+    # gtest_discover_tests replaces gtest_add_tests,
+    # see https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
+    gtest_discover_tests(${TESTNAME}
+        # set a working directory so your project root so that you can find test data via paths relative to the project root
+        WORKING_DIRECTORY ${PROJECT_DIR}
+        PROPERTIES ENVIRONMENT "TESTROOT=${PROJECT_SOURCE_DIR}/tests/root/"
+    )
+    set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
+endmacro()
+
+macro(dynolog_add_test TESTNAME)
+    dynolog_add_test_base(${TESTNAME} ${ARGN})
+    target_link_libraries(${TESTNAME} PRIVATE dynolog_lib)
+    target_include_directories(${TESTNAME} PRIVATE "${PROJECT_SOURCE_DIR}/src")
+endmacro()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,27 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/googletest" "third_party/googletest")
-include(GoogleTest)
 
-# Follow recipe here: https://cliutils.gitlab.io/modern-cmake/chapters/testing/googletest.html
-
-macro(dynolog_add_test TESTNAME)
-    # create an executable in which the tests will be stored
-    add_executable(${TESTNAME} ${ARGN})
-    # link the Google test infrastructure, mocking library, and a default main function.
-    target_link_libraries(${TESTNAME} gtest gmock gtest_main)
-    # gtest_discover_tests replaces gtest_add_tests,
-    # see https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
-    gtest_discover_tests(${TESTNAME}
-        # set a working directory so your project root so that you can find test data via paths relative to the project root
-        WORKING_DIRECTORY ${PROJECT_DIR}
-        PROPERTIES ENVIRONMENT "TESTROOT=${PROJECT_SOURCE_DIR}/tests/root/"
-    )
-    set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
-
-    target_link_libraries(${TESTNAME} dynolog_lib)
-    target_include_directories(${TESTNAME} PRIVATE "${PROJECT_SOURCE_DIR}/src")
-endmacro()
-
+include(BuildTests.cmake)
 dynolog_add_test(KernelCollecterTest KernelCollecterTest.cpp)
 
 add_subdirectory(rpc)

--- a/tests/rpc/CMakeLists.txt
+++ b/tests/rpc/CMakeLists.txt
@@ -7,4 +7,4 @@ target_link_libraries(json_client PUBLIC glog::glog)
 dynolog_add_test(SimpleJsonClientTest
   SimpleJsonClientTest.cpp SimpleJsonClientTest.h)
 
-target_link_libraries(SimpleJsonClientTest dynolog_rpc_lib)
+target_link_libraries(SimpleJsonClientTest PRIVATE dynolog_rpc_lib)


### PR DESCRIPTION
Summary:
Migrates ipcfabric to open source dynolog

Details
* Update to absolute paths in source files
* Add cmake and ctest support so now ipcfabric tests will also run on github!
* Factored out test code into BuildTests.Cmake

Note
- Created a new ipc_sender binary for testing fb local dyno ipc logger (cc haowangludx)

Reviewed By: williamsumendap

Differential Revision: D39318153

