### PR TITLE
Filter AMD Events under NDA into fb/

### DIFF
--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -10,9 +10,9 @@
 namespace facebook::hbt::perf_event {
 
 namespace amd_msr {
-// 2.1.21.3 MSRs - MSRC001_0xxx - Processor Programming
+// 2.1.16.3 MSRs - MSRC001_0xxx - Processor Programming
 // Reference (PPR) for AMD Family 19h Model 01h, Revision B1
-// Processors Volume 1 of 5
+// Processors Volume 1
 struct CorePmuMsrAmd {
   uint64_t event : 8;
   uint64_t unitMask : 8;
@@ -81,60 +81,69 @@ union PmuMsr {
 /*
 Events and formulas for this file come from AMD Processor Programming
 Reference (PPR) for AMD Family 19h Model 01h, Revision B1 Processors
-Volume 1 of 5
+Volume 1
 
-The section that defines them is 2.1.22.2 Performance Measurement and
-Table 34: Guidance for Common Performance Statistics with Complex Event Selects
+The section that defines them is 2.1.17.2 Performance Measurement and
+Table 25: Guidance for Common Performance Statistics with Complex Event Selects
 */
 
 constexpr PmuMsr kRetiredInstructions{.amdCore = {.event = 0xc0}};
 constexpr PmuMsr kUnhaltedCycles{.amdCore = {.event = 0x76}};
+
 // L1 iCache
 constexpr PmuMsr kL1ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x7}}; // Same as e=0x60,u=0x10
-constexpr PmuMsr kL1ICacheInstrFetches{.amdCore = {.event = 0x80}};
-constexpr PmuMsr kL1ICacheInstrFetchesMisses{.amdCore = {.event = 0x81}};
+
 // L1 dCache
 constexpr PmuMsr kL1DCacheMisses{
     .amdCore = {.event = 0x41, .unitMask = 0x1f}}; // AMD recommended way
-constexpr PmuMsr kL1DCacheAcceses{.amdCore = {.event = 0x40}};
+
 // L2 Cache
 constexpr PmuMsr kL2ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x1}};
 constexpr PmuMsr kL2DCacheAccesses{
     .amdCore = {.event = 0x64, .unitMask = 0x78}}; // Same as e=0x60,u=0xc8
 constexpr PmuMsr kL2DCacheMisses{.amdCore = {.event = 0x64, .unitMask = 0x8}};
+
 // L2 with Prefetcher
 constexpr PmuMsr kL2Accesses{.amdCore = {.event = 0x64, .unitMask = 0x7f}};
 constexpr PmuMsr kL2Misses{.amdCore = {.event = 0x64, .unitMask = 0x9}};
 constexpr PmuMsr kL2PrefetcherHitsInL2{.amdCore = {.event = 0x70}};
 constexpr PmuMsr kL2PrefetcherHitsInL3{.amdCore = {.event = 0x71}};
 constexpr PmuMsr kL2PrefetcherMissesInL3{.amdCore = {.event = 0x72}};
+
 // Flops
 constexpr PmuMsr kRetiredX87Flops{.amdCore = {.event = 0x2, .unitMask = 0x7}};
 constexpr PmuMsr kRetiredSseAvxFlops{
     .amdCore = {.event = 0x3, .unitMask = 0xf}};
+
 // Branches
 constexpr PmuMsr kRetiredBranchInstructions{.amdCore = {.event = 0xc2}};
 constexpr PmuMsr kRetiredBranchMispred{.amdCore = {.event = 0xc3}};
 constexpr PmuMsr kRetiredFarControlTransfer{.amdCore = {.event = 0xc6}};
+
 // TLB
 constexpr PmuMsr kDTlbMisses{.amdCore = {.event = 0x45, .unitMask = 0xf0}};
 constexpr PmuMsr kDTlbAccesses{.amdCore = {.event = 0x45, .unitMask = 0xff}};
 constexpr PmuMsr kITlbMisses{.amdCore = {.event = 0x85, .unitMask = 0xf}};
 constexpr PmuMsr kITlbAccesses{.amdCore = {.event = 0x84}};
+
 // Stall cycles
