### PR TITLE
Build basic monitor file and test

### DIFF
--- a/hbt/src/CMakeLists.txt
+++ b/hbt/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 # (c) Meta Platforms, Inc. and affiliates.
 cmake_minimum_required(VERSION 3.20)
 
+include_directories(${PROJECT_SOURCE_DIR}/third_party/pfs/include)
+
 add_subdirectory(common)
 add_subdirectory(intel_pt)
 add_subdirectory(perf_event)
+add_subdirectory(mon)

--- a/hbt/src/common/CMakeLists.txt
+++ b/hbt/src/common/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(Defs Defs.h)
 set_target_properties(Defs PROPERTIES LINKER_LANGUAGE CXX)
 
 add_library(System System.h System.cpp)
-target_include_directories(System PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pfs/include)
 target_include_directories(System PUBLIC ${PROJECT_SOURCE_DIR})
 target_link_libraries(System PUBLIC fmt::fmt)
 target_link_libraries(System PUBLIC pfs)

--- a/hbt/src/common/Defs.h
+++ b/hbt/src/common/Defs.h
@@ -215,6 +215,10 @@ class LogEntry final {
   if (unlikely(cond))          \
   HBT_LOG_ERROR()
 
+#define HBT_DCHECK_NOT_NULLPTR(t)             \
+  if (unlikely(typeid(t) != typeid(nullptr))) \
+  HBT_THROW_ASSERT() << "\n\tExpected argument to be not null."
+
 #define __HBT_EXPAND_OPD(opd) HBT_STRINGIFY(opd) << " (" << (opd) << ")"
 
 //

--- a/hbt/src/mon/CMakeLists.txt
+++ b/hbt/src/mon/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_compile_options("-Wconversion")
+
+add_library(Monitor Monitor.h)
+set_target_properties(Monitor PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(Monitor PUBLIC System)
+target_link_libraries(Monitor PUBLIC IntelPTMonitor)
+target_link_libraries(Monitor PUBLIC MonData)
+
+add_library(IntelPTMonitor IntelPTMonitor.h IntelPTMonitor.cpp)
+target_link_libraries(IntelPTMonitor PUBLIC System)
+target_link_libraries(IntelPTMonitor PUBLIC Defaults)
+target_link_libraries(IntelPTMonitor PUBLIC IptEventBuilder)
+target_link_libraries(IntelPTMonitor PUBLIC PerCpuTraceAuxGenerator)
+
+add_library(MonData MonData.h MonData.cpp)
+target_link_libraries(MonData PUBLIC pfs)
+target_link_libraries(MonData PUBLIC System)
+
+add_subdirectory(tests)
+
+add_library(PerCpuSliceGenerator PerCpuSliceGenerator.h)
+set_target_properties(PerCpuSliceGenerator PROPERTIES LINKER_LANGUAGE CXX)

--- a/hbt/src/mon/MonData.h
+++ b/hbt/src/mon/MonData.h
@@ -6,9 +6,12 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
+
+#ifdef HBT_ENABLE_TRACING
 #include "hbt/src/phase/PerCpuMetaDataConsumer.h"
 #include "hbt/src/tagstack/IntervalSlicer.h"
 #include "hbt/src/tagstack/Slicer.h"
+#endif // HBT_ENABLE_TRACING
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -23,6 +26,7 @@
 
 namespace facebook::hbt::mon {
 
+#ifdef HBT_ENABLE_TRACING
 struct SliceFreq {
   // Total duration
   TimeStamp duration = 0;
@@ -632,6 +636,7 @@ struct TagStackIdBinner {
 };
 
 } // namespace binmap
+#endif // HBT_ENABLE_TRACING
 
 struct ModuleInfo {
   ModuleInfo(const std::string& systemPath, size_t loadAddress)

--- a/hbt/src/mon/TraceMonitor.h
+++ b/hbt/src/mon/TraceMonitor.h
@@ -87,7 +87,7 @@ class TraceMonitor : public TraceCollector {
               kWriteByteSize,
               nread);
           auto p = reinterpret_cast<const uint64_t*>(d);
-          HBT_DCHECK_NE(p, nullptr)
+          HBT_DCHECK_NOT_NULLPTR(p)
               << fmt::format("Timestamp cannot be null pointer");
           TimeStamp tstamp = *p, duration = *(p + 1);
           // All fields after first two are counts.

--- a/hbt/src/mon/tests/CMakeLists.txt
+++ b/hbt/src/mon/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_compile_options("-Wconversion")
+add_compile_options("-Wconversion-null")
+
+add_executable(MonitorTest MonitorTest.cpp)
+target_link_libraries(MonitorTest PUBLIC Monitor)
+target_link_libraries(MonitorTest PUBLIC BuiltinMetrics)
+target_link_libraries(MonitorTest PRIVATE gtest gmock gtest_main)

--- a/hbt/src/mon/tests/MonitorTest.cpp
+++ b/hbt/src/mon/tests/MonitorTest.cpp
@@ -14,9 +14,13 @@
 using namespace facebook::hbt;
 using namespace facebook::hbt::mon;
 using namespace facebook::hbt::perf_event;
+
+#ifdef HBT_ENABLE_TRACING
 using namespace facebook::hbt::phase;
 using namespace facebook::hbt::tagstack;
+#endif // HBT_ENABLE_TRACING
 
+#ifdef HBT_ENABLE_TRACING
 void runSlices(std::vector<CpuId> cpus) {
   EXPECT_GE(cpus.size(), 1);
 
@@ -242,6 +246,7 @@ TEST(PerCpuSlicer, TwoCpusNoZeroCpu) {
   // may not have those CPU ids enabled/online.
   runSlices({10, 8});
 };
+#endif // HBT_ENABLE_TRACING
 
 TEST(IntelPTMonitor, SystemWideTraceCollection) {
   auto cpus = CpuSet::makeAllOnline();
@@ -364,6 +369,7 @@ TEST(IntelPTMonitor, SystemWideTraceCopy) {
   mon.close();
 }
 
+#ifdef HBT_ENABLE_TRACING
 TEST(ContextSwitch, CopyToSink) {
   Monitor mon;
 
@@ -391,3 +397,4 @@ TEST(ContextSwitch, CopyToSink) {
   // Ensure that the copy lambda was called for each CPU.
   ASSERT_EQ(seenCpus, cpu_set.asSet());
 }
+#endif // HBT_ENABLE_TRACING

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(CpuEventsGroup PUBLIC PmuEvent)
 
 add_library(PmuDevices PmuDevices.h PmuDevices.cpp)
 target_link_libraries(PmuDevices PUBLIC CpuEventsGroup)
+target_link_libraries(PmuDevices PUBLIC stdc++fs)
 target_link_libraries(PmuDevices PUBLIC PmuEvent)
 target_link_libraries(PmuDevices PUBLIC CpuArch)
 

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -391,13 +391,13 @@ struct GroupReadValues {
 
   explicit GroupReadValues(const GroupReadValues& other)
       : GroupReadValues(other.getNumEvents()) {
-    HBT_DCHECK_NE(other.t, nullptr);
-    HBT_DCHECK_NE(t, nullptr);
+    HBT_DCHECK_NOT_NULLPTR(other.t);
+    HBT_DCHECK_NOT_NULLPTR(t);
     ::memcpy(t, other.t, other.getNumReadBytes());
   }
 
   GroupReadValues& operator=(const GroupReadValues& other) {
-    HBT_DCHECK_NE(other.t, nullptr);
+    HBT_DCHECK_NOT_NULLPTR(other.t);
     release_();
     new (this) GroupReadValues(other);
     return *this;
@@ -405,7 +405,7 @@ struct GroupReadValues {
 
   GroupReadValues(GroupReadValues&& other) noexcept
       : t(std::exchange(other.t, nullptr)) {
-    HBT_DCHECK_NE(t, nullptr);
+    HBT_DCHECK_NOT_NULLPTR(t);
   }
 
   GroupReadValues& operator=(GroupReadValues&& other) {

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -8,6 +8,8 @@
 #include <hbt/src/perf_event/PmuEvent.h>
 #include <string>
 
+#include <filesystem>
+
 namespace fs = std::filesystem;
 
 namespace facebook::hbt::perf_event {


### PR DESCRIPTION
Summary:
Build hbt/src/mon/Monitor.h and related dependencies.

Currently we don't support Bperf and tracing functionalities so those are excluded from compilation using preprocessor directives.

Reviewed By: ccdavid

Differential Revision: D40540840

