### PR TITLE
move MetricFrame to dynomin

### DIFF
--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -25,5 +25,7 @@ target_link_libraries(dynolog_lib PUBLIC dynolog_ipcmonitor_lib)
 add_subdirectory(gpumon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_dcgm_lib "-ldl")
 
+add_subdirectory(metric_frame)
+
 add_executable(dynolog Main.cpp)
 target_link_libraries(dynolog PRIVATE dynolog_lib dynolog_rpc_lib)

--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(metric_series STATIC MetricSeries.h)
+set_target_properties(metric_series PROPERTIES LINKER_LANGUAGE CXX)
+add_library(metric_frame_ts_unit STATIC
+    MetricFrameTsUnit.h MetricFrameTsUnit.cpp MetricFrameTsUnitInterface.h)
+add_library(metric_frame STATIC
+    MetricFrame.h MetricFrame.cpp MetricFrameBase.h MetricFrameBase.cpp)
+target_link_libraries(metric_frame metric_series metric_frame_ts_unit)

--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "dynolog/src/metric_frame/MetricFrame.h"
+#include "dynolog/src/metric_frame/MetricFrameTsUnitInterface.h"
+
+#include <stdexcept>
+
+namespace facebook::dynolog {
+
+MetricFrameMap::MetricFrameMap(
+    size_t maxLength,
+    std::string name,
+    std::string description,
+    std::shared_ptr<MetricFrameTsUnitInterface> ts)
+    : MetricFrameBase(std::move(name), std::move(description), std::move(ts)) {
+  if (ts_->maxLength() != maxLength) {
+    throw std::invalid_argument(
+        "TsUnit maxLength (" + std::to_string(ts_->maxLength()) +
+        ") is different from MetricFrame maxLength (" +
+        std::to_string(maxLength) + ")");
+  }
+}
+
+bool MetricFrameMap::addSeries(
+    const std::string& key,
+    MetricSeriesVar seriesVar) {
+  if (series_.count(key)) {
+    return false;
+  }
+  series_.insert({key, std::move(seriesVar)});
+  return true;
+}
+
+bool MetricFrameMap::eraseSeries(const std::string& name) {
+  return series_.erase(name) == 1;
+}
+
+bool MetricFrameMap::addSamples(const MapSamplesT& samples, TimePoint time) {
+  for (const auto& [name, sampleVar] : samples) {
+    auto seriesIt = series_.find(name);
+    if (seriesIt == series_.end()) {
+      continue;
+    }
+    auto& seriesVar = seriesIt->second;
+    addSample(sampleVar, seriesVar);
+  }
+  ts_->addSample(time);
+  return true;
+}
+
+size_t MetricFrameMap::width() const {
+  return series_.size();
+};
+
+std::optional<MetricSeriesVar> MetricFrameMap::series(
+    const std::string& name) const {
+  auto it = series_.find(name);
+  if (it == series_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+std::optional<MetricSeriesVar> MetricFrameMap::series(const int) const {
+  return std::nullopt;
+}
+
+MetricFrameVector::MetricFrameVector(
+    VectorSeriesDefList defs,
+    std::string name,
+    std::string description,
+    std::shared_ptr<MetricFrameTsUnitInterface> ts)
+    : MetricFrameBase(std::move(name), std::move(description), std::move(ts)),
+      series_{defs} {}
+
+bool MetricFrameVector::addSamples(
+    const VectorSamplesT& samples,
+    TimePoint time) {
+  if (samples.size() != width()) {
+    return false;
+  }
+  for (size_t idx = 0; idx < series_.size(); idx++) {
+    auto& series = series_[idx];
+    auto& sample = samples[idx];
+    addSample(sample, series);
+  }
+  ts_->addSample(time);
+  return true;
+}
+
+size_t MetricFrameVector::width() const {
+  return series_.size();
+}
+
+std::optional<MetricSeriesVar> MetricFrameVector::series(
+    const std::string&) const {
+  return std::nullopt;
+}
+
+std::optional<MetricSeriesVar> MetricFrameVector::series(int idx) const {
+  if (idx >= width()) {
+    return std::nullopt;
+  }
+  return series_[idx];
+}
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrame.h
+++ b/dynolog/src/metric_frame/MetricFrame.h
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "dynolog/src/metric_frame/MetricFrameBase.h"
+#include "dynolog/src/metric_frame/MetricFrameTsUnitInterface.h"
+#include "dynolog/src/metric_frame/MetricSeries.h"
+
+#include <cmath>
+#include <map>
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace facebook::dynolog {
+
+using MapSamplesT = std::vector<std::pair<std::string, SampleVarT>>;
+using VectorSamplesT = std::vector<SampleVarT>;
+
+class MetricFrameMap : public MetricFrameBase {
+ public:
+  MetricFrameMap(
+      size_t capacity,
+      std::string name,
+      std::string description,
+      std::shared_ptr<MetricFrameTsUnitInterface> ts);
+  bool addSeries(const std::string& key, MetricSeriesVar seriesVar);
+  bool eraseSeries(const std::string& name);
+  bool addSamples(const MapSamplesT& samples, TimePoint time);
+  size_t width() const override;
+  std::optional<MetricSeriesVar> series(const std::string& name) const override;
+  std::optional<MetricSeriesVar> series(int name) const override;
+
+ protected:
+  std::map<std::string, MetricSeriesVar> series_;
+};
+
+using VectorSeriesDefList = std::vector<MetricSeriesVar>;
+
+class MetricFrameVector : public MetricFrameBase {
+ public:
+  MetricFrameVector(
+      VectorSeriesDefList defs,
+      std::string name,
+      std::string description,
+      std::shared_ptr<MetricFrameTsUnitInterface> ts);
+  bool addSamples(const VectorSamplesT& samples, TimePoint time);
+  size_t width() const override;
+  std::optional<MetricSeriesVar> series(const std::string& name) const override;
+  std::optional<MetricSeriesVar> series(int name) const override;
+
+ protected:
+  VectorSeriesDefList series_;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "dynolog/src/metric_frame/MetricFrameBase.h"
+
+namespace facebook::dynolog {
+
+MetricFrameBase::MetricFrameBase(
+    std::string name,
+    std::string description,
+    std::shared_ptr<MetricFrameTsUnitInterface> ts)
+    : name_{std::move(name)},
+      description_{std::move(description)},
+      ts_{std::move(ts)} {}
+
+const std::string& MetricFrameBase::name() const {
+  return name_;
+}
+
+const std::string& MetricFrameBase::description() const {
+  return description_;
+}
+
+size_t MetricFrameBase::length() const {
+  return ts_->length();
+}
+
+size_t MetricFrameBase::maxLength() const {
+  return ts_->maxLength();
+}
+
+std::optional<TimePoint> MetricFrameBase::firstSampleTime() const {
+  return ts_->firstSampleTime();
+}
+
+std::optional<TimePoint> MetricFrameBase::lastSampleTime() const {
+  return ts_->lastSampleTime();
+}
+
+std::optional<MetricFrameSlice> MetricFrameBase::slice(
+    TimePoint startTime,
+    TimePoint endTime,
+    MATCH_POLICY startTimePolicy,
+    MATCH_POLICY endTimePolicy) const {
+  auto rangeMaybe =
+      ts_->getRange(startTime, endTime, startTimePolicy, endTimePolicy);
+  if (!rangeMaybe.has_value()) {
+    return std::nullopt;
+  }
+  return MetricFrameSlice(*this, rangeMaybe.value());
+}
+
+void MetricFrameBase::addSample(
+    const SampleVarT& sampleVar,
+    MetricSeriesVar& seriesVar) {
+  std::visit(
+      [&sampleVar](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<MetricSeriesInt64Ptr, T>) {
+          arg->addSample(std::get<int64_t>(sampleVar));
+        } else if constexpr (std::is_same_v<T, MetricSeriesDoublePtr>) {
+          arg->addSample(std::get<double>(sampleVar));
+        }
+      },
+      seriesVar);
+}
+
+MetricFrameSlice::MetricFrameSlice(
+    const MetricFrameBase& frame,
+    MetricFrameRange range)
+    : frame_{frame}, range_{range} {}
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -1,0 +1,145 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "dynolog/src/metric_frame/MetricFrameTsUnitInterface.h"
+#include "dynolog/src/metric_frame/MetricSeries.h"
+
+#include <memory>
+#include <string>
+#include <variant>
+
+namespace facebook::dynolog {
+
+using SampleVarT = std::variant<int64_t, double>;
+using MetricSeriesInt64Ptr = std::shared_ptr<MetricSeries<int64_t>>;
+using MetricSeriesDoublePtr = std::shared_ptr<MetricSeries<double>>;
+using MetricSeriesVar =
+    std::variant<MetricSeriesInt64Ptr, MetricSeriesDoublePtr>;
+
+class MetricFrameSlice;
+
+class MetricFrameBase {
+ public:
+  MetricFrameBase(
+      std::string name,
+      std::string description,
+      std::shared_ptr<MetricFrameTsUnitInterface> ts);
+  virtual ~MetricFrameBase() = default;
+  const std::string& name() const;
+  const std::string& description() const;
+  size_t length() const;
+  size_t maxLength() const;
+  std::optional<TimePoint> firstSampleTime() const;
+  std::optional<TimePoint> lastSampleTime() const;
+  std::optional<MetricFrameSlice> slice(
+      TimePoint startTime,
+      TimePoint endTime,
+      MATCH_POLICY startTimePolicy = MATCH_POLICY::CLOSEST,
+      MATCH_POLICY endTimePolicy = MATCH_POLICY::CLOSEST) const;
+  virtual size_t width() const = 0;
+  virtual std::optional<MetricSeriesVar> series(
+      const std::string& name) const = 0;
+  virtual std::optional<MetricSeriesVar> series(int name) const = 0;
+
+ protected:
+  void addSample(const SampleVarT& sample, MetricSeriesVar& seriesVar);
+  std::string name_;
+  std::string description_;
+  std::shared_ptr<MetricFrameTsUnitInterface> ts_;
+};
+
+template <typename T>
+class MetricSeriesSlice {
+ public:
+  const std::string& name() const {
+    return series_.name();
+  }
+  const std::string& description() const {
+    return series_.description();
+  }
+  size_t size() const {
+    return series_.size();
+  }
+
+  template <typename R>
+  R rate(std::chrono::steady_clock::duration period) const {
+    return series_.template rate<R>(
+        period,
+        range_.end.time - range_.start.time,
+        series_.begin() + range_.start.offset,
+        series_.begin() + range_.end.offset + 1);
+  }
+  template <typename R>
+  R avg() const {
+    return series_.template avg<R>(
+        series_.begin() + range_.start.offset,
+        series_.begin() + range_.end.offset + 1);
+  }
+  T percentile(float percentage) const {
+    return series_.percentile(
+        percentage,
+        series_.begin() + range_.start.offset,
+        series_.begin() + range_.end.offset + 1);
+  }
+  T diff() const {
+    return series_.diff(
+        series_.begin() + range_.start.offset,
+        series_.begin() + range_.end.offset + 1);
+  }
+
+ protected:
+  MetricSeriesSlice(
+      const MetricSeries<T>& series,
+      const MetricFrameRange& range)
+      : series_{series}, range_{range} {}
+  const MetricSeries<T>& series_;
+  MetricFrameRange range_;
+
+  friend class MetricFrameSlice;
+};
+
+class MetricFrameSlice {
+ public:
+  template <typename T>
+  std::optional<MetricSeriesSlice<T>> series(const std::string& name) const {
+    auto seriesVar = frame_.series(name);
+    if (!seriesVar.has_value()) {
+      return std::nullopt;
+    }
+    return getSeriesFromVar<T>(seriesVar.value(), range_);
+  }
+  template <typename T>
+  std::optional<MetricSeriesSlice<T>> series(int name) const {
+    auto seriesVar = frame_.series(name);
+    if (!seriesVar.has_value()) {
+      return std::nullopt;
+    }
+    return getSeriesFromVar<T>(seriesVar.value(), range_);
+  }
+
+ protected:
+  MetricFrameSlice(const MetricFrameBase& frame, MetricFrameRange range);
+  const MetricFrameBase& frame_;
+  MetricFrameRange range_;
+
+ private:
+  template <typename T>
+  static std::optional<MetricSeriesSlice<T>> getSeriesFromVar(
+      const MetricSeriesVar& seriesVar,
+      const MetricFrameRange& range) {
+    auto seriesPtrMaybe =
+        std::get_if<std::shared_ptr<MetricSeries<T>>>(&seriesVar);
+    if (!seriesPtrMaybe) {
+      return std::nullopt;
+    }
+    return MetricSeriesSlice<T>(**seriesPtrMaybe, range);
+  }
+
+  friend class MetricFrameBase;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "dynolog/src/metric_frame/MetricFrameTsUnit.h"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace facebook::dynolog {
+
+MetricFrameTsUnitFixInterval::MetricFrameTsUnitFixInterval(
+    std::chrono::microseconds interval,
+    size_t frameLength)
+    : interval_{interval}, frameLength_{frameLength} {
+  if (interval_.count() == 0) {
+    throw std::invalid_argument(
+        "interval of MetricFrameTsUnitFixInterval cannot be 0");
+  }
+}
+
+void MetricFrameTsUnitFixInterval::addSample(TimePoint time) {
+  sampleCount_ = std::min(frameLength_, sampleCount_ + 1);
+  lastSampleTime_ = time;
+}
+
+std::optional<TimePoint> MetricFrameTsUnitFixInterval::firstSampleTime() const {
+  if (sampleCount_ == 0) {
+    return std::nullopt;
+  }
+  return lastSampleTime_ - (sampleCount_ - 1) * interval_;
+};
+
+std::optional<TimePoint> MetricFrameTsUnitFixInterval::lastSampleTime() const {
+  if (sampleCount_ == 0) {
+    return std::nullopt;
+  }
+  return lastSampleTime_;
+}
+
+size_t MetricFrameTsUnitFixInterval::length() const {
+  return sampleCount_;
+}
+
+size_t MetricFrameTsUnitFixInterval::maxLength() const {
+  return frameLength_;
+}
+
+std::optional<MetricFrameRange> MetricFrameTsUnitFixInterval::getRange(
+    TimePoint startTime,
+    TimePoint endTime,
+    MATCH_POLICY startTimePolicy,
+    MATCH_POLICY endTimePolicy) const {
+  auto startMaybe = findMatchingOffset(startTime, startTimePolicy);
+  auto endMaybe = findMatchingOffset(endTime, endTimePolicy);
+  if (!startMaybe.has_value() || !endMaybe.has_value()) {
+    return std::nullopt;
+  }
+
+  return MetricFrameRange{.start = startMaybe.value(), .end = endMaybe.value()};
+}
+
+TimePoint MetricFrameTsUnitFixInterval::offsetToTime(size_t offset) const {
+  return lastSampleTime_ - (sampleCount_ - offset - 1) * interval_;
+}
+
+std::optional<MetricFrameOffset>
+MetricFrameTsUnitFixInterval::findMatchingOffset(
+    TimePoint requestedTime,
+    MATCH_POLICY policy) const {
+  if (sampleCount_ == 0) {
+    return std::nullopt;
+  }
+  double offsetFloat = sampleCount_ - 1 +
+      static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(
+                              requestedTime - lastSampleTime_)
+                              .count()) /
+          std::chrono::duration_cast<std::chrono::microseconds>(interval_)
+              .count();
+
+  std::optional<size_t> offset;
+  switch (policy) {
+    case MATCH_POLICY::CLOSEST:
+      offset = closestPolicy(offsetFloat);
+      break;
+    case MATCH_POLICY::PREV_CLOSEST:
+      offset = prevClosestPolicy(offsetFloat);
+      break;
+    case MATCH_POLICY::NEXT_CLOSEST:
+      offset = nextClosestPolicy(offsetFloat);
+      break;
+  }
+
+  if (!offset.has_value()) {
+    return std::nullopt;
+  }
+
+  return MetricFrameOffset{
+      .offset = offset.value(), .time = offsetToTime(offset.value())};
+}
+
+std::optional<size_t> MetricFrameTsUnitFixInterval::closestPolicy(
+    double offsetFloat) const {
+  if (offsetFloat < 0) {
+    return 0;
+  }
+  if (offsetFloat > sampleCount_ - 1) {
+    return sampleCount_ - 1;
+  }
+  return std::lround(offsetFloat);
+}
+
+std::optional<size_t> MetricFrameTsUnitFixInterval::prevClosestPolicy(
+    double offsetFloat) const {
+  if (offsetFloat < 0) {
+    return std::nullopt;
+  }
+  if (offsetFloat > sampleCount_ - 1) {
+    return sampleCount_ - 1;
+  }
+  return std::floor(offsetFloat);
+}
+
+std::optional<size_t> MetricFrameTsUnitFixInterval::nextClosestPolicy(
+    double offsetFloat) const {
+  if (offsetFloat < 0) {
+    return 0;
+  }
+  if (offsetFloat > sampleCount_ - 1) {
+    return std::nullopt;
+  }
+  return std::ceil(offsetFloat);
+}
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.h
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "dynolog/src/metric_frame/MetricFrameTsUnitInterface.h"
+
+#include <optional>
+
+namespace facebook::dynolog {
+
+class MetricFrameTsUnitFixInterval : public MetricFrameTsUnitInterface {
+ public:
+  MetricFrameTsUnitFixInterval(
+      std::chrono::microseconds interval,
+      size_t frameLength);
+  virtual void addSample(TimePoint time) override;
+  virtual std::optional<TimePoint> firstSampleTime() const override;
+  virtual std::optional<TimePoint> lastSampleTime() const override;
+  virtual size_t length() const override;
+  virtual size_t maxLength() const override;
+  virtual std::optional<MetricFrameRange> getRange(
+      TimePoint startTime,
+      TimePoint endTime,
+      MATCH_POLICY startTimePolicy,
+      MATCH_POLICY endTimePolicy) const override;
+
+ protected:
+  const std::chrono::microseconds interval_;
+  const size_t frameLength_;
+  size_t sampleCount_ = 0;
+  TimePoint lastSampleTime_;
+
+  TimePoint offsetToTime(size_t offset) const;
+  std::optional<MetricFrameOffset> findMatchingOffset(
+      TimePoint requestedTime,
+      MATCH_POLICY policy) const;
+
+  std::optional<size_t> closestPolicy(double offsetFloat) const;
+  std::optional<size_t> prevClosestPolicy(double offsetFloat) const;
+  std::optional<size_t> nextClosestPolicy(double offsetFloat) const;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+namespace facebook::dynolog {
+
+using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+
+enum class MATCH_POLICY {
+  CLOSEST, // use the closest sample
+  PREV_CLOSEST, // use the closest sample previous to provided timepoint
+  NEXT_CLOSEST, // use the closest sample next to provided timepoint
+};
+
+struct MetricFrameOffset {
+  size_t offset;
+  TimePoint time;
+};
+
+struct MetricFrameRange {
+  MetricFrameOffset start;
+  MetricFrameOffset end;
+};
+
+class MetricFrameTsUnitInterface {
+ public:
+  virtual ~MetricFrameTsUnitInterface() = default;
+  virtual void addSample(TimePoint time) = 0;
+  virtual std::optional<TimePoint> firstSampleTime() const = 0;
+  virtual std::optional<TimePoint> lastSampleTime() const = 0;
+  virtual size_t length() const = 0;
+  virtual size_t maxLength() const = 0;
+  virtual std::optional<MetricFrameRange> getRange(
+      TimePoint startTime,
+      TimePoint endTime,
+      MATCH_POLICY startTimePolicy = MATCH_POLICY::CLOSEST,
+      MATCH_POLICY endTimePolicy = MATCH_POLICY::CLOSEST) const = 0;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -1,0 +1,263 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <ratio>
+#include <stdexcept>
+#include <vector>
+
+namespace facebook::dynolog {
+
+template <typename T>
+class MetricSeries final {
+ public:
+  class Iterator : public std::iterator<std::random_access_iterator_tag, T> {
+   public:
+    using difference_type = int;
+    using value_type = T;
+
+    Iterator(
+        const std::vector<T>& data,
+        size_t size,
+        size_t headIdx,
+        size_t headDis)
+        : data_{&data}, size_{size}, headIdx_{headIdx}, headDis_{headDis} {}
+    // see P2325R3
+    // default constructor should not be required in the future
+    Iterator() {}
+
+    const value_type& operator*() const {
+      return data_->at(dataIdx());
+    }
+
+    Iterator& operator++() {
+      headDis_++;
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator temp = *this;
+      ++*this;
+      return temp;
+    }
+
+    Iterator& operator--() {
+      headDis_--;
+      return *this;
+    }
+
+    Iterator operator--(int) {
+      Iterator temp = *this;
+      --*this;
+      return temp;
+    }
+
+    bool operator==(const Iterator& rhs) const {
+      return headDis_ == rhs.headDis_;
+    }
+
+    bool operator!=(const Iterator& rhs) const {
+      return headDis_ != rhs.headDis_;
+    }
+
+    bool operator<(const Iterator& rhs) const {
+      return headDis_ < rhs.headDis_;
+    }
+
+    bool operator<=(const Iterator& rhs) const {
+      return headDis_ <= rhs.headDis_;
+    }
+
+    bool operator>(const Iterator& rhs) const {
+      return headDis_ > rhs.headDis_;
+    }
+
+    bool operator>=(const Iterator& rhs) const {
+      return headDis_ >= rhs.headDis_;
+    }
+
+    Iterator operator+(difference_type dis) const {
+      Iterator temp = *this;
+      temp.headDis_ += dis;
+      return temp;
+    }
+
+    friend Iterator operator+(const difference_type lhs, const Iterator& rhs) {
+      return rhs + lhs;
+    }
+
+    Iterator& operator+=(difference_type dis) {
+      headDis_ += dis;
+      return *this;
+    }
+
+    difference_type operator-(const Iterator& rhs) const {
+      return headDis_ - rhs.headDis_;
+    }
+
+    Iterator operator-(difference_type dis) const {
+      Iterator temp = *this;
+      temp.headDis_ -= dis;
+      return temp;
+    }
+
+    Iterator& operator-=(difference_type dis) {
+      headDis_ += dis;
+      return *this;
+    }
+
+    const value_type& operator[](const difference_type dis) const {
+      return *(*this + dis);
+    }
+
+   private:
+    const std::vector<T>* data_ = nullptr;
+    size_t size_;
+    // current tail index in data_
+    size_t headIdx_;
+    // distance to head
+    size_t headDis_;
+
+    size_t dataIdx() const {
+      return (headIdx_ + headDis_) % size_;
+    }
+  };
+
+  MetricSeries(size_t bufferLen, std::string name, std::string description)
+      : data_{std::vector<T>(bufferLen)},
+        name_{std::move(name)},
+        description_{std::move(description)} {}
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const std::string& description() const {
+    return description_;
+  }
+
+  void addSample(const T& sample) {
+    if (size_ == data_.size()) {
+      data_[tail_] = sample;
+      tail_ = idxNext(tail_);
+      head_ = idxNext(head_);
+    } else {
+      data_[tail_] = sample;
+      tail_ = idxNext(tail_);
+      size_++;
+    }
+  }
+
+  const T& at(size_t idx) {
+    return *(begin() + idx);
+  }
+
+  Iterator begin() const {
+    return Iterator(data_, size_, head_, 0);
+  }
+
+  Iterator end() const {
+    return Iterator(data_, size_, head_, size_);
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+  size_t maxLength() {
+    return data_.size();
+  }
+
+  T& operator[](const size_t idx) {
+    return *(begin() + idx);
+  }
+
+  const T& operator[](const size_t idx) const {
+    return *(begin() + idx);
+  }
+
+  template <typename R>
+  R rate(
+      std::chrono::steady_clock::duration period,
+      std::chrono::steady_clock::duration duration,
+      std::optional<Iterator> beginMaybe = std::nullopt,
+      std::optional<Iterator> endMaybe = std::nullopt) const {
+    auto begin_ = beginMaybe.value_or(begin());
+    auto end_ = endMaybe.value_or(end());
+    auto value = diff(beginMaybe, endMaybe);
+    return rate<R>(value, period, duration);
+  }
+
+  template <typename R>
+  R avg(
+      std::optional<Iterator> beginMaybe = std::nullopt,
+      std::optional<Iterator> endMaybe = std::nullopt) const {
+    auto begin_ = beginMaybe.value_or(begin());
+    auto end_ = endMaybe.value_or(end());
+    return std::accumulate(begin_, end_, R{0}) / (end_ - begin_);
+  }
+
+  T percentile(
+      float percentage,
+      std::optional<Iterator> beginMaybe = std::nullopt,
+      std::optional<Iterator> endMaybe = std::nullopt) const {
+    auto begin_ = beginMaybe.value_or(begin());
+    auto end_ = endMaybe.value_or(end());
+    std::vector<T> dataCopy(begin_, end_);
+    auto nthIdx = lround(percentage * (dataCopy.size() - 1));
+    std::nth_element(
+        dataCopy.begin(), dataCopy.begin() + nthIdx, dataCopy.end());
+    return dataCopy[nthIdx];
+  }
+
+  T diff(
+      std::optional<Iterator> beginMaybe = std::nullopt,
+      std::optional<Iterator> endMaybe = std::nullopt) const {
+    auto begin_ = beginMaybe.value_or(begin());
+    auto end_ = endMaybe.value_or(end());
+    return *(end_ - 1) - *begin_;
+  }
+
+ private:
+  template <typename R>
+  static R rate(
+      const T& value,
+      std::chrono::steady_clock::duration period,
+      std::chrono::steady_clock::duration duration) {
+    if constexpr (std::is_integral_v<R>) {
+      if (period > duration) {
+        return value * (period / duration);
+      } else {
+        return value / (duration / period);
+      }
+    } else {
+      return static_cast<R>(value) *
+          static_cast<double>(
+                 std::chrono::duration_cast<std::chrono::microseconds>(period)
+                     .count()) /
+          std::chrono::duration_cast<std::chrono::microseconds>(duration)
+              .count();
+    }
+  }
+  int idxNext(int idx) const {
+    return (idx + 1) % data_.size();
+  }
+  std::vector<T> data_;
+  size_t head_ = 0;
+  size_t tail_ = 0;
+  size_t size_ = 0;
+  const std::string name_;
+  const std::string description_;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/tests/CMakeLists.txt
+++ b/dynolog/tests/CMakeLists.txt
@@ -6,3 +6,4 @@ dynolog_add_test(KernelCollecterTest KernelCollecterTest.cpp)
 
 add_subdirectory(rpc)
 add_subdirectory(tracing)
+add_subdirectory(metric_frame)

--- a/dynolog/tests/metric_frame/CMakeLists.txt
+++ b/dynolog/tests/metric_frame/CMakeLists.txt
@@ -1,0 +1,9 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+dynolog_add_test(MetricSeriesTest MetricSeriesTest.cpp)
+target_link_libraries(MetricSeriesTest PRIVATE metric_series)
+
+dynolog_add_test(MetricFrameTsUnitTest MetricFrameTsUnitTest.cpp)
+target_link_libraries(MetricFrameTsUnitTest PRIVATE metric_frame_ts_unit)
+
+dynolog_add_test(MetricFrameTest MetricFrameTest.cpp)
+target_link_libraries(MetricFrameTest PRIVATE metric_frame)

--- a/dynolog/tests/metric_frame/MetricFrameTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTest.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include "dynolog/src/metric_frame/MetricFrame.h"
+#include "dynolog/src/metric_frame/MetricFrameTsUnit.h"
+#include "dynolog/src/metric_frame/MetricSeries.h"
+
+using namespace ::testing;
+using namespace ::facebook::dynolog;
+
+using namespace std::literals::chrono_literals;
+
+TEST(MetricSeriesSliceTest, constructor) {
+  auto ts = std::make_shared<MetricFrameTsUnitFixInterval>(
+      std::chrono::seconds{60}, 10);
+  auto tsLong = std::make_shared<MetricFrameTsUnitFixInterval>(
+      std::chrono::seconds{60}, 100);
+  MetricFrameMap frameMap(10, "test", "test metric frame", std::move(ts));
+
+  EXPECT_EQ(frameMap.length(), 0);
+  EXPECT_EQ(frameMap.width(), 0);
+  EXPECT_EQ(frameMap.maxLength(), 10);
+  EXPECT_EQ(frameMap.name(), "test");
+  EXPECT_EQ(frameMap.description(), "test metric frame");
+  EXPECT_FALSE(frameMap.firstSampleTime().has_value());
+  EXPECT_FALSE(frameMap.lastSampleTime().has_value());
+
+  EXPECT_THROW(
+      MetricFrameMap(10, "test", "test metric frame", std::move(tsLong)),
+      std::invalid_argument);
+}
+
+TEST(MetricSeriesSliceTest, metricFrameMapSmokeTest) {
+  auto ts = std::make_shared<MetricFrameTsUnitFixInterval>(
+      std::chrono::seconds{60}, 10);
+  MetricFrameMap frameMap(10, "test", "test metric frame", std::move(ts));
+
+  std::string series1Key = "metric1";
+  std::string series2Key = "metric2";
+
+  auto series1 =
+      std::make_shared<MetricSeries<int64_t>>(10, series1Key, "test metric 1");
+  auto series2 =
+      std::make_shared<MetricSeries<double>>(10, series2Key, "test metric 2");
+
+  frameMap.addSeries(series1Key, std::move(series1));
+  frameMap.addSeries(series2Key, std::move(series2));
+
+  EXPECT_EQ(frameMap.length(), 0);
+  EXPECT_EQ(frameMap.maxLength(), 10);
+  EXPECT_EQ(frameMap.width(), 2);
+
+  auto now = std::chrono::steady_clock::now();
+
+  frameMap.addSamples({{"metric1", 42l}, {"metric2", 23.9f}}, now);
+  EXPECT_EQ(frameMap.length(), 1);
+  EXPECT_EQ(frameMap.maxLength(), 10);
+  for (int i = 1; i <= 10; i++) {
+    frameMap.addSamples(
+        {{"metric1", 42l + i}, {"metric2", 23.9f + i}}, now + 60s * i);
+  }
+  // |  60s | 120s | 180s | 240s | 300s | 360s | 420s | 480s | 540s | 600s |
+  // |  43  |  44  |  45  |  46  |  47  |  48  |  49  |  50  |  51  | 52   |
+  // | 24.9 | 25.9 | 26.9 | 27.9 | 28.9 | 29.9 | 30.9 | 31.9 | 32.9 | 33.9 |
+  //           |-----------------------------------|
+  EXPECT_EQ(frameMap.length(), 10);
+  EXPECT_EQ(frameMap.maxLength(), 10);
+  EXPECT_EQ(frameMap.firstSampleTime().value(), now + 60s);
+  EXPECT_EQ(frameMap.lastSampleTime().value(), now + 600s);
+
+  ASSERT_TRUE(frameMap.slice(now + 100s, now + 400s).has_value());
+  auto frameSlice = frameMap.slice(now + 100s, now + 400s).value();
+
+  auto seriesSlice1 = frameSlice.series<int64_t>("metric1");
+  auto seriesSlice2 = frameSlice.series<double>("metric2");
+  ASSERT_TRUE(seriesSlice1.has_value());
+  ASSERT_TRUE(seriesSlice2.has_value());
+  EXPECT_FALSE(frameSlice.series<int64_t>("not_exist").has_value());
+
+  EXPECT_EQ(seriesSlice1->avg<int>(), 46);
+  EXPECT_NEAR(seriesSlice1->avg<double>(), 46.5, 1e-3);
+  EXPECT_EQ(seriesSlice1->percentile(0.2), 45);
+  EXPECT_NEAR(seriesSlice1->rate<double>(1s), 0.01667, 1e-3);
+  EXPECT_EQ(seriesSlice1->rate<int>(1min), 1);
+  EXPECT_EQ(seriesSlice1->diff(), 5);
+
+  EXPECT_NEAR(seriesSlice2->avg<double>(), 28.4, 1e-3);
+  EXPECT_NEAR(seriesSlice2->percentile(0.4), 27.9, 1e-3);
+  EXPECT_NEAR(seriesSlice2->rate<double>(1s), 0.01667, 1e-3);
+  EXPECT_EQ(seriesSlice2->rate<int>(1min), 1);
+  EXPECT_NEAR(seriesSlice2->diff(), 5.0, 1e-3);
+
+  EXPECT_TRUE(frameMap.eraseSeries(series1Key));
+  EXPECT_FALSE(frameMap.eraseSeries("not_exist"));
+  EXPECT_FALSE(
+      frameMap.slice(now, now + 140s)->series<int64_t>(series1Key).has_value());
+  EXPECT_FALSE(frameMap.series(series1Key));
+}
+
+TEST(MetricSeriesSliceTest, metricFrameVectorSmokeTest) {
+  std::string series1Key = "metric1";
+  std::string series2Key = "metric2";
+
+  auto ts = std::make_shared<MetricFrameTsUnitFixInterval>(
+      std::chrono::seconds{60}, 10);
+  MetricFrameVector frameVector(
+      {std::make_shared<MetricSeries<int64_t>>(10, series1Key, "test metric 1"),
+       std::make_shared<MetricSeries<double>>(10, series2Key, "test metric 2")},
+      "test",
+      "test metric frame",
+      std::move(ts));
+
+  EXPECT_EQ(frameVector.length(), 0);
+  EXPECT_EQ(frameVector.maxLength(), 10);
+  EXPECT_EQ(frameVector.width(), 2);
+
+  auto now = std::chrono::steady_clock::now();
+  frameVector.addSamples({42l, 23.9f}, now);
+  EXPECT_EQ(frameVector.length(), 1);
+  EXPECT_EQ(frameVector.maxLength(), 10);
+  for (int i = 1; i <= 10; i++) {
+    frameVector.addSamples({42l + i, 23.9f + i}, now + 60s * i);
+  }
+  // |  60s | 120s | 180s | 240s | 300s | 360s | 420s | 480s | 540s | 600s |
+  // |  43  |  44  |  45  |  46  |  47  |  48  |  49  |  50  |  51  | 52   |
+  // | 24.9 | 25.9 | 26.9 | 27.9 | 28.9 | 29.9 | 30.9 | 31.9 | 32.9 | 33.9 |
+  //           |-----------------------------------|
+  EXPECT_EQ(frameVector.length(), 10);
+  EXPECT_EQ(frameVector.maxLength(), 10);
+  EXPECT_EQ(frameVector.firstSampleTime().value(), now + 60s);
+  EXPECT_EQ(frameVector.lastSampleTime().value(), now + 600s);
+
+  ASSERT_TRUE(frameVector.slice(now + 100s, now + 400s).has_value());
+  auto frameSlice = frameVector.slice(now + 100s, now + 400s).value();
+
+  auto seriesSlice1 = frameSlice.series<int64_t>(0);
+  auto seriesSlice2 = frameSlice.series<double>(1);
+  ASSERT_TRUE(seriesSlice1.has_value());
+  ASSERT_TRUE(seriesSlice2.has_value());
+  EXPECT_FALSE(frameSlice.series<int64_t>(10).has_value());
+
+  EXPECT_EQ(seriesSlice1->avg<int>(), 46);
+  EXPECT_NEAR(seriesSlice1->avg<double>(), 46.5, 1e-3);
+  EXPECT_EQ(seriesSlice1->percentile(0.2), 45);
+  EXPECT_NEAR(seriesSlice1->rate<double>(1s), 0.01667, 1e-3);
+  EXPECT_EQ(seriesSlice1->rate<int>(1min), 1);
+  EXPECT_EQ(seriesSlice1->diff(), 5);
+
+  EXPECT_NEAR(seriesSlice2->avg<double>(), 28.4, 1e-3);
+  EXPECT_NEAR(seriesSlice2->percentile(0.4), 27.9, 1e-3);
+  EXPECT_NEAR(seriesSlice2->rate<double>(1s), 0.01667, 1e-3);
+  EXPECT_EQ(seriesSlice2->rate<int>(1min), 1);
+  EXPECT_NEAR(seriesSlice2->diff(), 5, 1e-3);
+}

--- a/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "dynolog/src/metric_frame/MetricFrameTsUnit.h"
+
+using namespace ::testing;
+using namespace ::facebook::dynolog;
+
+using namespace std::literals;
+using namespace std::literals::chrono_literals;
+
+class MetricFrameTsUnitFixIntervalTest : public MetricFrameTsUnitFixInterval {
+ public:
+  MetricFrameTsUnitFixIntervalTest() : MetricFrameTsUnitFixInterval{60s, 10} {}
+};
+
+TEST(MetricFrameTsUnitTest, constructor) {
+  MetricFrameTsUnitFixIntervalTest t;
+}
+
+TEST(MetricFrameTsUnitTest, smokeTest) {
+  MetricFrameTsUnitFixIntervalTest t;
+  MetricFrameTsUnitInterface& i = t;
+  auto now = std::chrono::steady_clock::now();
+  i.addSample(now - 120s);
+  i.addSample(now - 60s);
+  i.addSample(now);
+
+  EXPECT_EQ(i.lastSampleTime(), now);
+  EXPECT_EQ(i.firstSampleTime(), now - 120s);
+  EXPECT_EQ(i.length(), 3);
+  EXPECT_EQ(i.maxLength(), 10);
+
+  auto resMaybe = i.getRange(now - 120s, now);
+  EXPECT_TRUE(resMaybe.has_value());
+  auto& res = resMaybe.value();
+  EXPECT_EQ(res.start.offset, 0);
+  EXPECT_EQ(res.start.time, now - 120s);
+  EXPECT_EQ(res.end.offset, 2);
+  EXPECT_EQ(res.end.time, now);
+}
+
+TEST(MetricFrameTsUnitTest, emptyFrame) {
+  MetricFrameTsUnitFixIntervalTest t;
+  MetricFrameTsUnitInterface& i = t;
+  auto now = std::chrono::steady_clock::now();
+  auto resMaybe = i.getRange(now - 120s, now);
+  EXPECT_FALSE(resMaybe.has_value());
+  EXPECT_FALSE(i.lastSampleTime().has_value());
+  EXPECT_FALSE(i.firstSampleTime().has_value());
+  EXPECT_EQ(i.length(), 0);
+  EXPECT_EQ(i.maxLength(), 10);
+}
+
+TEST(MetricFrameTsUnitTest, interpolationPolicies) {
+  MetricFrameTsUnitFixIntervalTest t;
+  MetricFrameTsUnitInterface& i = t;
+  auto now = std::chrono::steady_clock::now();
+  i.addSample(now - 120s);
+  i.addSample(now - 60s);
+  i.addSample(now);
+
+  /*
+  ------*---120----------60---------now-----#---
+        |-----------------------------------|
+  */
+
+  auto res = i.getRange(now - 144s, now + 36s).value();
+  EXPECT_EQ(res.start.offset, 0);
+  EXPECT_EQ(res.start.time, now - 120s);
+  EXPECT_EQ(res.end.offset, 2);
+  EXPECT_EQ(res.end.time, now);
+
+  EXPECT_FALSE(i.getRange(
+                    now - 144s,
+                    now + 36s,
+                    MATCH_POLICY::NEXT_CLOSEST,
+                    MATCH_POLICY::NEXT_CLOSEST)
+                   .has_value());
+
+  EXPECT_FALSE(i.getRange(
+                    now - 144s,
+                    now + 36s,
+                    MATCH_POLICY::PREV_CLOSEST,
+                    MATCH_POLICY::PREV_CLOSEST)
+                   .has_value());
+
+  EXPECT_TRUE(i.getRange(
+                   now - 144s,
+                   now + 36s,
+                   MATCH_POLICY::NEXT_CLOSEST,
+                   MATCH_POLICY::PREV_CLOSEST)
+                  .has_value());
+
+  /*
+  ----------120--*-------60-------#-now---------
+                 |----------------|
+  */
+
+  res = i.getRange(now - 102s, now - 12s).value();
+  EXPECT_EQ(res.start.offset, 0);
+  EXPECT_EQ(res.end.offset, 2);
+
+  res = i.getRange(now - 102s, now - 12s, MATCH_POLICY::NEXT_CLOSEST).value();
+  EXPECT_EQ(res.start.offset, 1);
+  EXPECT_EQ(res.end.offset, 2);
+
+  res = i.getRange(
+             now - 102s,
+             now - 12s,
+             MATCH_POLICY::NEXT_CLOSEST,
+             MATCH_POLICY::PREV_CLOSEST)
+            .value();
+  EXPECT_EQ(res.start.offset, 1);
+  EXPECT_EQ(res.end.offset, 1);
+
+  /*
+  ----------120-----*----60-------#-now---------
+                    |-------------|
+  */
+
+  res = i.getRange(now - 89s, now - 12s).value();
+  EXPECT_EQ(res.start.offset, 1);
+  EXPECT_EQ(res.end.offset, 2);
+}

--- a/dynolog/tests/metric_frame/MetricSeriesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricSeriesTest.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "dynolog/src/metric_frame/MetricSeries.h"
+
+#include <optional>
+
+using namespace ::testing;
+using namespace ::facebook::dynolog;
+
+TEST(MetricSeriesTest, constructor) {
+  MetricSeries<int> t(5, "test_metric", "this is a test metric in unittest");
+  EXPECT_EQ(t.size(), 0);
+  EXPECT_EQ(t.begin(), t.end());
+  EXPECT_EQ(t.name(), "test_metric");
+  EXPECT_EQ(t.description(), "this is a test metric in unittest");
+}
+
+TEST(MetricSeriesTest, testAddSample) {
+  MetricSeries<int> t(3, "test_metric", "this is a test metric in unittest");
+  t.addSample(5);
+  EXPECT_EQ(t.size(), 1);
+  t.addSample(4);
+  EXPECT_EQ(t.size(), 2);
+  t.addSample(3);
+  EXPECT_EQ(t.size(), 3);
+  size_t count = 0;
+  for (const auto e : t) {
+    EXPECT_EQ(e, 5 - count);
+    count++;
+  }
+  t.addSample(2);
+  EXPECT_EQ(t.size(), 3);
+  count = 0;
+  for (const auto e : t) {
+    EXPECT_EQ(e, 4 - count);
+    count++;
+  }
+}
+
+TEST(MetricSeriesTest, testRate) {
+  MetricSeries<int> t(3, "test_metric", "this is a test metric in unittest");
+  t.addSample(0);
+  t.addSample(5);
+  t.addSample(12);
+  EXPECT_EQ(
+      t.rate<int>(
+          std::chrono::seconds(1), std::chrono::seconds(2), t.begin(), t.end()),
+      6);
+  EXPECT_EQ(t.rate<int>(std::chrono::seconds(1), std::chrono::seconds(2)), 6);
+  EXPECT_EQ(
+      t.rate<int>(std::chrono::seconds(1), std::chrono::seconds(2), t.begin()),
+      6);
+
+  EXPECT_EQ(
+      t.rate<int>(
+          std::chrono::minutes(1),
+          std::chrono::seconds(2),
+          t.begin(),
+          t.end() - 1),
+      150);
+
+  // get float result instead of int
+  EXPECT_NEAR(
+      t.rate<float>(
+          std::chrono::seconds(1),
+          std::chrono::seconds(2),
+          t.begin(),
+          t.end() - 1),
+      5.0 / 2.0,
+      1e-3);
+}
+
+TEST(MetricSeriesTest, testAvg) {
+  MetricSeries<int> t(3, "test_metric", "this is a test metric in unittest");
+  t.addSample(0);
+  t.addSample(12);
+  t.addSample(8);
+  EXPECT_EQ(t.avg<int>(t.begin(), t.end() - 1), 6);
+  EXPECT_EQ(t.avg<int>(t.begin(), t.end()), 6);
+  EXPECT_EQ(t.avg<int>(t.begin()), 6);
+  EXPECT_EQ(t.avg<int>(), 6);
+  // get float
+  EXPECT_NEAR(t.avg<float>(), 20.0 / 3, 1e-3);
+}
+
+TEST(MetricSeriesTest, testPercentile) {
+  MetricSeries<int> t(101, "test_metric", "this is a test metric in unittest");
+  std::vector<int> candidates(101);
+  for (int i = 0; i <= 100; i++) {
+    candidates[i] = i;
+  }
+  for (int i = 0; i <= 100; i++) {
+    auto idx = std::rand() % (101 - i);
+    t.addSample(candidates[idx]);
+    std::swap(candidates[100 - i], candidates[idx]);
+  }
+
+  EXPECT_EQ(t.percentile(0.57, t.begin(), t.end()), 57);
+  EXPECT_EQ(t.percentile(0.0, t.begin(), t.end()), 0);
+  EXPECT_EQ(t.percentile(1.0, t.begin(), t.end()), 100);
+  EXPECT_EQ(t.percentile(0.124, t.begin(), t.end()), 12);
+  EXPECT_EQ(t.percentile(0.125, t.begin(), t.end()), 13);
+}
+
+TEST(MetricSeriesTest, testDiff) {
+  MetricSeries<int> t(3, "test_metric", "this is a test metric in unittest");
+  t.addSample(0);
+  t.addSample(12);
+  t.addSample(8);
+
+  EXPECT_EQ(t.diff(), 8);
+  EXPECT_EQ(t.diff(t.begin(), t.end() - 1), 12);
+  EXPECT_EQ(t.diff(t.begin() + 1, t.end()), -4);
+}


### PR DESCRIPTION
Summary: MetricFrame is a common library handling metric samples storage and aggregation. This is not depend on Meta dedicated environment so we can move this into open source dynolog.

Differential Revision: D39251377

