### PR TITLE
add pid based ipc logger and numeric value

### DIFF
--- a/dynolog/src/ipcfabric/Utils.h
+++ b/dynolog/src/ipcfabric/Utils.h
@@ -34,11 +34,7 @@ struct LibkinetoRequest {
 };
 
 constexpr char dynolog_endpoint[] = "dynolog";
-constexpr char type_model_state[] = "model_status";
-constexpr char type_model_id[] = "model_entity_id";
-constexpr char type_tw_task[] = "tw_task";
 constexpr char kLibkinetoRequest[] = "req";
 constexpr char kLibkinetoContext[] = "ctxt";
-
 } // namespace ipcfabric
 } // namespace dynolog


### PR DESCRIPTION
Summary:
This diff adds the GC collection stats through the DynoIPCLogger
  - add IPCMonitor and Dyno handling of GC stats
  - add DynoIPCLogger logging for metrics
  - add DynoIPCLogger construction from pid
  - moved some internal constants from oss dynolog IPCFabric code to internal code IPCUtils.h

Reviewed By: xerothermic, jj10306

Differential Revision: D40565837