+// Found in kernel perf_events
+// https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/tools/perf/pmu-events/arch/x86/amdzen3/cache.json?h=v6.0
 constexpr PmuMsr kStalledCyclesBackPressure{
     .amdCore = {.event = 0x87, .unitMask = 0x1}};
 constexpr PmuMsr kStalledCyclesIdqEmpty{
     .amdCore = {.event = 0x87, .unitMask = 0x2}};
 constexpr PmuMsr kStalledCyclesAny{.amdCore = {.event = 0x87, .unitMask = 0x4}};
+
 // Retired uops
 constexpr PmuMsr kRetiredUOps{.amdCore = {.event = 0xc1}};
 constexpr PmuMsr kDeUopsDispatchedOpCache{
     .amdCore = {.event = 0xaa, .unitMask = 0x2}};
 constexpr PmuMsr kDeUopsDispatchedDecoder{
     .amdCore = {.event = 0xaa, .unitMask = 0x1}};
+
 // IC Fill Source
 constexpr PmuMsr kIcCacheFillL2{.amdCore = {.event = 0x82}};
 constexpr PmuMsr kIcCacheFillSys{.amdCore = {.event = 0x83}};
@@ -142,34 +151,15 @@ constexpr PmuMsr kIcCacheFillSys{.amdCore = {.event = 0x83}};
 // MAB Latency
 constexpr PmuMsr kLsAllocMabCount{.amdCore = {.event = 0x5f}};
 constexpr PmuMsr kLsMabAllocPipes{.amdCore = {.event = 0x41, .unitMask = 0x1f}};
-constexpr PmuMsr kIcMabRequest{.amdCore = {.event = 0x80, .event_11_8 = 0x2}};
 constexpr PmuMsr kIcMabRequestsPrefetch{
     .amdCore = {.event = 0x84, .event_11_8 = 0x2}};
 constexpr PmuMsr kIcMabRequestsDemad{
     .amdCore = {.event = 0x85, .event_11_8 = 0x2}};
 
 // L3 counters
-constexpr PmuMsr kL3CacheAccess{.amdL3 = {.event = 0x01, .unitMask = 0x80}};
-constexpr PmuMsr kL3CacheMisses{.amdL3 = {.event = 0x06, .unitMask = 0x80}};
 constexpr PmuMsr kL3FillRdRespLat{.amdL3 = {.event = 0x90}};
 constexpr PmuMsr kL3FillRdCnt{.amdL3 = {.event = 0x9A, .unitMask = 0x1F}};
-constexpr PmuMsr kL3FillLatOtherRdResp{
-    .amdL3 = {.event = 0x9B, .unitMask = 0x0B}};
 
-// DF counters
-constexpr PmuMsr kDfUmcCReadReqs{.amdDf = {.event = 0x87, .unitMask = 0x30}};
-constexpr PmuMsr kDfUmcCCancelsIssd{.amdDf = {.event = 0x87, .unitMask = 0x02}};
-constexpr PmuMsr kDfUmcGReadReqs{
-    .amdDf = {.event = 0x7, .unitMask = 0x30, .event_11_8 = 0x1}};
-constexpr PmuMsr kDfUmcGCCancelsIssd{
-    .amdDf = {.event = 0x7, .unitMask = 0x02, .event_11_8 = 0x1}};
-
-constexpr PmuMsr kDfUmcCWriteReqs{.amdDf = {.event = 0x87, .unitMask = 0x08}};
-constexpr PmuMsr kDfUmcDWriteReqs{.amdDf = {.event = 0xC7, .unitMask = 0x08}};
-constexpr PmuMsr kDfUmcGWriteReqs{
-    .amdDf = {.event = 0x7, .unitMask = 0x08, .event_11_8 = 0x1}};
-constexpr PmuMsr kDfUmcHWriteReqs{
-    .amdDf = {.event = 0x47, .unitMask = 0x08, .event_11_8 = 0x1}};
 } // namespace amd_msr
 
 void addAmdEvents(const CpuInfo& info, PmuDeviceManager& pmu_manager);


### PR DESCRIPTION
Summary:
* Moved NDA events to fb/AmdEvents.h
* Create stub cpp_library "AmdEventsFB" to use when we need to use the NDA events from hbt

Differential Revision: D40748626

