### PR TITLE
add blank value check for dcgm

### DIFF
--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -325,12 +325,19 @@ void DcgmGroupInfo::update() {
 
             // Store value
             if (v.fieldType == 'd') {
+              if (v.value.dbl == DCGM_FP64_BLANK) {
+                blank_value_field = true;
+              }
               metricsDouble[FieldIdToName[v.fieldId]] = v.value.dbl;
             } else if (v.fieldType == 'i') {
+              if (v.value.i64 == DCGM_INT64_BLANK) {
+                blank_value_field = true;
+              }
               metricsInt[FieldIdToName[v.fieldId]] = v.value.i64;
             }
           }
         }
+        metricsInt["dcgm_error"] = blank_value_field ? 1 : 0;
         metricsMapDouble_[entity.m_entityId] = metricsDouble;
         metricsMapInt_[entity.m_entityId] = metricsInt;
       }


### PR DESCRIPTION
Summary: This diff adds null value check for OSS DCGM, sometimes DCGM will populate BLANK value, we indicate with dcgm error 1, and reflect the bad value in the logging.

Differential Revision: D40479457

