### PR TITLE
handle exceptions about non-existing metrics/evnets

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -357,6 +357,7 @@ void populatePredefinedEventsOffcore(
       break;
     case CpuArch::SKL:
     case CpuArch::SKX:
+    case CpuArch::CLX:
       pmu_manager->addEvent(std::make_shared<EventDef>(
           offcoreEventDef->pmu_type,
           "DynoPerfCounter::DRAM_ACCESS_READS",


### PR DESCRIPTION
Summary: make sure dynolog will not crash when running on some CPU architecture that bperf doesn't support right now.

Reviewed By: briancoutinho

Differential Revision: D39989048

