### PR TITLE
Use recommended copyright header in source files //hbt/src/{intel_pt,ringbuffer,tagstack,utils}

### DIFF
--- a/hbt/src/intel_pt/IptEventBuilder.cpp
+++ b/hbt/src/intel_pt/IptEventBuilder.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/intel_pt/IptEventBuilder.h"
 #include "hbt/src/perf_event/PmuEvent.h"
 

--- a/hbt/src/intel_pt/IptEventBuilder.h
+++ b/hbt/src/intel_pt/IptEventBuilder.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <cstdint>

--- a/hbt/src/intel_pt/main.py
+++ b/hbt/src/intel_pt/main.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import argparse
 import time

--- a/hbt/src/intel_pt/tests/IptCapChecker.cpp
+++ b/hbt/src/intel_pt/tests/IptCapChecker.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <iostream>
 
 #include "hbt/src/intel_pt/IptEventBuilder.h"

--- a/hbt/src/intel_pt/tests/parse_lines__tests.py
+++ b/hbt/src/intel_pt/tests/parse_lines__tests.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/hbt/src/intel_pt/tracer.py
+++ b/hbt/src/intel_pt/tracer.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import collections
 import fcntl

--- a/hbt/src/ringbuffer/Consumer.h
+++ b/hbt/src/ringbuffer/Consumer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/ringbuffer/PerCpuRingBuffer.h
+++ b/hbt/src/ringbuffer/PerCpuRingBuffer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/Consumer.h"

--- a/hbt/src/ringbuffer/Producer.h
+++ b/hbt/src/ringbuffer/Producer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/ringbuffer/RingBuffer.h
+++ b/hbt/src/ringbuffer/RingBuffer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/ringbuffer/RingBufferBlockingOps.h
+++ b/hbt/src/ringbuffer/RingBufferBlockingOps.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/RingBuffer.h"
 
 #include <thread>

--- a/hbt/src/ringbuffer/Shm.h
+++ b/hbt/src/ringbuffer/Shm.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/PerCpuRingBuffer.h"

--- a/hbt/src/ringbuffer/benchmarks/Consumer.hpp
+++ b/hbt/src/ringbuffer/benchmarks/Consumer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/benchmarks/Data.hpp"

--- a/hbt/src/ringbuffer/benchmarks/Data.hpp
+++ b/hbt/src/ringbuffer/benchmarks/Data.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <cstdint>

--- a/hbt/src/ringbuffer/benchmarks/MPMCBenchmark.hpp
+++ b/hbt/src/ringbuffer/benchmarks/MPMCBenchmark.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/common/System.h"
 #include "hbt/src/ringbuffer/benchmarks/Consumer.hpp"
 #include "hbt/src/ringbuffer/benchmarks/Data.hpp"

--- a/hbt/src/ringbuffer/benchmarks/MPMCQueueBenchmark.cpp
+++ b/hbt/src/ringbuffer/benchmarks/MPMCQueueBenchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/benchmarks/Consumer.hpp"
 #include "hbt/src/ringbuffer/benchmarks/Data.hpp"
 #include "hbt/src/ringbuffer/benchmarks/MPMCBenchmark.hpp"

--- a/hbt/src/ringbuffer/benchmarks/MPMCQueueConsumerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/MPMCQueueConsumerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <folly/MPMCQueue.h>

--- a/hbt/src/ringbuffer/benchmarks/MPMCQueueProducerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/MPMCQueueProducerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <folly/MPMCQueue.h>

--- a/hbt/src/ringbuffer/benchmarks/MPMCRingBufferBenchmark.cpp
+++ b/hbt/src/ringbuffer/benchmarks/MPMCRingBufferBenchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/RingBuffer.h"
 #include "hbt/src/ringbuffer/benchmarks/Data.hpp"
 #include "hbt/src/ringbuffer/benchmarks/MPMCBenchmark.hpp"

--- a/hbt/src/ringbuffer/benchmarks/Producer.hpp
+++ b/hbt/src/ringbuffer/benchmarks/Producer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/benchmarks/Data.hpp"

--- a/hbt/src/ringbuffer/benchmarks/RingBufferConsumerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/RingBufferConsumerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/Consumer.h"

--- a/hbt/src/ringbuffer/benchmarks/RingBufferProducerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/RingBufferProducerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/Producer.h"

--- a/hbt/src/ringbuffer/benchmarks/SPSCBenchmark.hpp
+++ b/hbt/src/ringbuffer/benchmarks/SPSCBenchmark.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/common/System.h"
 #include "hbt/src/ringbuffer/benchmarks/Consumer.hpp"
 #include "hbt/src/ringbuffer/benchmarks/Producer.hpp"

--- a/hbt/src/ringbuffer/benchmarks/SPSCQueueBenchmark.cpp
+++ b/hbt/src/ringbuffer/benchmarks/SPSCQueueBenchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/benchmarks/SPSCBenchmark.hpp"
 #include "hbt/src/ringbuffer/benchmarks/SPSCQueueConsumerWrapper.hpp"
 #include "hbt/src/ringbuffer/benchmarks/SPSCQueueProducerWrapper.hpp"

