### PR TITLE
Add scuba logger

### DIFF
--- a/dynolog/src/CompositeLogger.cpp
+++ b/dynolog/src/CompositeLogger.cpp
@@ -1,0 +1,47 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "dynolog/src/CompositeLogger.h"
+
+namespace dynolog {
+
+CompositeLogger::CompositeLogger(std::vector<std::unique_ptr<Logger>> loggers) {
+  loggers_ = std::move(loggers);
+}
+
+void CompositeLogger::setTimestamp(Timestamp ts) {
+  for (const auto& logger : loggers_) {
+    logger->setTimestamp(ts);
+  }
+}
+
+void CompositeLogger::logInt(const std::string& key, int64_t val) {
+  for (const auto& logger : loggers_) {
+    logger->logInt(key, val);
+  }
+}
+
+void CompositeLogger::logUint(const std::string& key, uint64_t val) {
+  for (const auto& logger : loggers_) {
+    logger->logUint(key, val);
+  }
+}
+
+void CompositeLogger::logFloat(const std::string& key, float val) {
+  for (const auto& logger : loggers_) {
+    logger->logFloat(key, val);
+  }
+}
+
+void CompositeLogger::logStr(const std::string& key, const std::string& val) {
+  for (const auto& logger : loggers_) {
+    logger->logStr(key, val);
+  }
+}
+
+void CompositeLogger::finalize() {
+  for (const auto& logger : loggers_) {
+    logger->finalize();
+  }
+}
+
+} // namespace dynolog

--- a/dynolog/src/CompositeLogger.h
+++ b/dynolog/src/CompositeLogger.h
@@ -1,0 +1,28 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+#include "dynolog/src/Logger.h"
+
+namespace dynolog {
+
+class CompositeLogger : public Logger {
+ public:
+  explicit CompositeLogger(std::vector<std::unique_ptr<Logger>> loggers);
+
+  void setTimestamp(Timestamp ts) override;
+
+  void logInt(const std::string& key, int64_t val) override;
+
+  void logUint(const std::string& key, uint64_t val) override;
+
+  void logFloat(const std::string& key, float val) override;
+
+  void logStr(const std::string& key, const std::string& val) override;
+
+  void finalize() override;
+
+ private:
+  std::vector<std::unique_ptr<Logger>> loggers_;
+};
+
+} // namespace dynolog

