### PR TITLE
fix unittest failure caused by reuse fabric manager address

### DIFF
--- a/dynolog/src/tracing/IPCMonitor.cpp
+++ b/dynolog/src/tracing/IPCMonitor.cpp
@@ -23,8 +23,8 @@ constexpr int kSleepUs = 10000;
 const std::string kLibkinetoRequest = "req";
 const std::string kLibkinetoContext = "ctxt";
 
-IPCMonitor::IPCMonitor() {
-  ipc_manager_ = FabricManager::factory("dynolog");
+IPCMonitor::IPCMonitor(const std::string& ipc_fabric_name) {
+  ipc_manager_ = FabricManager::factory(ipc_fabric_name);
   // below ensures singleton exists
   LOG(INFO) << "Kineto config manager : active processes = "
             << LibkinetoConfigManager::getInstance()->processCount(0);

--- a/dynolog/src/tracing/IPCMonitor.h
+++ b/dynolog/src/tracing/IPCMonitor.h
@@ -14,7 +14,7 @@ namespace tracing {
 class IPCMonitor {
  public:
   using FabricManager = dynolog::ipcfabric::FabricManager;
-  IPCMonitor();
+  IPCMonitor(const std::string& ipc_fabric_name = "dynolog");
 
   void loop();
 

--- a/dynolog/tests/tracing/IPCMonitorTest.cpp
+++ b/dynolog/tests/tracing/IPCMonitorTest.cpp
@@ -46,7 +46,7 @@ TEST(IPCMonitorTest, LibkinetoRegisterAndOndemandTest) {
     std::unique_ptr<Message> msg =
         Message::constructMessage<decltype(ctx)>(ctx, "ctxt");
     LOG(INFO) << "Client sending ctx message";
-    client->sync_send(*msg, "dynolog");
+    client->sync_send(*msg, "dynolog_unittest");
 
     LOG(INFO) << "Client waiting for response";
     auto resp_msg = client->poll_recv(100 /*retries*/, 1000000 /*sleep us*/);
@@ -68,7 +68,7 @@ TEST(IPCMonitorTest, LibkinetoRegisterAndOndemandTest) {
     msg =
         Message::constructMessage<LibkinetoRequest, int32_t>(*req, "req", size);
     LOG(INFO) << "Client sending req message";
-    client->sync_send(*msg, "dynolog");
+    client->sync_send(*msg, "dynolog_unittest");
 
     LOG(INFO) << "Client waiting for response";
     resp_msg = client->poll_recv(100 /*retries*/, 1000000 /*sleep us*/);
@@ -79,7 +79,7 @@ TEST(IPCMonitorTest, LibkinetoRegisterAndOndemandTest) {
 
   } else {
     // Receiver side - IPC Monitor
-    auto monitor = std::make_unique<IPCMonitor>();
+    auto monitor = std::make_unique<IPCMonitor>("dynolog_unittest");
     EXPECT_EQ(LibkinetoConfigManager::getInstance()->processCount(0), 0);
 
     /* sleep override */


### PR DESCRIPTION
Summary: Previously IPCMonitor will spawn FabricManager at "dynolog" address, this will conflict with IPC unit test. This diff modifies the constructor to create the IPCMonitor with customized address as parameter

Reviewed By: jj10306

Differential Revision:
D41138621

LaMa Project: L1137347

