### PR TITLE
Add gpu trace option to profile by iteration count

### DIFF
--- a/cli/src/commands/gputrace.rs
+++ b/cli/src/commands/gputrace.rs
@@ -19,14 +19,27 @@ pub fn run_gputrace(
     job_id: u64,
     pids: &str,
     duration_ms: u64,
+    iterations: i64,
     log_file: &str,
     profile_start_time: u64,
+    profile_start_iteration_roundup: u64,
     process_limit: u32,
 ) -> Result<()> {
+    let trigger_config = if iterations > 0 {
+        format!(
+            r#"PROFILE_START_ITERATION_ROUNDUP={}\nACTIVITIES_ITERATIONS={}"#,
+            profile_start_iteration_roundup, iterations
+        )
+    } else {
+        format!(r#"ACTIVITIES_DURATION_MSECS={}"#, duration_ms)
+    };
+
     let kineto_config = format!(
-        r#"PROFILE_START_TIME={}\n ACTIVITIES_DURATION_MSECS={}\nACTIVITIES_LOG_FILE={}"#,
-        profile_start_time, duration_ms, log_file
+        r#"PROFILE_START_TIME={}\nACTIVITIES_LOG_FILE={}\n{}"#,
+        profile_start_time, log_file, trigger_config
     );
+
+    println!("Kineto config = \n{}", kineto_config);
 
     let request_json = format!(
         r#"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,12 +55,19 @@ enum Command {
         /// Duration of trace to collect in ms.
         #[clap(long, default_value_t = 500)]
         duration_ms: u64,
+        /// Training iterations to collect, this takes precedence over duration.
+        #[clap(long, default_value_t = -1)]
+        iterations: i64,
         /// Log file for trace.
         #[clap(long)]
         log_file: String,
         /// Unix timestamp used for synchronized collection (milliseconds since epoch)
         #[clap(long, default_value_t = 0)]
         profile_start_time: u64,
+        /// Start iteration roundup, starts an iteration based trace at a multiple
+        /// of this value.
+        #[clap(long, default_value_t = 1)]
+        profile_start_iteration_roundup: u64,
         /// Max number of processes to profile
         #[clap(long, default_value_t = 3)]
         process_limit: u32,
@@ -94,15 +101,19 @@ fn main() -> Result<()> {
             pids,
             log_file,
             duration_ms,
+            iterations,
             profile_start_time,
+            profile_start_iteration_roundup,
             process_limit,
         } => gputrace::run_gputrace(
             dyno_client,
             job_id,
             &pids,
             duration_ms,
+            iterations,
             &log_file,
             profile_start_time,
+            profile_start_iteration_roundup,
             process_limit,
         ),
         // ... add new commands here


### PR DESCRIPTION
Summary:
Enables GPU trace using iteration option.
Pytorch app needs to call profiler.step() right now for this to work.

Showing new options
```
dyno-gputrace
Capture gputrace

USAGE:
    dyno gputrace [OPTIONS] --log-file <LOG_FILE>

OPTIONS:
        --iterations <ITERATIONS>                                              Training iterations to collect, this takes precedence over duration [default: -1]
        --profile-start-iteration-roundup <PROFILE_START_ITERATION_ROUNDUP>    Start iteration roundup, starts an iteration based trace at a multiple of this value [default: 1]
```

Reviewed By: anupambhatnagar

Differential Revision: D41662294