--- a/hbt/src/ringbuffer/benchmarks/SPSCQueueConsumerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/SPSCQueueConsumerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <folly/ProducerConsumerQueue.h>

--- a/hbt/src/ringbuffer/benchmarks/SPSCQueueProducerWrapper.hpp
+++ b/hbt/src/ringbuffer/benchmarks/SPSCQueueProducerWrapper.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <folly/ProducerConsumerQueue.h>

--- a/hbt/src/ringbuffer/benchmarks/SPSCRingBufferBenchmark.cpp
+++ b/hbt/src/ringbuffer/benchmarks/SPSCRingBufferBenchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/benchmarks/RingBufferConsumerWrapper.hpp"
 #include "hbt/src/ringbuffer/benchmarks/RingBufferProducerWrapper.hpp"
 #include "hbt/src/ringbuffer/benchmarks/SPSCBenchmark.hpp"

--- a/hbt/src/ringbuffer/benchmarks/ThreadBind.hpp
+++ b/hbt/src/ringbuffer/benchmarks/ThreadBind.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/ringbuffer/benchmarks/TriggerableThread.hpp
+++ b/hbt/src/ringbuffer/benchmarks/TriggerableThread.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include <atomic>

--- a/hbt/src/ringbuffer/tests/PerCpuRingBufferTest.cpp
+++ b/hbt/src/ringbuffer/tests/PerCpuRingBufferTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/PerCpuRingBuffer.h"
 
 #include <gtest/gtest.h>

--- a/hbt/src/ringbuffer/tests/RingBufferTest.cpp
+++ b/hbt/src/ringbuffer/tests/RingBufferTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/RingBuffer.h"
 #include "hbt/src/ringbuffer/Consumer.h"
 #include "hbt/src/ringbuffer/Producer.h"

--- a/hbt/src/ringbuffer/tests/ShmPerCpuRingBufferTest.cpp
+++ b/hbt/src/ringbuffer/tests/ShmPerCpuRingBufferTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/ringbuffer/PerCpuRingBuffer.h"
 #include "hbt/src/ringbuffer/Shm.h"
 

--- a/hbt/src/tagstack/Event.h
+++ b/hbt/src/tagstack/Event.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/tagstack/IntervalSlicer.cpp
+++ b/hbt/src/tagstack/IntervalSlicer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/tagstack/IntervalSlicer.h"
 
 namespace facebook::hbt::tagstack {

--- a/hbt/src/tagstack/IntervalSlicer.h
+++ b/hbt/src/tagstack/IntervalSlicer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/tagstack/Slicer.h"

--- a/hbt/src/tagstack/PerfEventStream.h
+++ b/hbt/src/tagstack/PerfEventStream.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/perf_event/CpuEventsGroup.h"

--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/tagstack/Event.h"

--- a/hbt/src/tagstack/Stream.h
+++ b/hbt/src/tagstack/Stream.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/ringbuffer/Consumer.h"

--- a/hbt/src/tagstack/TagStack.h
+++ b/hbt/src/tagstack/TagStack.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/tagstack/TscConverterStream.h
+++ b/hbt/src/tagstack/TscConverterStream.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/System.h"

--- a/hbt/src/tagstack/tests/IntervalSlicerTest.cpp
+++ b/hbt/src/tagstack/tests/IntervalSlicerTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include <gtest/gtest.h>
 
 #include "hbt/src/tagstack/IntervalSlicer.h"

--- a/hbt/src/tagstack/tests/SlicerTest.cpp
+++ b/hbt/src/tagstack/tests/SlicerTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/tagstack/Slicer.h"
 #include "hbt/src/ringbuffer/RingBuffer.h"
 #include "hbt/src/tagstack/Stream.h"

--- a/hbt/src/tagstack/tests/StreamTest.cpp
+++ b/hbt/src/tagstack/tests/StreamTest.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #include "hbt/src/tagstack/Stream.h"
 #include "hbt/src/perf_event/PerCpuDummyGenerator.h"
 #include "hbt/src/tagstack/PerfEventStream.h"

--- a/hbt/src/utils/ValueTimeSeries.h
+++ b/hbt/src/utils/ValueTimeSeries.h
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "hbt/src/common/Defs.h"


### PR DESCRIPTION
Summary:
Remove exiting header if it exists:
```find hbt/src/{intel_pt,ringbuffer,tagstack,utils} -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs -n1 sed -i 's/\/\/.*Copyright.*//'
find hbt/src/{intel_pt,ringbuffer,tagstack,utils} -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs -n1 sed -i 's/\/\/.*(c).*//'
```

Add recommended header:
```
find hbt/src/{intel_pt,ringbuffer,tagstack,utils} -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs -n1 sed -i '1i\/\/ Copyright (c) Meta Platforms, Inc. and affiliates.'
find hbt/src/{intel_pt,ringbuffer,tagstack,utils} -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs -n1 sed -i '2i\/\/\n\/\/ This source code is licensed under the MIT license found in the\n\/\/ LICENSE file in the root directory of this source tree.\n'
```

Python files edited by hand.

Differential Revision: D40169049