--- a/dynolog/src/KernelCollector.cpp
+++ b/dynolog/src/KernelCollector.cpp
@@ -25,7 +25,7 @@ void KernelCollector::step() {
 }
 
 void KernelCollector::log(Logger& log) {
-  log.log("uptime", uptime_);
+  log.logInt("uptime", uptime_);
 
   // Avoid logging first sample of metrics requiring delta computation
   if (first_) {
@@ -42,15 +42,15 @@ void KernelCollector::log(Logger& log) {
   log.logFloat("cpu_s", cpuDelta_.s / total_ticks * 100.0);
 
   // CPU utilization is 1 - idle/total
-  log.log("cpu_util", 100 * (1 - cpuDelta_.i / total_ticks));
+  log.logFloat("cpu_util", 100 * (1 - cpuDelta_.i / total_ticks));
 
-  log.log("cpu_u_ms", ticksToMs(cpuDelta_.u));
-  log.log("cpu_s_ms", ticksToMs(cpuDelta_.s));
-  log.log("cpu_w_ms", ticksToMs(cpuDelta_.w));
-  log.log("cpu_n_ms", ticksToMs(cpuDelta_.n));
-  log.log("cpu_x_ms", ticksToMs(cpuDelta_.x));
-  log.log("cpu_y_ms", ticksToMs(cpuDelta_.y));
-  log.log("cpu_z_ms", ticksToMs(cpuDelta_.z));
+  log.logInt("cpu_u_ms", ticksToMs(cpuDelta_.u));
+  log.logInt("cpu_s_ms", ticksToMs(cpuDelta_.s));
+  log.logInt("cpu_w_ms", ticksToMs(cpuDelta_.w));
+  log.logInt("cpu_n_ms", ticksToMs(cpuDelta_.n));
+  log.logInt("cpu_x_ms", ticksToMs(cpuDelta_.x));
+  log.logInt("cpu_y_ms", ticksToMs(cpuDelta_.y));
+  log.logInt("cpu_z_ms", ticksToMs(cpuDelta_.z));
 
   if (numCpuSockets_ > 1) {
     for (int i = 0; i < numCpuSockets_; i++) {
@@ -68,14 +68,14 @@ void KernelCollector::log(Logger& log) {
   }
 
   for (const auto& [devName, devRxtx] : rxtxDelta_) {
-    log.log(fmt::format("rx_bytes_{}", devName), devRxtx.rxBytes);
-    log.log(fmt::format("rx_packets_{}", devName), devRxtx.rxPackets);
-    log.log(fmt::format("rx_errors_{}", devName), devRxtx.rxErrors);
-    log.log(fmt::format("rx_drops_{}", devName), devRxtx.rxDrops);
-    log.log(fmt::format("tx_bytes_{}", devName), devRxtx.txBytes);
-    log.log(fmt::format("tx_packets_{}", devName), devRxtx.txPackets);
-    log.log(fmt::format("tx_errors_{}", devName), devRxtx.txErrors);
-    log.log(fmt::format("tx_drops_{}", devName), devRxtx.txDrops);
+    log.logUint(fmt::format("rx_bytes_{}", devName), devRxtx.rxBytes);
+    log.logUint(fmt::format("rx_packets_{}", devName), devRxtx.rxPackets);
+    log.logUint(fmt::format("rx_errors_{}", devName), devRxtx.rxErrors);
+    log.logUint(fmt::format("rx_drops_{}", devName), devRxtx.rxDrops);
+    log.logUint(fmt::format("tx_bytes_{}", devName), devRxtx.txBytes);
+    log.logUint(fmt::format("tx_packets_{}", devName), devRxtx.txPackets);
+    log.logUint(fmt::format("tx_errors_{}", devName), devRxtx.txErrors);
+    log.logUint(fmt::format("tx_drops_{}", devName), devRxtx.txDrops);
   }
 
   log.setTimestamp();

--- a/dynolog/src/Logger.cpp
+++ b/dynolog/src/Logger.cpp
@@ -12,6 +12,15 @@ using json = nlohmann::json;
 
 namespace dynolog {
 
+DEFINE_string(
+    access_token,
+    "",
+    "The ODS access token to publish through Graph API");
+DEFINE_string(
+    certificate_path,
+    "/etc/ssl/certs/ca-certificates.crt",
+    "The path for SSL certificate");
+
 std::string JsonLogger::timestampStr() const {
   std::time_t ts_time_t = std::chrono::system_clock::to_time_t(ts_);
   std::tm ts_tm = *std::localtime(&ts_time_t);
@@ -35,6 +44,10 @@ void JsonLogger::logFloat(const std::string& key, float val) {
 }
 
 void JsonLogger::logUint(const std::string& key, uint64_t val) {
+  json_[key] = val;
+}
+
+void JsonLogger::logStr(const std::string& key, const std::string& val) {
   json_[key] = val;
 }
 

--- a/dynolog/src/Logger.h
+++ b/dynolog/src/Logger.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <gflags/gflags.h>
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <map>
@@ -12,6 +13,9 @@
 #include <type_traits>
 
 namespace dynolog {
+
+DECLARE_string(access_token);
+DECLARE_string(certificate_path);
 
 // An abstract class for logging metrics
 //  1. Create a class with this interface for each log entry
@@ -34,20 +38,9 @@ class Logger {
   // Logs an unsigned integer value
   virtual void logUint(const std::string& key, uint64_t val) = 0;
 
-  virtual void finalize() = 0;
+  virtual void logStr(const std::string& key, const std::string& val) = 0;
 
-  template <typename T>
-  void log(const std::string& key, T val) {
-    if (std::is_same<T, int64_t>::value) {
-      logInt(key, val);
-    } else if (std::is_same<T, uint64_t>::value) {
-      logUint(key, val);
-    } else if (std::is_same<T, float>::value) {
-      logFloat(key, val);
-    } else {
-      static_assert("unsupported type in log()");
-    }
-  }
+  virtual void finalize() = 0;
 };
 
 class JsonLogger : public Logger {
@@ -61,6 +54,8 @@ class JsonLogger : public Logger {
   void logFloat(const std::string& key, float val) override;
 
   void logUint(const std::string& key, uint64_t val) override;
+
+  void logStr(const std::string& key, const std::string& val) override;
 
   void finalize() override;
 

--- a/dynolog/src/ODSJsonLogger.cpp
+++ b/dynolog/src/ODSJsonLogger.cpp
@@ -13,15 +13,7 @@
 #include <glog/logging.h>
 #include <unistd.h>
 
-DEFINE_string(
-    access_token,
-    "",
-    "The ODS access token to publish through Graph API");
 DEFINE_string(category_id, "", "The category id of the ODS endpoint");
-DEFINE_string(
-    certificate_path,
-    "/etc/ssl/certs/ca-certificates.crt",
-    "The path for SSL certificate");
 DEFINE_string(ods_entity_prefix, "", "The prefix for ODS entity name");
 
 namespace dynolog {

--- a/dynolog/src/PerfMonitor.cpp
+++ b/dynolog/src/PerfMonitor.cpp
@@ -58,15 +58,15 @@ void PerfMonitor::log(Logger& logger) {
         float countPerSec = static_cast<float>(
             static_cast<double>(count) * 1e3 / static_cast<double>(time));
         std::string key = "mips";
-        logger.log(key, countPerSec);
+        logger.logFloat(key, countPerSec);
       } else if (id == "cycles" && nickname == "cycles") {
         // * 10^9 (nanoseconds) / 10^6 (millions of instructions)
         float countPerSec = static_cast<float>(
             static_cast<double>(count) * 1e3 / static_cast<double>(time));
         std::string key = "mega_cycles_per_second";
-        logger.log(key, countPerSec);
+        logger.logFloat(key, countPerSec);
       } else {
-        logger.log(nickname, count);
+        logger.logUint(nickname, count);
       }
     }
   }

--- a/dynolog/src/ScubaLogger.cpp
+++ b/dynolog/src/ScubaLogger.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "dynolog/src/ScubaLogger.h"
+#include <string>
+#ifdef USE_GRAPH_ENDPOINT
+#include <cpr/cpr.h> // @manual
+#include <curl/curl.h> // @manual
+#endif
+#include <fmt/format.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <unistd.h>
+#include <chrono>
+
+namespace dynolog {
+constexpr int HOSTNAME_MAX = 50;
+constexpr char kScubaUrl[] = "https://graph.facebook.com/scribe_logs";
+DEFINE_string(
+    fair_scribe_category,
+    "perfpipe_fair_cluster_gpu_stats",
+    "The scribe category name for fair gpu stats, used for scuba logging");
+
+ScubaLogger::ScubaLogger(const std::string& scribe_category)
+    : scribe_category_(scribe_category) {
+  char hostname[HOSTNAME_MAX] = "";
+  gethostname(hostname, HOSTNAME_MAX);
+  hostname_ = std::string(hostname);
+}
+
+void ScubaLogger::logInt(const std::string& key, int64_t val) {
+  metrics_int_[key] = val;
+}
+
+void ScubaLogger::logUint(const std::string& key, uint64_t val) {
+  metrics_int_[key] = val;
+}
+
+void ScubaLogger::logFloat(const std::string& key, float val) {
+  metrics_double_[key] = val;
+}
+
+void ScubaLogger::logStr(const std::string& key, const std::string& val) {
+  metrics_str_[key] = val;
+}
+
+void ScubaLogger::clearMetrics() {
+  metrics_int_.clear();
+  metrics_str_.clear();
+  metrics_double_.clear();
+}
+
+void ScubaLogger::finalize() {
+  metrics_str_["host_name"] = hostname_;
+
+  // user of logger need to set time
+  metrics_int_["time"] =
+      std::chrono::duration_cast<std::chrono::seconds>(ts_.time_since_epoch())
+          .count();
+
+  nlohmann::json scuba_message = {
+      {"int", metrics_int_},
+      {"normal", metrics_str_},
+      {"double", metrics_double_},
+  };
+
+  nlohmann::json log = {
+      {"category", scribe_category_},
+      {"message", scuba_message.dump()},
+      {"line_escape", false},
+  };
+
+  nlohmann::json logs;
+  logs.push_back(log);
+
+#ifdef USE_GRAPH_ENDPOINT
+  cpr::SslOptions sslOpts =
+      cpr::Ssl(cpr::ssl::CaInfo{FLAGS_certificate_path.c_str()});
+
+  cpr::Response r = cpr::Post(
+      cpr::Url{kScubaUrl},
+      cpr::Payload{{"access_token", FLAGS_access_token}, {"logs", logs.dump()}},
+      sslOpts);
+
+  // flush the logger
+  if (r.status_code != 200) {
+    LOG(ERROR) << "Scuba publish request failed: " << r.text;
+  }
+#else
+  LOG_FIRST_N(WARNING, 1) << "Scuba logger was not included in the build";
+#endif
+
+  LOG(INFO) << logs.dump();
+  clearMetrics();
+}
+
+} // namespace dynolog

--- a/dynolog/src/ScubaLogger.h
+++ b/dynolog/src/ScubaLogger.h
@@ -9,9 +9,11 @@
 
 namespace dynolog {
 
-class ODSJsonLogger : public JsonLogger {
+DECLARE_string(fair_scribe_category);
+
+class ScubaLogger final : public Logger {
  public:
-  ODSJsonLogger();
+  explicit ScubaLogger(const std::string& scribe_category);
   void setTimestamp(Timestamp ts) override {
     ts_ = ts;
   }
@@ -20,14 +22,21 @@ class ODSJsonLogger : public JsonLogger {
 
   void logFloat(const std::string& key, float val) override;
 
-  void logStr(const std::string& /* key */, const std::string& /* val */)
-      override {}
+  void logUint(const std::string& key, uint64_t val) override;
+
+  void logStr(const std::string& key, const std::string& val) override;
 
   void finalize() override;
 
  private:
+  void clearMetrics();
+
+  Timestamp ts_;
+  std::string scribe_category_;
   std::string hostname_;
-  nlohmann::json metrics_json_;
+  nlohmann::json metrics_int_;
+  nlohmann::json metrics_double_;
+  nlohmann::json metrics_str_;
 };
 
 } // namespace dynolog

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -19,6 +19,11 @@
 namespace dynolog {
 namespace gpumon {
 
+DEFINE_string(
+    dcgm_fields,
+    kDcgmDefaultFieldIds,
+    "The field ids to monitor on DCGM (GPUs), comma separated");
+
 constexpr double maxKeepAgeSec = 2;
 constexpr int maxKeepSamples = 2;
 const std::string groupName = "DcgmGroupInfo";
@@ -346,6 +351,8 @@ void DcgmGroupInfo::update() {
 }
 
 void DcgmGroupInfo::log(Logger& logger) {
+  const auto t = std::chrono::system_clock::now();
+  logger.setTimestamp(t);
   for (const auto& [index, metric_map] : metricsMapDouble_) {
     for (const auto& [key, val] : metric_map) {
       logger.logFloat(key, val);

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -16,6 +16,8 @@
 namespace dynolog {
 namespace gpumon {
 
+DECLARE_string(dcgm_fields);
+
 constexpr char kDcgmDefaultFieldIds[] =
     "100,155,204,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012";
 


### PR DESCRIPTION
Summary: Adding scuba logger that supports logging to scribe category perfpipe_fair_cluster_gpu_stats. This will be used for FAIR cluster scuba table logging

Differential Revision:
D40814142

LaMa Project: L1137347

