### PR TITLE
Use recommended copyright header in source files //dynolog

### DIFF
--- a/src/FBRelayLogger.cpp
+++ b/src/FBRelayLogger.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <fmt/format.h>
 #include <gflags/gflags.h>

--- a/src/FBRelayLogger.h
+++ b/src/FBRelayLogger.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/KernelCollector.cpp
+++ b/src/KernelCollector.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "KernelCollector.h"

--- a/src/KernelCollector.h
+++ b/src/KernelCollector.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/KernelCollectorBase.cpp
+++ b/src/KernelCollectorBase.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/src/KernelCollectorBase.h
+++ b/src/KernelCollectorBase.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/LibkinetoConfigManager.cpp
+++ b/src/LibkinetoConfigManager.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <fmt/core.h>
 #include <fmt/format.h>

--- a/src/LibkinetoConfigManager.h
+++ b/src/LibkinetoConfigManager.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/LibkinetoTypes.h
+++ b/src/LibkinetoTypes.h
@@ -1,4 +1,8 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <vector>

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <fmt/format.h>
 #include <glog/logging.h>

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // Dynomin : A portable telemetry monitoring daemon.
 

--- a/src/ServiceHandler.cpp
+++ b/src/ServiceHandler.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ServiceHandler.h"

--- a/src/ServiceHandler.h
+++ b/src/ServiceHandler.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/Types.h
+++ b/src/Types.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/cli/src/commands/gputrace.rs
+++ b/src/cli/src/commands/gputrace.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::net::TcpStream;
 

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // Export all command submodules to be used in main.rs
 // Note: This "intermediate" commands module is purely for organizational purposes.

--- a/src/cli/src/commands/status.rs
+++ b/src/cli/src/commands/status.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::net::TcpStream;
 

--- a/src/cli/src/commands/utils.rs
+++ b/src/cli/src/commands/utils.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::io::Read;
 use std::io::Write;

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::net::TcpStream;
 use std::net::ToSocketAddrs;

--- a/src/ipcfabric/Endpoint.h
+++ b/src/ipcfabric/Endpoint.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <asm/unistd.h>
 #include <stdlib.h>
 #include <sys/socket.h>

--- a/src/ipcfabric/FabricManager.h
+++ b/src/ipcfabric/FabricManager.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <cstddef>

--- a/src/ipcfabric/Utils.h
+++ b/src/ipcfabric/Utils.h
@@ -1,4 +1,7 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/ipcfabric/tests/IPCFabricTest.cpp
+++ b/src/ipcfabric/tests/IPCFabricTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <iostream>
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude

--- a/src/ipcfabric/tests/IPCSender.cpp
+++ b/src/ipcfabric/tests/IPCSender.cpp
@@ -1,4 +1,7 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "FabricManager.h" // @manual=//dynolog/src/ipcfabric:ipcfabric

--- a/src/rpc/SimpleJsonServer.cpp
+++ b/src/rpc/SimpleJsonServer.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <fmt/format.h>
 #include <glog/logging.h>

--- a/src/rpc/SimpleJsonServer.h
+++ b/src/rpc/SimpleJsonServer.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/rpc/SimpleJsonServerInl.h
+++ b/src/rpc/SimpleJsonServerInl.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <fmt/format.h>
 #include <glog/logging.h>

--- a/src/tracing/IPCMonitor.cpp
+++ b/src/tracing/IPCMonitor.cpp
@@ -1,4 +1,7 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include "IPCMonitor.h"
 

--- a/src/tracing/IPCMonitor.h
+++ b/src/tracing/IPCMonitor.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/tests/KernelCollecterTest.cpp
+++ b/tests/KernelCollecterTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <sys/stat.h>
 
 #include <glog/logging.h>

--- a/tests/rpc/SimpleJsonClientTest.cpp
+++ b/tests/rpc/SimpleJsonClientTest.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/tests/rpc/SimpleJsonClientTest.h
+++ b/tests/rpc/SimpleJsonClientTest.h
@@ -1,5 +1,8 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <glog/logging.h>
 #include <optional>
 

--- a/tests/rpc/SimpleJsonClientTestCLI.cpp
+++ b/tests/rpc/SimpleJsonClientTestCLI.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/tests/tracing/IPCMonitorTest.cpp
+++ b/tests/tracing/IPCMonitorTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <chrono>
 #include <iostream>
 


### PR DESCRIPTION
Summary:
Remove exiting header if it exsits:
```
find dynolog/ -name '*.rs' -o -name '*.cpp' -o -name '*.h' |  xargs -n1 sed -i 's/\/\/.*Copyright.*//'
find dynolog/ -name '*.rs' -o -name '*.cpp' -o -name '*.h' | xargs -n1 sed -i 's/\/\/.*(c)*//'
find dynolog/ -name '*.rs' -o -name '*.cpp' -o -name '*.h' | xargs -n1 sed -i '2i\/\/\n\/\/ This source code is licensed under the MIT license found in the\n\/\/ LICENSE file in the root directory of this source tree.'
```

Add recommended header:
```
find dynolog/ -name '*.rs' -o -name '*.cpp' -o -name '*.h' | xargs -n1 sed -i '1i\/\/ Copyright (c) Meta Platforms, Inc. and affiliates.'
```

Differential Revision: D40036346

