### PR TITLE
Update dyno DCGM to DCGM 3.0

### DIFF
--- a/dynolog/src/gpumon/DcgmApiStub.cpp
+++ b/dynolog/src/gpumon/DcgmApiStub.cpp
@@ -5,7 +5,6 @@
 
 #include "dynolog/src/gpumon/DcgmApiStub.h"
 #include <dlfcn.h>
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <mutex>
 #include <ostream>
@@ -17,6 +16,11 @@ DEFINE_string(
     dcgm_lib_path,
     kDcgmDefaultLibPath,
     "The path to dynamic loading DCGM shared libraries");
+
+DEFINE_int32(
+    dcgm_major_version,
+    2,
+    "Version of Nvidia DCGM library. Currently supports 2 and 3");
 
 #define CHECK_NULL(val) CHECK_EQ((val), static_cast<void*>(NULL))
 

--- a/dynolog/src/gpumon/DcgmApiStub.h
+++ b/dynolog/src/gpumon/DcgmApiStub.h
@@ -5,8 +5,11 @@
 
 #pragma once
 
+#include <gflags/gflags.h>
 #include "dynolog/src/gpumon/dcgm_fields.h"
 #include "dynolog/src/gpumon/dcgm_structs.h"
+
+DECLARE_int32(dcgm_major_version);
 
 extern "C" {
 /**

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -37,7 +37,7 @@ class DcgmGroupInfo {
 
  private:
   DcgmGroupInfo(
-      const std::vector<unsigned short>& fields,
+      std::vector<unsigned short> fields,
       const std::vector<unsigned short>& prof_fields,
       int updateIntervalMs);
   void init();
@@ -45,7 +45,6 @@ class DcgmGroupInfo {
   void createFieldGroups(const std::vector<unsigned short>& fields);
   void watchFields();
   void watchProfFields(const std::vector<unsigned short>& prof_fields);
-  void printSupportedProfMetricGroups();
 
   std::vector<unsigned int> gpuIdList_;
   int deviceCount_ = 0;

--- a/dynolog/src/gpumon/dcgm_agent.h
+++ b/dynolog/src/gpumon/dcgm_agent.h
@@ -140,7 +140,7 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmStopEmbedded(dcgmHandle_t pDcgmHandle);
  *         - \ref DCGM_ST_INIT_ERROR           if DCGM encountered an error while initializing the remote client library
  *         - \ref DCGM_ST_UNINITIALIZED        if DCGM has not been initialized with \ref dcgmInit
  */
-dcgmReturn_t DCGM_PUBLIC_API dcgmConnect(char *ipAddress, dcgmHandle_t *pDcgmHandle);
+dcgmReturn_t DCGM_PUBLIC_API dcgmConnect(const char *ipAddress, dcgmHandle_t *pDcgmHandle);
 
 /**
  * This method is used to connect to a stand-alone host engine process. Remote host engines are started
@@ -405,7 +405,7 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmGetGpuInstanceHierarchy(dcgmHandle_t dcgmHandle
  *        - \ref DCGM_ST_NOT_SUPPORTED     if the given entityGroup does not support enumeration.
  *        - \ref DCGM_ST_BADPARAM          if any parameter is invalid
  */
-dcgmReturn_t DCGM_PUBLIC_API dcgmGetNvLinkLinkStatus(dcgmHandle_t dcgmHandle, dcgmNvLinkStatus_v2 *linkStatus);
+dcgmReturn_t DCGM_PUBLIC_API dcgmGetNvLinkLinkStatus(dcgmHandle_t dcgmHandle, dcgmNvLinkStatus_v3 *linkStatus);
 
 /** @} */
 
@@ -444,7 +444,7 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmGetNvLinkLinkStatus(dcgmHandle_t dcgmHandle, dc
  */
 dcgmReturn_t DCGM_PUBLIC_API dcgmGroupCreate(dcgmHandle_t pDcgmHandle,
                                              dcgmGroupType_t type,
-                                             char *groupName,
+                                             const char *groupName,
                                              dcgmGpuGrp_t *pDcgmGrpId);
 
 /**
@@ -597,7 +597,7 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmGroupGetAllIds(dcgmHandle_t pDcgmHandle,
 dcgmReturn_t DCGM_PUBLIC_API dcgmFieldGroupCreate(dcgmHandle_t dcgmHandle,
                                                   int numFieldIds,
                                                   unsigned short *fieldIds,
-                                                  char *fieldGroupName,
+                                                  const char *fieldGroupName,
                                                   dcgmFieldGrp_t *dcgmFieldGroupId);
 
 /**
@@ -1731,45 +1731,6 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmGetGroupTopology(dcgmHandle_t pDcgmHandle,
  */
 /***************************************************************************************************/
 
-/**
- * Toggle the state of introspection metadata gathering in DCGM.  Metadata gathering will increase the memory usage
- * of DCGM so that it can store the metadata it gathers.
- *
- * @param pDcgmHandle                   IN: DCGM Handle
- * @param enabledState                  IN: The state to set gathering of introspection data to
- *
- * @return
- *        - \ref DCGM_ST_OK                   if the call was successful
- *        - \ref DCGM_ST_BADPARAM             enabledState is an invalid state for metadata gathering
- *
- */
-dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectToggleState(dcgmHandle_t pDcgmHandle, dcgmIntrospectState_t enabledState);
-
-/*************************************************************************/
-/**
- * Get the current amount of memory used to store the given field collection.
- *
- * @param pDcgmHandle                   IN: DCGM Handle
- * @param context                       IN: see \ref dcgmIntrospectContext_t.  This identifies the level of fields to do
- *                                          introspection for (ex: all fields, field groups) context->version must be
- *                                          set to dcgmIntrospectContext_version prior to this call.
- * @param memoryInfo                IN/OUT: see \ref dcgmIntrospectFullMemory_t. memoryInfo->version must be set to
- *                                          dcgmIntrospectFullMemory_version prior to this call.
- * @param waitIfNoData                  IN: if no metadata has been gathered, should this call block until data has been
- *                                          gathered (1), or should this call just return DCGM_ST_NO_DATA (0).
- * @return
- *        - \ref DCGM_ST_OK                   if the call was successful
- *        - \ref DCGM_ST_NOT_CONFIGURED       if metadata gathering state is \a DCGM_INTROSPECT_STATE_DISABLED
- *        - \ref DCGM_ST_NO_DATA              if \a waitIfNoData is false and metadata has not been gathered yet
- *        - \ref DCGM_ST_VER_MISMATCH         if context->version or memoryInfo->version is 0 or invalid.
- *
- */
-dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectGetFieldsMemoryUsage(dcgmHandle_t pDcgmHandle,
-                                                                dcgmIntrospectContext_t *context,
-                                                                dcgmIntrospectFullMemory_t *memoryInfo,
-                                                                int waitIfNoData);
-
-
 /*************************************************************************/
 /**
  * Retrieve the total amount of memory that the hostengine process is currently using.
@@ -1794,31 +1755,6 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectGetHostengineMemoryUsage(dcgmHandle_t
 
 /*************************************************************************/
 /**
- * Get introspection info relating to execution time needed to update the fields
- * identified by \a context.
- *
- * @param pDcgmHandle        IN: DCGM Handle
- * @param context            IN: see \ref dcgmIntrospectContext_t.  This identifies the level of fields to do
- *                               introspection for (ex: all fields, field group ) context->version must be set to
- *                               dcgmIntrospectContext_version prior to this call.
- * @param execTime       IN/OUT: see \ref dcgmIntrospectFullFieldsExecTime_t. execTime->version must be set to
- *                               dcgmIntrospectFullFieldsExecTime_version prior to this call.
- * @param waitIfNoData       IN: if no metadata is gathered, wait until data has been gathered (1) or return
- *                               DCGM_ST_NO_DATA (0)
- * @return
- *        - \ref DCGM_ST_OK                   if the call was successful
- *        - \ref DCGM_ST_NOT_CONFIGURED       if metadata gathering state is \a DCGM_INTROSPECT_STATE_DISABLED
- *        - \ref DCGM_ST_NO_DATA              if \a waitIfNoData is false and metadata has not been gathered yet
- *        - \ref DCGM_ST_VER_MISMATCH         if context->version or execTime->version is 0 or invalid.
- *
- */
-dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectGetFieldsExecTime(dcgmHandle_t pDcgmHandle,
-                                                             dcgmIntrospectContext_t *context,
-                                                             dcgmIntrospectFullFieldsExecTime_t *execTime,
-                                                             int waitIfNoData);
-
-/*************************************************************************/
-/**
  * Retrieve the CPU utilization of the DCGM hostengine process.
  *
  * @param pDcgmHandle        IN: DCGM Handle
@@ -1836,22 +1772,6 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectGetFieldsExecTime(dcgmHandle_t pDcgmH
 dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectGetHostengineCpuUtilization(dcgmHandle_t pDcgmHandle,
                                                                        dcgmIntrospectCpuUtil_t *cpuUtil,
                                                                        int waitIfNoData);
-
-/*************************************************************************/
-/**
- * This method is used to manually tell the the introspection module to update
- * all DCGM introspection data. This is normally performed automatically on an
- * interval of 1 second.
- *
- * @param pDcgmHandle        IN: DCGM Handle
- * @param waitForUpdate      IN: Whether or not to wait for the update loop to complete before returning to the caller
- *
- * @return
- *        - \ref DCGM_ST_OK                   if the call was successful
- *        - \ref DCGM_ST_BADPARAM             if \a waitForUpdate is invalid
- *
- */
-dcgmReturn_t DCGM_PUBLIC_API dcgmIntrospectUpdateAll(dcgmHandle_t pDcgmHandle, int waitForUpdate);
 
 /** @} */ // Closing for DCGMAPI_METADATA
 
@@ -1900,23 +1820,23 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmSelectGpusByTopology(dcgmHandle_t pDcgmHandle,
 
 /*************************************************************************/
 /**
- * Set a module to be blacklisted. This module will be prevented from being loaded
+ * Add a module to the denylist. This module will be prevented from being loaded
  * if it hasn't been loaded already. Modules are lazy-loaded as they are used by
  * DCGM APIs, so it's important to call this API soon after the host engine has been started.
- * You can also pass --blacklist-modules to the nv-hostengine binary to make sure modules
- * get blacklisted immediately after the host engine starts up.
+ * You can also pass --denylist-modules to the nv-hostengine binary to make sure modules
+ * get add to the denylist immediately after the host engine starts up.
  *
  * @param pDcgmHandle        IN: DCGM Handle
- * @param moduleId           IN: ID of the module to blacklist. Use \ref dcgmModuleGetStatuses to get a list of valid
+ * @param moduleId           IN: ID of the module to denylist. Use \ref dcgmModuleGetStatuses to get a list of valid
  *                               module IDs.
  *
  * @return
- *        - \ref DCGM_ST_OK         if the module has been blacklisted.
- *        - \ref DCGM_ST_IN_USE     if the module has already been loaded and cannot be blacklisted.
+ *        - \ref DCGM_ST_OK         if the module has been add to the denylist.
+ *        - \ref DCGM_ST_IN_USE     if the module has already been loaded and cannot add to the denylist.
  *        - \ref DCGM_ST_BADPARAM   if a parameter is missing or bad.
  *
  */
-dcgmReturn_t DCGM_PUBLIC_API dcgmModuleBlacklist(dcgmHandle_t pDcgmHandle, dcgmModuleId_t moduleId);
+dcgmReturn_t DCGM_PUBLIC_API dcgmModuleDenylist(dcgmHandle_t pDcgmHandle, dcgmModuleId_t moduleId);
 
 /*************************************************************************/
 /**
@@ -2069,7 +1989,7 @@ dcgmReturn_t DCGM_PUBLIC_API dcgmProfResume(dcgmHandle_t pDcgmHandle);
  *        - \ref DCGM_ST_OK
  *
  */
-dcgmReturn_t DCGM_PUBLIC_API dcgmAddFakeInstances(dcgmHandle_t pDcgmHandle, dcgmMigHierarchy_v1 *hierarchy);
+dcgmReturn_t DCGM_PUBLIC_API dcgmAddFakeInstances(dcgmHandle_t pDcgmHandle, dcgmMigHierarchy_v2 *hierarchy);
 
 #ifdef __cplusplus
 }

--- a/dynolog/src/gpumon/dcgm_errors.h
+++ b/dynolog/src/gpumon/dcgm_errors.h
@@ -50,7 +50,7 @@ typedef enum dcgmError_enum
     DCGM_FR_DEVICE_COUNT_MISMATCH        = 20, //!< Disagreement in GPU count between /dev and NVML
     DCGM_FR_BAD_PARAMETER                = 21, //!< Bad parameter passed to API
     DCGM_FR_CANNOT_OPEN_LIB              = 22, //!< Cannot open a library that must be accessed
-    DCGM_FR_BLACKLISTED_DRIVER           = 23, //!< A blacklisted driver (nouveau) is active
+    DCGM_FR_DENYLISTED_DRIVER            = 23, //!< A driver on the denylist (nouveau) is active
     DCGM_FR_NVML_LIB_BAD                 = 24, //!< The NVML library is missing expected functions
     DCGM_FR_GRAPHICS_PROCESSES           = 25, //!< Graphics processes are active on this GPU
     DCGM_FR_HOSTENGINE_CONN              = 26, //!< Unstable connection to nv-hostengine (daemonized DCGM)
@@ -197,8 +197,8 @@ extern dcgm_error_meta_t dcgmErrorMeta[];
 #define DCGM_FR_BAD_PARAMETER_MSG "Bad parameter to function %s cannot be processed"
 // library name, error returned from dlopen
 #define DCGM_FR_CANNOT_OPEN_LIB_MSG "Cannot open library %s: '%s'"
-// the name of the blacklisted driver
-#define DCGM_FR_BLACKLISTED_DRIVER_MSG "Found blacklisted driver: %s"
+// the name of the denylisted driver
+#define DCGM_FR_DENYLISTED_DRIVER_MSG "Found driver on the denylist: %s"
 // the name of the function that wasn't found
 #define DCGM_FR_NVML_LIB_BAD_MSG "Cannot get pointer to %s from libnvidia-ml.so"
 #define DCGM_FR_GRAPHICS_PROCESSES_MSG                                                 \
@@ -385,7 +385,7 @@ extern dcgm_error_meta_t dcgmErrorMeta[];
 #define DCGM_FR_CANNOT_OPEN_LIB_NEXT                                  \
     "Check for the existence of the library and set LD_LIBRARY_PATH " \
     "if needed."
-#define DCGM_FR_BLACKLISTED_DRIVER_NEXT "Please load the appropriate driver."
+#define DCGM_FR_DENYLISTED_DRIVER_NEXT "Please load the appropriate driver."
 #define DCGM_FR_NVML_LIB_BAD_NEXT                             \
     "Make sure that the required version of libnvidia-ml.so " \
     "is present and accessible on the system."

--- a/dynolog/src/gpumon/dcgm_fields.h
+++ b/dynolog/src/gpumon/dcgm_fields.h
@@ -188,6 +188,7 @@ typedef enum dcgm_field_entity_group_t
     DCGM_FE_SWITCH,   /*!< Field is associated with a Switch entity */
     DCGM_FE_GPU_I,    /*!< Field is associated with a GPU Instance entity */
     DCGM_FE_GPU_CI,   /*!< Field is associated with a GPU Compute Instance entity */
+    DCGM_FE_LINK,     /*!< Field is associated with an NVLink */
 
     DCGM_FE_COUNT /*!< Number of elements in this enumeration. Keep this entry last */
 } dcgm_field_entity_group_t;
@@ -196,6 +197,7 @@ typedef enum dcgm_field_entity_group_t
  * Represents an identifier for an entity within a field entity. For instance, this is the gpuId for DCGM_FE_GPU.
  */
 typedef unsigned int dcgm_field_eid_t;
+
 
 /** @} */
 
@@ -363,6 +365,21 @@ typedef unsigned int dcgm_field_eid_t;
  * 1 = enabled
  */
 #define DCGM_FI_DEV_CC_MODE 74
+
+/**
+ * Attributes for the given MIG device handles
+ */
+#define DCGM_FI_DEV_MIG_ATTRIBUTES 75
+
+/**
+ * GPU instance profile information
+ */
+#define DCGM_FI_DEV_MIG_GI_INFO 76
+
+/**
+ * Compute instance profile information
+ */
+#define DCGM_FI_DEV_MIG_CI_INFO 77
 
 /**
  * ECC inforom version
@@ -593,25 +610,7 @@ typedef unsigned int dcgm_field_eid_t;
  */
 #define DCGM_FI_DEV_DEC_UTIL 207
 
-/**
- * Memory utilization samples
- */
-#define DCGM_FI_DEV_MEM_COPY_UTIL_SAMPLES 210
-
-/*
- * SM utilization samples
- */
-#define DCGM_FI_DEV_GPU_UTIL_SAMPLES 211
-
-/**
- * Graphics processes running on the GPU.
- */
-#define DCGM_FI_DEV_GRAPHICS_PIDS 220
-
-/**
- * Compute processes running on the GPU.
- */
-#define DCGM_FI_DEV_COMPUTE_PIDS 221
+/* Fields 210, 211, 220 and 221 are internal-only. See dcgm_fields_internal.hpp */
 
 /**
  * XID errors. The value is the specific XID error
@@ -699,7 +698,7 @@ typedef unsigned int dcgm_field_eid_t;
 #define DCGM_FI_DEV_FB_RESERVED 253
 
 /**
- * Percentage used (Used+Reserved/Total) of Frame Buffer. Range 0.0-1.0
+ * Percentage used of Frame Buffer: 'Used/(Total - Reserved)'. Range 0.0-1.0
  */
 #define DCGM_FI_DEV_FB_USED_PERCENT 254
 
@@ -1212,6 +1211,40 @@ typedef unsigned int dcgm_field_eid_t;
  */
 #define DCGM_FI_DEV_NVLINK_BANDWIDTH_L11 480
 
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L12 406
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L13 407
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L14 408
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L15 481
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L16 482
+#define DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L17 483
+
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L12 416
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L13 417
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L14 418
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L15 484
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L16 485
+#define DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L17 486
+
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L12 426
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L13 427
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L14 428
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L15 487
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L16 488
+#define DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L17 489
+
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L12 436
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L13 437
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L14 438
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L15 491
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L16 492
+#define DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L17 493
+
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L12 446
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L13 447
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L14 448
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L15 494
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L16 495
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_L17 496
 
 /**
  * Virtualization Mode corresponding to the GPU.
@@ -1259,6 +1292,32 @@ typedef unsigned int dcgm_field_eid_t;
  * Information about active frame buffer capture sessions on a target device
  */
 #define DCGM_FI_DEV_FBC_SESSIONS_INFO 508
+
+/**
+ * Includes Count and currently Supported vGPU types on a device
+ */
+#define DCGM_FI_DEV_SUPPORTED_VGPU_TYPE_IDS 509
+
+/**
+ * Includes Static info of vGPU types supported on a device
+ */
+#define DCGM_FI_DEV_VGPU_TYPE_INFO 510
+
+/**
+ * Includes the name of a vGPU type supported on a device
+ */
+#define DCGM_FI_DEV_VGPU_TYPE_NAME 511
+
+/**
+ * Includes the class of a vGPU type supported on a device
+ */
+#define DCGM_FI_DEV_VGPU_TYPE_CLASS 512
+
+/**
+ * Includes the license info for a vGPU type supported on a device
+ */
+#define DCGM_FI_DEV_VGPU_TYPE_LICENSE 513
+
 /**
  * VM ID of the vGPU instance
  */
@@ -1322,12 +1381,17 @@ typedef unsigned int dcgm_field_eid_t;
 /**
  * License state information of the vGPU instance
  */
-#define DCGM_FI_DEV_VGPU_LICENSE_INSTANCE_STATE 532
+#define DCGM_FI_DEV_VGPU_INSTANCE_LICENSE_STATE 532
 
 /**
  * PCI Id of the vGPU instance
  */
 #define DCGM_FI_DEV_VGPU_PCI_ID 533
+
+/**
+ * GPU Instance ID for the given vGPU Instance
+ */
+#define DCGM_FI_DEV_VGPU_VM_GPU_INSTANCE_ID 534
 
 /**
  * Starting field ID of the vGPU instance
@@ -1729,337 +1793,189 @@ typedef unsigned int dcgm_field_eid_t;
 #define DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P17 771
 
 /**
- * <p>NVSwitch Tx Bandwidth Counter 0 for port 0</p>
+ * <p>NVSwitch Tx Throughput Counter for ports 0-17</p>
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P00 780
+#define DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_TX 780
 /**
- * NVSwitch Rx Bandwidth Counter 0 for port 0
+ * NVSwitch Rx Throughput Counter for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P00 781
+#define DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_RX 781
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 1
+ * NvSwitch fatal_errors for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P01 782
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 1
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P01 783
+#define DCGM_FI_DEV_NVSWITCH_LINK_FATAL_ERRORS 782
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 2
+ * NvSwitch non_fatal_errors for ports 0-17
+ *
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P02 784
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 2
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P02 785
+#define DCGM_FI_DEV_NVSWITCH_LINK_NON_FATAL_ERRORS 783
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 3
+ * NvSwitch replay_count_errors for ports  0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P03 786
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 3
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P03 787
+#define DCGM_FI_DEV_NVSWITCH_LINK_REPLAY_ERRORS 784
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 4
+ * NvSwitch recovery_count_errors for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P04 788
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 4
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P04 789
+#define DCGM_FI_DEV_NVSWITCH_LINK_RECOVERY_ERRORS 785
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 5
+ * NvSwitch filt_err_count_errors for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P05 790
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 5
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P05 791
+#define DCGM_FI_DEV_NVSWITCH_LINK_FLIT_ERRORS 786
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 6
+ * NvLink lane_crs_err_count_aggregate_errors for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P06 792
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 6
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P06 793
+#define DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS 787
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 7
+ * NvLink lane ecc_err_count_aggregate_errors for ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P07 794
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 7
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P07 795
+#define DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS 788
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 8
+ * Nvlink lane latency low lane0 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P08 796
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 8
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P08 797
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC0 789
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 9
+ * Nvlink lane latency low lane1 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P09 798
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 9
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P09 799
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC1 790
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 10
+ * Nvlink lane latency low lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P10 800
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 10
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P10 801
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC2 791
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 11
+ * Nvlink lane latency low lane3 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P11 802
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 11
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P11 803
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC3 792
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 12
+ * Nvlink lane latency medium lane0 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P12 804
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 12
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P12 805
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC0 793
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 13
+ * Nvlink lane latency medium lane1 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P13 806
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 13
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P13 807
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC1 794
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 14
+ * Nvlink lane latency medium lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P14 808
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 14
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P14 809
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC2 795
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 15
+ * Nvlink lane latency medium lane3 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P15 810
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 15
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P15 811
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC3 796
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 16
+ * Nvlink lane latency high lane0 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P16 812
-/**
- * NVSwitch Rx Bandwidth Counter 0 for port 16
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P16 813
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC0 797
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 17
+ * Nvlink lane latency high lane1 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P17 814
-/**
- * <p>NVSwitch Rx Bandwidth Counter 0 for port 17</p>
- * <p>&nbsp;</p>
- * <p>&nbsp;</p>
- * <p>&nbsp;</p>
- * <p>NVSwitch Tx and RX Bandwidth Counter 1 for each port</p>
- * <p>By default, Counter 1 counts packets.</p>
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P17 815
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC1 798
 
 /**
- * <p>NVSwitch Tx Bandwidth Counter 1 for port 0</p>
+ * Nvlink lane latency high lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P00 820
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 0
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P00 821
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC2 799
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 1
+ * Nvlink lane latency high lane3 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P01 822
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 1
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P01 823
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC3 800
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 2
+ * Nvlink lane latency panic lane0 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P02 824
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 2
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P02 825
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC0 801
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 3
+ * Nvlink lane latency panic lane1 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P03 826
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 3
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P03 827
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC1 802
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 4
+ * Nvlink lane latency panic lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P04 828
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 4
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P04 829
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC2 803
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 5
+ * Nvlink lane latency panic lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P05 830
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 5
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P05 831
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC3 804
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 6
+ * Nvlink lane latency count lane0 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P06 832
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 6
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P06 833
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC0 805
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 7
+ * Nvlink lane latency count lane1 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P07 834
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 7
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P07 835
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC1 806
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 8
+ * Nvlink lane latency count lane2 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P08 836
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 8
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P08 837
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC2 807
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 9
+ * Nvlink lane latency count lane3 counter.
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P09 838
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 9
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P09 839
+#define DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC3 808
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 10
+ * NvLink lane crc_err_count for lane 0 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P10 840
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 10
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P10 841
+#define DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE0 809
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 11
+ * NvLink lane crc_err_count for lane 1 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P11 842
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 11
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P11 843
+#define DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE1 810
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 12
+ * NvLink lane crc_err_count for lane 2 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P12 844
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 12
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P12 845
+#define DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE2 811
 
 /**
- * NVSwitch Tx Bandwidth Counter 0 for port 13
+ * NvLink lane crc_err_count for lane 3 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P13 846
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 13
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P13 847
+#define DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE3 812
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 14
+ * NvLink lane ecc_err_count for lane 0 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P14 848
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 14
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P14 849
+#define DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE0 813
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 15
+ * NvLink lane ecc_err_count for lane 1 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P15 850
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 15
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P15 851
+#define DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE1 814
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 16
+ * NvLink lane ecc_err_count for lane 2 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P16 852
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 16
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P16 853
+#define DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE2 815
 
 /**
- * NVSwitch Tx Bandwidth Counter 1 for port 17
+ * NvLink lane ecc_err_count for lane 3 on ports 0-17
  */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P17 854
-/**
- * NVSwitch Rx Bandwidth Counter 1 for port 17
- * <p>&nbsp;</p>
- * <p>&nbsp;</p>
- * <p>&nbsp;</p>
- * NVSwitch error counters
- */
-#define DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P17 855
+#define DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE3 816
 
 /**
  * NVSwitch fatal error information.
@@ -2074,6 +1990,31 @@ typedef unsigned int dcgm_field_eid_t;
 #define DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS 857
 
 /**
+ * NVSwitch current temperature.
+ */
+#define DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT 858
+
+/**
+ * NVSwitch limit slowdown temperature.
+ */
+#define DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SLOWDOWN 859
+
+/**
+ * NVSwitch limit shutdown temperature.
+ */
+#define DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SHUTDOWN 860
+
+/**
+ * NVSwitch throughput Tx.
+ */
+#define DCGM_FI_DEV_NVSWITCH_THROUGHPUT_TX 861
+
+/**
+ * NVSwitch throughput Rx.
+ */
+#define DCGM_FI_DEV_NVSWITCH_THROUGHPUT_RX 862
+
+/**
  * Starting field ID of the NVSwitch instance
  */
 #define DCGM_FI_FIRST_NVSWITCH_FIELD_ID 700
@@ -2081,7 +2022,7 @@ typedef unsigned int dcgm_field_eid_t;
 /**
  * Last field ID of the NVSwitch instance
  */
-#define DCGM_FI_LAST_NVSWITCH_FIELD_ID 860
+#define DCGM_FI_LAST_NVSWITCH_FIELD_ID 899
 
 /**
  * For now max NVSwitch field Ids taken as difference of DCGM_FI_LAST_NVSWITCH_FIELD_ID and
@@ -2157,12 +2098,14 @@ typedef unsigned int dcgm_field_eid_t;
 #define DCGM_FI_PROF_PCIE_RX_BYTES 1010
 
 /**
- * The number of bytes of active NvLink tx (transmit) data including both header and payload.
+ * The total number of bytes of active NvLink tx (transmit) data including both header and payload.
+ * Per-link fields are available below
  */
 #define DCGM_FI_PROF_NVLINK_TX_BYTES 1011
 
 /**
- * The number of bytes of active NvLink rx (read) data including both header and payload.
+ * The total number of bytes of active NvLink rx (read) data including both header and payload.
+ * Per-link fields are available below
  */
 #define DCGM_FI_PROF_NVLINK_RX_BYTES 1012
 
@@ -2177,9 +2120,101 @@ typedef unsigned int dcgm_field_eid_t;
 #define DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE 1014
 
 /**
+ * The ratio of cycles the tensor (DFMA) pipe is active (off the peak sustained elapsed cycles)
+ */
+#define DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE 1015
+
+/**
+ * Ratio of cycles the integer pipe is active.
+ */
+#define DCGM_FI_PROF_PIPE_INT_ACTIVE 1016
+
+/**
+ * Ratio of cycles each of the NVDEC engines are active.
+ */
+#define DCGM_FI_PROF_NVDEC0_ACTIVE 1017
+#define DCGM_FI_PROF_NVDEC1_ACTIVE 1018
+#define DCGM_FI_PROF_NVDEC2_ACTIVE 1019
+#define DCGM_FI_PROF_NVDEC3_ACTIVE 1020
+#define DCGM_FI_PROF_NVDEC4_ACTIVE 1021
+#define DCGM_FI_PROF_NVDEC5_ACTIVE 1022
+#define DCGM_FI_PROF_NVDEC6_ACTIVE 1023
+#define DCGM_FI_PROF_NVDEC7_ACTIVE 1024
+
+/**
+ * Ratio of cycles each of the NVJPG engines are active.
+ */
+#define DCGM_FI_PROF_NVJPG0_ACTIVE 1025
+#define DCGM_FI_PROF_NVJPG1_ACTIVE 1026
+#define DCGM_FI_PROF_NVJPG2_ACTIVE 1027
+#define DCGM_FI_PROF_NVJPG3_ACTIVE 1028
+#define DCGM_FI_PROF_NVJPG4_ACTIVE 1029
+#define DCGM_FI_PROF_NVJPG5_ACTIVE 1030
+#define DCGM_FI_PROF_NVJPG6_ACTIVE 1031
+#define DCGM_FI_PROF_NVJPG7_ACTIVE 1032
+
+/**
+ * Ratio of cycles each of the NVOFA engines are active.
+ */
+#define DCGM_FI_PROF_NVOFA0_ACTIVE 1033
+
+/**
+ * The per-link number of bytes of active NvLink TX (transmit) or RX (transmit) data including both header and payload.
+ * For example: DCGM_FI_PROF_NVLINK_L0_TX_BYTES -> L0 TX
+ * To get the bandwidth for a link, add the RX and TX value together like
+ * total = DCGM_FI_PROF_NVLINK_L0_TX_BYTES + DCGM_FI_PROF_NVLINK_L0_RX_BYTES
+ */
+#define DCGM_FI_PROF_NVLINK_L0_TX_BYTES  1040
+#define DCGM_FI_PROF_NVLINK_L0_RX_BYTES  1041
+#define DCGM_FI_PROF_NVLINK_L1_TX_BYTES  1042
+#define DCGM_FI_PROF_NVLINK_L1_RX_BYTES  1043
+#define DCGM_FI_PROF_NVLINK_L2_TX_BYTES  1044
+#define DCGM_FI_PROF_NVLINK_L2_RX_BYTES  1045
+#define DCGM_FI_PROF_NVLINK_L3_TX_BYTES  1046
+#define DCGM_FI_PROF_NVLINK_L3_RX_BYTES  1047
+#define DCGM_FI_PROF_NVLINK_L4_TX_BYTES  1048
+#define DCGM_FI_PROF_NVLINK_L4_RX_BYTES  1049
+#define DCGM_FI_PROF_NVLINK_L5_TX_BYTES  1050
+#define DCGM_FI_PROF_NVLINK_L5_RX_BYTES  1051
+#define DCGM_FI_PROF_NVLINK_L6_TX_BYTES  1052
+#define DCGM_FI_PROF_NVLINK_L6_RX_BYTES  1053
+#define DCGM_FI_PROF_NVLINK_L7_TX_BYTES  1054
+#define DCGM_FI_PROF_NVLINK_L7_RX_BYTES  1055
+#define DCGM_FI_PROF_NVLINK_L8_TX_BYTES  1056
+#define DCGM_FI_PROF_NVLINK_L8_RX_BYTES  1057
+#define DCGM_FI_PROF_NVLINK_L9_TX_BYTES  1058
+#define DCGM_FI_PROF_NVLINK_L9_RX_BYTES  1059
+#define DCGM_FI_PROF_NVLINK_L10_TX_BYTES 1060
+#define DCGM_FI_PROF_NVLINK_L10_RX_BYTES 1061
+#define DCGM_FI_PROF_NVLINK_L11_TX_BYTES 1062
+#define DCGM_FI_PROF_NVLINK_L11_RX_BYTES 1063
+#define DCGM_FI_PROF_NVLINK_L12_TX_BYTES 1064
+#define DCGM_FI_PROF_NVLINK_L12_RX_BYTES 1065
+#define DCGM_FI_PROF_NVLINK_L13_TX_BYTES 1066
+#define DCGM_FI_PROF_NVLINK_L13_RX_BYTES 1067
+#define DCGM_FI_PROF_NVLINK_L14_TX_BYTES 1068
+#define DCGM_FI_PROF_NVLINK_L14_RX_BYTES 1069
+#define DCGM_FI_PROF_NVLINK_L15_TX_BYTES 1070
+#define DCGM_FI_PROF_NVLINK_L15_RX_BYTES 1071
+#define DCGM_FI_PROF_NVLINK_L16_TX_BYTES 1072
+#define DCGM_FI_PROF_NVLINK_L16_RX_BYTES 1073
+#define DCGM_FI_PROF_NVLINK_L17_TX_BYTES 1074
+#define DCGM_FI_PROF_NVLINK_L17_RX_BYTES 1075
+
+/**
+ * NVLink throughput First.
+ */
+#define DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+
+/**
+ * NVLink throughput Last.
+ */
+#define DCGM_FI_PROF_NVLINK_THROUGHPUT_LAST DCGM_FI_PROF_NVLINK_L17_RX_BYTES
+
+/**
  * 1 greater than maximum fields above. This is the 1 greater than the maximum field id that could be allocated
  */
-#define DCGM_FI_MAX_FIELDS 1015
+#define DCGM_FI_MAX_FIELDS 1076
 
 
 /** @} */
@@ -2216,7 +2251,9 @@ typedef struct
 
     dcgm_field_output_format_p valueFormat; /*!< pointer to the structure that holds the formatting the
                                                  values for fields */
-} dcgm_field_meta_t, *dcgm_field_meta_p;
+} dcgm_field_meta_t;
+
+typedef const dcgm_field_meta_t *dcgm_field_meta_p;
 
 /***************************************************************************************************/
 /** @addtogroup dcgmFieldIdentifiers
@@ -2246,7 +2283,7 @@ dcgm_field_meta_p DCGM_PUBLIC_API DcgmFieldGetById(unsigned short fieldId);
  *       >0     Pointer to field metadata structure if found
  *
  */
-dcgm_field_meta_p DCGM_PUBLIC_API DcgmFieldGetByTag(char *tag);
+dcgm_field_meta_p DCGM_PUBLIC_API DcgmFieldGetByTag(const char *tag);
 
 /**
  * Initialize the DcgmFields module. Call this once from inside

--- a/dynolog/src/gpumon/dcgm_structs.h
+++ b/dynolog/src/gpumon/dcgm_structs.h
@@ -156,14 +156,33 @@
 
 /**
  * Number of NvLink links per GPU supported by DCGM
- * This is 12 for Ampere, 6 for Volta, and 4 for Pascal
+ * 18 for Hopper, 12 for Ampere, 6 for Volta, and 4 for Pascal
  */
-#define DCGM_NVLINK_MAX_LINKS_PER_GPU 12
+#define DCGM_NVLINK_MAX_LINKS_PER_GPU 18
+
+/**
+ * Number of nvlink errors supported by DCGM
+ * @see NVML_NVLINK_ERROR_COUNT
+ *
+ * NVML_NVLINK_ERROR_DL_ECC_DATA not currently supported
+ */
+#define DCGM_NVLINK_ERROR_COUNT 4
+
+/**
+ * Number of nvlink error types: @see NVML_NVLINK_ERROR_COUNT
+ * TODO: update with refactor of ampere-next nvlink APIs (JIRA DCGM-2628)
+ */
+#define DCGM_HEALTH_WATCH_NVLINK_ERROR_NUM_FIELDS 4
 
 /**
  * Maximum NvLink links pre-Ampere
  */
 #define DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY1 6
+
+/**
+ * Maximum NvLink links pre-Hopper
+ */
+#define DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY2 12
 
 /**
  * Max number of NvSwitches supported by DCGM
@@ -173,7 +192,12 @@
 /**
  * Number of NvLink links per NvSwitch supported by DCGM
  */
-#define DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH 36
+#define DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH 64
+
+/**
+ * Number of Lines per NvSwitch NvLink supported by DCGM
+ */
+#define DCGM_LANE_MAX_LANES_PER_NVSWICH_LINK 4
 
 /**
  * Maximum number of vGPU instances per physical GPU
@@ -310,7 +334,7 @@ typedef enum dcgmReturn_enum
                                                //!< the current one finishes.
     DCGM_ST_DIAG_BAD_JSON               = -40, //!< The DCGM GPU Diagnostic returned JSON that cannot be parsed
     DCGM_ST_DIAG_BAD_LAUNCH             = -41, //!< Error while launching the DCGM GPU Diagnostic
-    DCGM_ST_DIAG_VARIANCE               = -42, //!< There is too much variance while training the diagnostic
+    DCGM_ST_DIAG_UNUSED                 = -42, //!< Unused
     DCGM_ST_DIAG_THRESHOLD_EXCEEDED     = -43, //!< A field value met or exceeded the error threshold.
     DCGM_ST_INSUFFICIENT_DRIVER_VERSION = -44, //!< The installed driver version is insufficient for this API
     DCGM_ST_INSTANCE_NOT_FOUND          = -45, //!< The specified GPU instance does not exist
@@ -366,6 +390,8 @@ typedef enum dcgmChipArchitecture_enum
     DCGM_CHIP_ARCH_VOLTA   = 5, //!< All Volta-architecture parts
     DCGM_CHIP_ARCH_TURING  = 6, //!< All Turing-architecture parts
     DCGM_CHIP_ARCH_AMPERE  = 7, //!< All Ampere-architecture parts
+    DCGM_CHIP_ARCH_ADA     = 8, //!< All Ada-architecture parts
+    DCGM_CHIP_ARCH_HOPPER  = 9, //!< All Hopper-architecture parts
 
     DCGM_CHIP_ARCH_COUNT, //!< Keep this second to last, exclude unknown
 
@@ -418,6 +444,31 @@ typedef enum
     DcgmLoggingSeverityDebug       = 5,  /*!< Debug information (will generate large logs) */
     DcgmLoggingSeverityVerbose     = 6   /*!< Verbose debugging information */
 } DcgmLoggingSeverity_t;
+
+/**
+ * Represents a link object. type should be one of DCGM_FE_GPU or
+ * DCGM_FE_SWITCH; gpuId or switchID is the associated gpu or switch; and index
+ * is the link index, 0-based, with TX (even) coming before RX (odd).
+ */
+#pragma pack(push, 1)
+typedef struct dcgm_link_s
+{
+    union
+    {
+        struct
+        {
+            dcgm_field_entity_group_t type : 8; /*!< Entity Group */
+            uint8_t index                  : 8; /*!< Link Index Tx before Rx */
+            union
+            {
+                dcgm_field_eid_t gpuId    : 16; /*!< Physical GPU ID */
+                dcgm_field_eid_t switchId : 16; /*!< Physical Switch ID */
+            };
+        } parsed;             /*!< Broken out Link identifier GPU/SW:[GPU|SW]:Index */
+        dcgm_field_eid_t raw; /*!< Raw Link ID */
+    };
+} dcgm_link_t;
+#pragma pack(pop)
 
 /**
  * Connection options for dcgmConnect_v2 (v1)
@@ -600,20 +651,6 @@ typedef struct
 // The maximum compute instances are always the same as the maximum instances because each compute instance is
 // part of an instance.
 #define DCGM_MAX_COMPUTE_INSTANCES DCGM_MAX_INSTANCES
-
-/**
- * Structure to store the GPU hierarchy for a system
- *
- * Added in DCGM 2.0
- */
-typedef struct
-{
-    unsigned int version;
-    unsigned int count;
-    dcgmMigHierarchyInfo_t entityList[DCGM_MAX_HIERARCHY_INFO];
-} dcgmMigHierarchy_v1;
-
-#define dcgmMigHierarchy_version1 MAKE_DCGM_VERSION(dcgmMigHierarchy_v1, 1)
 
 typedef struct
 {
@@ -1189,14 +1226,37 @@ typedef dcgmDeviceVgpuTypeInfo_v2 dcgmDeviceVgpuTypeInfo_t;
  */
 #define dcgmDeviceVgpuTypeInfo_version dcgmDeviceVgpuTypeInfo_version2
 
+/**
+ * Represents the info related to vGPUs supported on the device.
+ */
 typedef struct
 {
-    unsigned int version;
-    unsigned int persistenceModeEnabled;
-    unsigned int migModeEnabled;
-} dcgmDeviceSettings_v1;
+    unsigned int version;              //!< Version number (dcgmDeviceSupportedVgpuTypeInfo_version)
+    unsigned long long deviceId;       //!< device ID of vGPU type
+    unsigned long long subsystemId;    //!< Subsystem ID of vGPU type
+    unsigned int numDisplayHeads;      //!< Count of vGPU's supported display heads
+    unsigned int maxInstances;         //!< maximum number of vGPU instances creatable on a device for given vGPU type
+    unsigned int frameRateLimit;       //!< Frame rate limit value of the vGPU type
+    unsigned int maxResolutionX;       //!< vGPU display head's maximum supported resolution in X dimension
+    unsigned int maxResolutionY;       //!< vGPU display head's maximum supported resolution in Y dimension
+    unsigned long long fbTotal;        //!< vGPU Total framebuffer size in megabytes
+    unsigned int gpuInstanceProfileId; //!< GPU Instance Profile ID for the given vGPU type
+} dcgmDeviceSupportedVgpuTypeInfo_v1;
 
-#define dcgmDevicesSettings_version1 MAKE_DCGM_VERSION(dcgmDeviceSettings_v1, 1)
+/**
+ * Typedef for \ref dcgmDeviceSupportedVgpuTypeInfo_v1
+ */
+typedef dcgmDeviceSupportedVgpuTypeInfo_v1 dcgmDeviceSupportedVgpuTypeInfo_t;
+
+/**
+ * Version 1 for \ref dcgmDeviceSupportedVgpuTypeInfo_v1
+ */
+#define dcgmDeviceSupportedVgpuTypeInfo_version1 MAKE_DCGM_VERSION(dcgmDeviceSupportedVgpuTypeInfo_v1, 1)
+
+/**
+ * Latest version for \ref dcgmDeviceSupportedVgpuTypeInfo_t
+ */
+#define dcgmDeviceSupportedVgpuTypeInfo_version dcgmDeviceSupportedVgpuTypeInfo_version1
 
 typedef struct
 {
@@ -1211,41 +1271,6 @@ typedef dcgmDeviceSettings_v2 dcgmDeviceSettings_t;
 #define dcgmDeviceSettings_version2 MAKE_DCGM_VERSION(dcgmDeviceSettings_v2, 2)
 
 #define dcgmDeviceSettings_version dcgmDeviceSettings_version2
-
-/**
- * Represents attributes corresponding to a device
- */
-typedef struct
-{
-    unsigned int version;                     //!< Version number (dcgmDeviceAttributes_version)
-    dcgmDeviceSupportedClockSets_t clockSets; //!< Supported clocks for the device
-    dcgmDeviceThermals_t thermalSettings;     //!< Thermal settings for the device
-    dcgmDevicePowerLimits_t powerLimits;      //!< Various power limits for the device
-    dcgmDeviceIdentifiers_t identifiers;      //!< Identifiers for the device
-    dcgmDeviceMemoryUsage_t memoryUsage;      //!< Memory usage info for the device
-    char unused[208];                         //!< Unused Space. Set to 0 for now
-} dcgmDeviceAttributes_v1;
-
-/**
- * Version 1 for \ref dcgmDeviceAttributes_v1
- */
-#define dcgmDeviceAttributes_version1 MAKE_DCGM_VERSION(dcgmDeviceAttributes_v1, 1)
-
-typedef struct
-{
-    unsigned int version;                     //!< Version number (dcgmDeviceAttributes_version)
-    dcgmDeviceSupportedClockSets_t clockSets; //!< Supported clocks for the device
-    dcgmDeviceThermals_t thermalSettings;     //!< Thermal settings for the device
-    dcgmDevicePowerLimits_t powerLimits;      //!< Various power limits for the device
-    dcgmDeviceIdentifiers_t identifiers;      //!< Identifiers for the device
-    dcgmDeviceMemoryUsage_t memoryUsage;      //!< Memory usage info for the device
-    dcgmDeviceSettings_v1 settings;           //!< Basic device settings
-} dcgmDeviceAttributes_v2;
-
-/**
- * Version 2 for \ref dcgmDeviceAttributes_v2
- */
-#define dcgmDeviceAttributes_version2 MAKE_DCGM_VERSION(dcgmDeviceAttributes_v2, 2)
 
 typedef struct
 {
@@ -1272,6 +1297,182 @@ typedef dcgmDeviceAttributes_v3 dcgmDeviceAttributes_t;
  * Latest version for \ref dcgmDeviceAttributes_t
  */
 #define dcgmDeviceAttributes_version dcgmDeviceAttributes_version3
+
+/**
+ * Structure to represent attributes info for a MIG device
+ */
+typedef struct
+{
+    unsigned int version;                   //!< Version Number (dcgmDeviceMigAttributesInfo_version)
+    unsigned int gpuInstanceId;             //!< GPU instance ID
+    unsigned int computeInstanceId;         //!< Compute instance ID
+    unsigned int multiprocessorCount;       //!< Streaming Multiprocessor count
+    unsigned int sharedCopyEngineCount;     //!< Shared Copy Engine count
+    unsigned int sharedDecoderCount;        //!< Shared Decoder Engine count
+    unsigned int sharedEncoderCount;        //!< Shared Encoder Engine count
+    unsigned int sharedJpegCount;           //!< Shared JPEG Engine count
+    unsigned int sharedOfaCount;            //!< Shared OFA Engine count
+    unsigned int gpuInstanceSliceCount;     //!< GPU instance slice count
+    unsigned int computeInstanceSliceCount; //!< Compute instance slice count
+    unsigned long long memorySizeMB;        //!< Device memory size (in MiB)
+} dcgmDeviceMigAttributesInfo_v1;
+
+/**
+ * Typedef for \ref dcgmDeviceMigAttributesInfo_v1
+ */
+typedef dcgmDeviceMigAttributesInfo_v1 dcgmDeviceMigAttributesInfo_t;
+
+/**
+ * Version 1 for \ref dcgmDeviceMigAttributesInfo_v1
+ */
+#define dcgmDeviceMigAttributesInfo_version1 MAKE_DCGM_VERSION(dcgmDeviceMigAttributesInfo_v1, 1)
+
+/**
+ * Latest version for \ref dcgmDeviceMigAttributesInfo_t
+ */
+#define dcgmDeviceMigAttributesInfo_version dcgmDeviceMigAttributesInfo_version1
+
+/**
+ * Structure to represent attributes for a MIG device
+ */
+typedef struct
+{
+    unsigned int version;                             //!< Version Number (dcgmDeviceMigAttributes_version)
+    unsigned int migDevicesCount;                     //!< Count of MIG devices
+    dcgmDeviceMigAttributesInfo_v1 migAttributesInfo; //!< MIG attributes information
+} dcgmDeviceMigAttributes_v1;
+
+/**
+ * Typedef for \ref dcgmDeviceMigAttributes_v1
+ */
+typedef dcgmDeviceMigAttributes_v1 dcgmDeviceMigAttributes_t;
+
+/**
+ * Version 1 for \ref dcgmDeviceMigAttributes_v1
+ */
+#define dcgmDeviceMigAttributes_version1 MAKE_DCGM_VERSION(dcgmDeviceMigAttributes_v1, 1)
+
+/**
+ * Latest version for \ref dcgmDeviceMigAttributes_t
+ */
+#define dcgmDeviceMigAttributes_version dcgmDeviceMigAttributes_version1
+
+/**
+ * Structure to represent GPU instance profile information
+ */
+typedef struct
+{
+    unsigned int version;             //!< Version Number (dcgmGpuInstanceProfileInfo_version)
+    unsigned int id;                  //!< Unique profile ID within the device
+    unsigned int isP2pSupported;      //!< Peer-to-Peer support
+    unsigned int sliceCount;          //!< GPU Slice count
+    unsigned int instanceCount;       //!< GPU instance count
+    unsigned int multiprocessorCount; //!< Streaming Multiprocessor count
+    unsigned int copyEngineCount;     //!< Copy Engine count
+    unsigned int decoderCount;        //!< Decoder Engine count
+    unsigned int encoderCount;        //!< Encoder Engine count
+    unsigned int jpegCount;           //!< JPEG Engine count
+    unsigned int ofaCount;            //!< OFA Engine count
+    unsigned long long memorySizeMB;  //!< Memory size in MBytes
+} dcgmGpuInstanceProfileInfo_v1;
+
+/**
+ * Typedef for \ref dcgmGpuInstanceProfileInfo_v1
+ */
+typedef dcgmGpuInstanceProfileInfo_v1 dcgmGpuInstanceProfileInfo_t;
+
+/**
+ * Version 1 for \ref dcgmGpuInstanceProfileInfo_v1
+ */
+#define dcgmGpuInstanceProfileInfo_version1 MAKE_DCGM_VERSION(dcgmGpuInstanceProfileInfo_v1, 1)
+
+/**
+ * Latest version for \ref dcgmGpuInstanceProfileInfo_t
+ */
+#define dcgmGpuInstanceProfileInfo_version dcgmGpuInstanceProfileInfo_version1
+
+/**
+ * Structure to represent GPU instance profiles
+ */
+typedef struct
+{
+    unsigned int version;                      //!< Version Number (dcgmGpuInstanceProfiles_version)
+    unsigned int profileCount;                 //!< Profile count
+    dcgmGpuInstanceProfileInfo_v1 profileInfo; //!< GPU instance profile information
+} dcgmGpuInstanceProfiles_v1;
+
+/**
+ * Typedef for \ref dcgmGpuInstanceProfiles_v1
+ */
+typedef dcgmGpuInstanceProfiles_v1 dcgmGpuInstanceProfiles_t;
+
+/**
+ * Version 1 for \ref dcgmGpuInstanceProfiles_v1
+ */
+#define dcgmGpuInstanceProfiles_version1 MAKE_DCGM_VERSION(dcgmGpuInstanceProfiles_v1, 1)
+
+/**
+ * Latest version for \ref dcgmGpuInstanceProfiles_t
+ */
+#define dcgmGpuInstanceProfiles_version dcgmGpuInstanceProfiles_version1
+
+/**
+ * Structure to represent Compute instance profile information
+ */
+typedef struct
+{
+    unsigned int version;               //!< Version Number (dcgmComputeInstanceProfileInfo_version)
+    unsigned int gpuInstanceId;         //!< GPU instance ID
+    unsigned int id;                    //!< Unique profile ID within the GPU instance
+    unsigned int sliceCount;            //!< GPU Slice count
+    unsigned int instanceCount;         //!< Compute instance count
+    unsigned int multiprocessorCount;   //!< Streaming Multiprocessor count
+    unsigned int sharedCopyEngineCount; //!< Shared Copy Engine count
+    unsigned int sharedDecoderCount;    //!< Shared Decoder Engine count
+    unsigned int sharedEncoderCount;    //!< Shared Encoder Engine count
+    unsigned int sharedJpegCount;       //!< Shared JPEG Engine count
+    unsigned int sharedOfaCount;        //!< Shared OFA Engine count
+} dcgmComputeInstanceProfileInfo_v1;
+
+/**
+ * Typedef for \ref dcgmComputeInstanceProfileInfo_v1
+ */
+typedef dcgmComputeInstanceProfileInfo_v1 dcgmComputeInstanceProfileInfo_t;
+
+/**
+ * Version 1 for \ref dcgmComputeInstanceProfileInfo_v1
+ */
+#define dcgmComputeInstanceProfileInfo_version1 MAKE_DCGM_VERSION(dcgmComputeInstanceProfileInfo_v1, 1)
+
+/**
+ * Latest version for \ref dcgmComputeInstanceProfileInfo_t
+ */
+#define dcgmComputeInstanceProfileInfo_version dcgmComputeInstanceProfileInfo_version1
+
+/**
+ * Structure to represent Compute instance profiles
+ */
+typedef struct
+{
+    unsigned int version;                          //!< Version Number (dcgmComputeInstanceProfiles_version)
+    unsigned int profileCount;                     //!< Profile count
+    dcgmComputeInstanceProfileInfo_v1 profileInfo; //!< Compute instance profile information
+} dcgmComputeInstanceProfiles_v1;
+
+/**
+ * Typedef for \ref dcgmComputeInstanceProfiles_v1
+ */
+typedef dcgmComputeInstanceProfiles_v1 dcgmComputeInstanceProfiles_t;
+
+/**
+ * Version 1 for \ref dcgmComputeInstanceProfiles_v1
+ */
+#define dcgmComputeInstanceProfiles_version1 MAKE_DCGM_VERSION(dcgmComputeInstanceProfiles_v1, 1)
+
+/**
+ * Latest version for \ref dcgmComputeInstanceProfiles_t
+ */
+#define dcgmComputeInstanceProfiles_version dcgmComputeInstanceProfiles_version1
 
 /**
  * Maximum number of vGPU types per physical GPU
@@ -2161,9 +2362,14 @@ typedef enum dcgmPerGpuTestIndices_enum
     DCGM_PULSE_TEST_INDEX       = 8, //!< Pulse test index
     // Remaining tests are included for convenience but have different execution rules
     // See DCGM_PER_GPU_TEST_COUNT
-    DCGM_SOFTWARE_INDEX       = 9,  //!< Software test index
-    DCGM_CONTEXT_CREATE_INDEX = 10, //!< Context create test index
-    DCGM_UNKNOWN_INDEX        = 11  //!< Unknown test
+    DCGM_UNUSED1_TEST_INDEX   = 9,
+    DCGM_UNUSED2_TEST_INDEX   = 10,
+    DCGM_UNUSED3_TEST_INDEX   = 11,
+    DCGM_UNUSED4_TEST_INDEX   = 12,
+    DCGM_UNUSED5_TEST_INDEX   = 13,
+    DCGM_SOFTWARE_INDEX       = 14, //!< Software test index
+    DCGM_CONTEXT_CREATE_INDEX = 15, //!< Context create test index
+    DCGM_UNKNOWN_INDEX        = 16  //!< Unknown test
 } dcgmPerGpuTestIndices_t;
 
 // TODO: transition these to dcgm_deprecated.h
@@ -2172,7 +2378,7 @@ typedef enum dcgmPerGpuTestIndices_enum
 
 // Number of diag tests
 // NOTE: does not include software and context_create which have different execution rules
-#define DCGM_PER_GPU_TEST_COUNT_V6 7
+#define DCGM_PER_GPU_TEST_COUNT_V8 13
 #define DCGM_PER_GPU_TEST_COUNT_V7 9
 
 /**
@@ -2182,8 +2388,8 @@ typedef struct
 {
     unsigned int gpuId;                                        //!< ID for the GPU this information pertains
     unsigned int hwDiagnosticReturn;                           //!< Per GPU hardware diagnostic test return code
-    dcgmDiagTestResult_v2 results[DCGM_PER_GPU_TEST_COUNT_V6]; //!< Array with a result for each per-gpu test
-} dcgmDiagResponsePerGpu_v2;
+    dcgmDiagTestResult_v2 results[DCGM_PER_GPU_TEST_COUNT_V8]; //!< Array with a result for each per-gpu test
+} dcgmDiagResponsePerGpu_v4;
 
 /**
  * Per gpu response structure v3
@@ -2203,7 +2409,7 @@ typedef struct
 
 typedef enum dcgmSoftwareTest_enum
 {
-    DCGM_SWTEST_BLACKLIST            = 0, //!< test for presence of blacklisted drivers (e.g. nouveau)
+    DCGM_SWTEST_DENYLIST             = 0, //!< test for presence of drivers on the denylist (e.g. nouveau)
     DCGM_SWTEST_NVML_LIBRARY         = 1, //!< test for presence (and version) of NVML lib
     DCGM_SWTEST_CUDA_MAIN_LIBRARY    = 2, //!< test for presence (and version) of CUDA lib
     DCGM_SWTEST_CUDA_RUNTIME_LIBRARY = 3, //!< test for presence (and version) of CUDA RT lib
@@ -2216,9 +2422,9 @@ typedef enum dcgmSoftwareTest_enum
 } dcgmSoftwareTest_t;
 
 /**
- * Global diagnostics result structure v6
+ * Global diagnostics result structure v8
  *
- * Since DCGM 2.0
+ * Since DCGM 3.0
  */
 typedef struct
 {
@@ -2227,10 +2433,10 @@ typedef struct
     unsigned int levelOneTestCount; //!< number of valid levelOne results
 
     dcgmDiagTestResult_v2 levelOneResults[LEVEL_ONE_MAX_RESULTS];    //!< Basic, system-wide test results.
-    dcgmDiagResponsePerGpu_v2 perGpuResponses[DCGM_MAX_NUM_DEVICES]; //!< per GPU test results
+    dcgmDiagResponsePerGpu_v4 perGpuResponses[DCGM_MAX_NUM_DEVICES]; //!< per GPU test results
     dcgmDiagErrorDetail_t systemError;                               //!< System-wide error reported from NVVS
-    char trainingMsg[1024];                                          //!< Training Message
-} dcgmDiagResponse_v6;
+    char _unused[1024];                                              //!< No longer used
+} dcgmDiagResponse_v8;
 
 /**
  * Global diagnostics result structure v7
@@ -2246,18 +2452,18 @@ typedef struct
     dcgmDiagTestResult_v2 levelOneResults[LEVEL_ONE_MAX_RESULTS];    //!< Basic, system-wide test results.
     dcgmDiagResponsePerGpu_v3 perGpuResponses[DCGM_MAX_NUM_DEVICES]; //!< per GPU test results
     dcgmDiagErrorDetail_t systemError;                               //!< System-wide error reported from NVVS
-    char trainingMsg[1024];                                          //!< Training Message
+    char _unused[1024];                                              //!< No longer used
 } dcgmDiagResponse_v7;
 
 /**
- * Typedef for \ref dcgmDiagResponse_v6
+ * Typedef for \ref dcgmDiagResponse_v8
  */
-typedef dcgmDiagResponse_v7 dcgmDiagResponse_t;
+typedef dcgmDiagResponse_v8 dcgmDiagResponse_t;
 
 /**
- * Version 6 for \ref dcgmDiagResponse_v6
+ * Version 8 for \ref dcgmDiagResponse_v8
  */
-#define dcgmDiagResponse_version6 MAKE_DCGM_VERSION(dcgmDiagResponse_v6, 6)
+#define dcgmDiagResponse_version8 MAKE_DCGM_VERSION(dcgmDiagResponse_v8, 8)
 
 /**
  * Version 7 for \ref dcgmDiagResponse_v7
@@ -2267,7 +2473,7 @@ typedef dcgmDiagResponse_v7 dcgmDiagResponse_t;
 /**
  * Latest version for \ref dcgmDiagResponse_t
  */
-#define dcgmDiagResponse_version dcgmDiagResponse_version7
+#define dcgmDiagResponse_version dcgmDiagResponse_version8
 
 /**
  * Represents level relationships within a system between two GPUs
@@ -2290,18 +2496,24 @@ typedef enum dcgmGpuLevel_enum
 
     /** \name NVLINK connectivity states */
     /**@{*/
-    DCGM_TOPOLOGY_NVLINK1  = 0x0100,  //!< GPUs connected via a single NVLINK link
-    DCGM_TOPOLOGY_NVLINK2  = 0x0200,  //!< GPUs connected via two NVLINK links
-    DCGM_TOPOLOGY_NVLINK3  = 0x0400,  //!< GPUs connected via three NVLINK links
-    DCGM_TOPOLOGY_NVLINK4  = 0x0800,  //!< GPUs connected via four NVLINK links
-    DCGM_TOPOLOGY_NVLINK5  = 0x1000,  //!< GPUs connected via five NVLINK links
-    DCGM_TOPOLOGY_NVLINK6  = 0x2000,  //!< GPUs connected via six NVLINK links
-    DCGM_TOPOLOGY_NVLINK7  = 0x4000,  //!< GPUs connected via seven NVLINK links
-    DCGM_TOPOLOGY_NVLINK8  = 0x8000,  //!< GPUs connected via eight NVLINK links
-    DCGM_TOPOLOGY_NVLINK9  = 0x10000, //!< GPUs connected via nine NVLINK links
-    DCGM_TOPOLOGY_NVLINK10 = 0x20000, //!< GPUs connected via ten NVLINK links
-    DCGM_TOPOLOGY_NVLINK11 = 0x40000, //!< GPUs connected via eleven NVLINK links
-    DCGM_TOPOLOGY_NVLINK12 = 0x80000, //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK1  = 0x0100,    //!< GPUs connected via a single NVLINK link
+    DCGM_TOPOLOGY_NVLINK2  = 0x0200,    //!< GPUs connected via two NVLINK links
+    DCGM_TOPOLOGY_NVLINK3  = 0x0400,    //!< GPUs connected via three NVLINK links
+    DCGM_TOPOLOGY_NVLINK4  = 0x0800,    //!< GPUs connected via four NVLINK links
+    DCGM_TOPOLOGY_NVLINK5  = 0x1000,    //!< GPUs connected via five NVLINK links
+    DCGM_TOPOLOGY_NVLINK6  = 0x2000,    //!< GPUs connected via six NVLINK links
+    DCGM_TOPOLOGY_NVLINK7  = 0x4000,    //!< GPUs connected via seven NVLINK links
+    DCGM_TOPOLOGY_NVLINK8  = 0x8000,    //!< GPUs connected via eight NVLINK links
+    DCGM_TOPOLOGY_NVLINK9  = 0x10000,   //!< GPUs connected via nine NVLINK links
+    DCGM_TOPOLOGY_NVLINK10 = 0x20000,   //!< GPUs connected via ten NVLINK links
+    DCGM_TOPOLOGY_NVLINK11 = 0x40000,   //!< GPUs connected via eleven NVLINK links
+    DCGM_TOPOLOGY_NVLINK12 = 0x80000,   //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK13 = 0x100000,  //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK14 = 0x200000,  //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK15 = 0x400000,  //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK16 = 0x800000,  //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK17 = 0x1000000, //!< GPUs connected via twelve NVLINK links
+    DCGM_TOPOLOGY_NVLINK18 = 0x2000000, //!< GPUs connected via twelve NVLINK links
     /**@}*/
 } dcgmGpuTopologyLevel_t;
 
@@ -2388,125 +2600,6 @@ typedef dcgmGroupTopology_v1 dcgmGroupTopology_t;
 #define dcgmGroupTopology_version dcgmGroupTopology_version1
 
 /**
- * Identifies a level to retrieve field introspection info for
- */
-typedef enum dcgmIntrospectLevel_enum
-{
-    DCGM_INTROSPECT_LVL_INVALID     = 0, //!< Invalid value
-    DCGM_INTROSPECT_LVL_FIELD       = 1, //!< Introspection data is grouped by field ID
-    DCGM_INTROSPECT_LVL_FIELD_GROUP = 2, //!< Introspection data is grouped by field group
-    DCGM_INTROSPECT_LVL_ALL_FIELDS,      //!< Introspection data is aggregated for all fields
-} dcgmIntrospectLevel_t;
-
-/**
- * Identifies the retrieval context for introspection API calls.
- */
-typedef struct
-{
-    unsigned int version;                //!< version number (dcgmIntrospectContext_version)
-    dcgmIntrospectLevel_t introspectLvl; //!< Introspect Level \ref dcgmIntrospectLevel_t
-    union
-    {
-        dcgmGpuGrp_t fieldGroupId;    //!< Only needed if \ref introspectLvl is DCGM_INTROSPECT_LVL_FIELD_GROUP
-        unsigned short fieldId;       //!< Only needed if \ref introspectLvl is DCGM_INTROSPECT_LVL_FIELD
-        unsigned long long contextId; //!< Overloaded way to access both fieldGroupId and fieldId
-    };
-} dcgmIntrospectContext_v1;
-
-/**
- * Typedef for \ref dcgmIntrospectContext_v1
- */
-typedef dcgmIntrospectContext_v1 dcgmIntrospectContext_t;
-
-/**
- * Version 1 for \ref dcgmIntrospectContext_t
- */
-#define dcgmIntrospectContext_version1 MAKE_DCGM_VERSION(dcgmIntrospectContext_v1, 1)
-
-/**
- * Latest version for \ref dcgmIntrospectContext_t
- */
-#define dcgmIntrospectContext_version dcgmIntrospectContext_version1
-
-/**
- * DCGM Execution time info for a set of fields
- */
-typedef struct
-{
-    unsigned int version; //!< version number (dcgmIntrospectFieldsExecTime_version)
-
-    long long meanUpdateFreqUsec; //!< the mean update frequency of all fields
-
-    double recentUpdateUsec; //!< the sum of every field's most recent execution time after they
-                             //!< have been normalized to \ref meanUpdateFreqUsec".
-                             //!< This is roughly how long it takes to update fields every \ref meanUpdateFreqUsec
-
-    long long totalEverUpdateUsec; //!< The total amount of time, ever, that has been spent updating all the fields
-} dcgmIntrospectFieldsExecTime_v1;
-
-/**
- * Typedef for \ref dcgmIntrospectFieldsExecTime_t
- */
-typedef dcgmIntrospectFieldsExecTime_v1 dcgmIntrospectFieldsExecTime_t;
-
-/**
- * Version 1 for \ref dcgmIntrospectFieldsExecTime_t
- */
-#define dcgmIntrospectFieldsExecTime_version1 MAKE_DCGM_VERSION(dcgmIntrospectFieldsExecTime_v1, 1)
-
-/**
- * Latest version for \ref dcgmIntrospectFieldsExecTime_t
- */
-#define dcgmIntrospectFieldsExecTime_version dcgmIntrospectFieldsExecTime_version1
-
-/**
- * Full introspection info for field execution time
- *
- * Since DCGM 2.0
- */
-typedef struct
-{
-    unsigned int version; //!< version number (dcgmIntrospectFullFieldsExecTime_version)
-
-    dcgmIntrospectFieldsExecTime_v1 aggregateInfo; //!< info that includes global and device scope
-
-    int hasGlobalInfo;                          //!< 0 means \ref globalInfo is populated, !0 means it's not
-    dcgmIntrospectFieldsExecTime_v1 globalInfo; //!< info that only includes global field scope
-
-    unsigned short gpuInfoCount;                         //!< count of how many entries in \ref gpuInfo are populated
-    unsigned int gpuIdsForGpuInfo[DCGM_MAX_NUM_DEVICES]; //!< the GPU ID at a given index identifies which gpu
-                                                         //!< the corresponding entry in \ref gpuInfo is from
-
-    dcgmIntrospectFieldsExecTime_v1 gpuInfo[DCGM_MAX_NUM_DEVICES]; //!< info that is separated by the
-                                                                   //!< GPU ID that the watches were for
-} dcgmIntrospectFullFieldsExecTime_v2;
-
-/**
- * typedef for \ref dcgmIntrospectFullFieldsExecTime_v1
- */
-typedef dcgmIntrospectFullFieldsExecTime_v2 dcgmIntrospectFullFieldsExecTime_t;
-
-/**
- * Version 1 for \ref dcgmIntrospectFullFieldsExecTime_t
- */
-#define dcgmIntrospectFullFieldsExecTime_version2 MAKE_DCGM_VERSION(dcgmIntrospectFullFieldsExecTime_v2, 2)
-
-/**
- * Latest version for \ref dcgmIntrospectFullFieldsExecTime_t
- */
-#define dcgmIntrospectFullFieldsExecTime_version dcgmIntrospectFullFieldsExecTime_version2
-
-/**
- * State of DCGM metadata gathering.  If it is set to DISABLED then "Metadata" API
- * calls to DCGM are not supported.
- */
-typedef enum dcgmIntrospectState_enum
-{
-    DCGM_INTROSPECT_STATE_DISABLED = 0,
-    DCGM_INTROSPECT_STATE_ENABLED  = 1
-} dcgmIntrospectState_t;
-
-/**
  * DCGM Memory usage information
  */
 typedef struct
@@ -2529,42 +2622,6 @@ typedef dcgmIntrospectMemory_v1 dcgmIntrospectMemory_t;
  * Latest version for \ref dcgmIntrospectMemory_t
  */
 #define dcgmIntrospectMemory_version dcgmIntrospectMemory_version1
-
-
-/**
- * Full introspection info for field memory
- */
-typedef struct
-{
-    unsigned int version; //!< version number (dcgmIntrospectFullMemory_version)
-
-    dcgmIntrospectMemory_v1 aggregateInfo; //!< info that includes global and device scope
-
-    int hasGlobalInfo;                  //!< 0 means \ref globalInfo is populated, !0 means it's not
-    dcgmIntrospectMemory_v1 globalInfo; //!< info that only includes global field scope
-
-    unsigned short gpuInfoCount;                         //!< count of how many entries in \ref gpuInfo are populated
-    unsigned int gpuIdsForGpuInfo[DCGM_MAX_NUM_DEVICES]; //!< the GPU ID at a given index identifies which gpu
-                                                         //!< the corresponding entry in \ref gpuInfo is from
-
-    dcgmIntrospectMemory_v1 gpuInfo[DCGM_MAX_NUM_DEVICES]; //!< info that is divided by the
-                                                           //!< GPU ID that the watches were for
-} dcgmIntrospectFullMemory_v1;
-
-/**
- * typedef for \ref dcgmIntrospectFullMemory_v1
- */
-typedef dcgmIntrospectFullMemory_v1 dcgmIntrospectFullMemory_t;
-
-/**
- * Version 1 for \ref dcgmIntrospectFullMemory_t
- */
-#define dcgmIntrospectFullMemory_version1 MAKE_DCGM_VERSION(dcgmIntrospectFullMemory_v1, 1)
-
-/**
- * Latest version for \ref dcgmIntrospectFullMemory_t
- */
-#define dcgmIntrospectFullMemory_version dcgmIntrospectFullMemory_version1
 
 /**
  * DCGM CPU Utilization information.  Multiply values by 100 to get them in %.
@@ -2619,12 +2676,12 @@ typedef dcgmIntrospectCpuUtil_v1 dcgmIntrospectCpuUtil_t;
 #define DCGM_RUN_FLAGS_STATSONFAIL 0x0002
 
 /**
- * Train DCGM diagnostic and output a configuration file with golden values
+ * UNUSED Train DCGM diagnostic and output a configuration file with golden values
  */
 #define DCGM_RUN_FLAGS_TRAIN 0x0004
 
 /**
- * Ignore warnings against training the diagnostic and train anyway
+ * UNUSED Ignore warnings against training the diagnostic and train anyway
  */
 #define DCGM_RUN_FLAGS_FORCE_TRAIN 0x0008
 
@@ -2658,12 +2715,13 @@ typedef struct
     char configFileContents[DCGM_MAX_CONFIG_FILE_LEN]; //!< Contents of nvvs config file (likely yaml)
     char throttleMask[DCGM_THROTTLE_MASK_LEN]; //!< Throttle reasons to ignore as either integer mask or csv list of
                                                //!< reasons
-    char pluginPath[DCGM_PATH_LEN];       //!< Custom path to the diagnostic plugins - No longer supported as of 2.2.9
-    unsigned int trainingIterations;      //!< Number of iterations for training
-    unsigned int trainingVariance;        //!< Acceptable training variance as a percentage of the value. (0-100)
-    unsigned int trainingTolerance;       //!< Acceptable training tolerance as a percentage of the value. (0-100)
-    char goldenValuesFile[DCGM_PATH_LEN]; //!< The path where the golden values should be recorded
-    unsigned int failCheckInterval;       //!< How often the fail early checks should occur when enabled.
+    char pluginPath[DCGM_PATH_LEN]; //!< Custom path to the diagnostic plugins - No longer supported as of 2.2.9
+
+    unsigned int _unusedInt1;       //!< No longer used
+    unsigned int _unusedInt2;       //!< No longer used
+    unsigned int _unusedInt3;       //!< No longer used
+    char _unusedBuf[DCGM_PATH_LEN]; //!< No longer used
+    unsigned int failCheckInterval; //!< How often the fail early checks should occur when enabled.
 } dcgmRunDiag_v7;
 
 /**
@@ -2740,9 +2798,16 @@ typedef struct
 
 typedef struct
 {
+    dcgm_field_eid_t entityId;                                              //!< Entity ID of the GPU (gpuId)
+    dcgmNvLinkLinkState_t linkState[DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY2]; //!< Per-GPU link states
+} dcgmNvLinkGpuLinkStatus_v2;
+
+
+typedef struct
+{
     dcgm_field_eid_t entityId;                                      //!< Entity ID of the GPU (gpuId)
     dcgmNvLinkLinkState_t linkState[DCGM_NVLINK_MAX_LINKS_PER_GPU]; //!< Per-GPU link states
-} dcgmNvLinkGpuLinkStatus_v2;
+} dcgmNvLinkGpuLinkStatus_v3;
 
 /**
  * State of NvLink links for a NvSwitch
@@ -2760,31 +2825,17 @@ typedef struct
 {
     unsigned int version; //!< Version of this request. Should be dcgmNvLinkStatus_version1
     unsigned int numGpus; //!< Number of entries in gpus[] that are populated
-    dcgmNvLinkGpuLinkStatus_v1 gpus[DCGM_MAX_NUM_DEVICES]; //!< Per-GPU NvLink link statuses
+    dcgmNvLinkGpuLinkStatus_v3 gpus[DCGM_MAX_NUM_DEVICES]; //!< Per-GPU NvLink link statuses
     unsigned int numNvSwitches;                            //!< Number of entries in nvSwitches[] that are populated
     dcgmNvLinkNvSwitchLinkStatus_t nvSwitches[DCGM_MAX_NUM_SWITCHES]; //!< Per-NvSwitch link statuses
-} dcgmNvLinkStatus_v1;
+} dcgmNvLinkStatus_v3;
+
+typedef dcgmNvLinkStatus_v3 dcgmNvLinkStatus_t;
 
 /**
- * Version 1 of dcgmNvLinkStatus
+ * Version 3 of dcgmNvLinkStatus
  */
-#define dcgmNvLinkStatus_version1 MAKE_DCGM_VERSION(dcgmNvLinkStatus_v1, 1)
-
-typedef struct
-{
-    unsigned int version; //!< Version of this request. Should be dcgmNvLinkStatus_version1
-    unsigned int numGpus; //!< Number of entries in gpus[] that are populated
-    dcgmNvLinkGpuLinkStatus_v2 gpus[DCGM_MAX_NUM_DEVICES]; //!< Per-GPU NvLink link statuses
-    unsigned int numNvSwitches;                            //!< Number of entries in nvSwitches[] that are populated
-    dcgmNvLinkNvSwitchLinkStatus_t nvSwitches[DCGM_MAX_NUM_SWITCHES]; //!< Per-NvSwitch link statuses
-} dcgmNvLinkStatus_v2;
-
-typedef dcgmNvLinkStatus_v2 dcgmNvLinkStatus_t;
-
-/**
- * Version 2 of dcgmNvLinkStatus
- */
-#define dcgmNvLinkStatus_version2 MAKE_DCGM_VERSION(dcgmNvLinkStatus_v2, 2)
+#define dcgmNvLinkStatus_version3 MAKE_DCGM_VERSION(dcgmNvLinkStatus_v3, 3)
 
 /* Bitmask values for dcgmGetFieldIdSummary - Sync with DcgmcmSummaryType_t */
 #define DCGM_SUMMARY_MIN      0x00000001
@@ -2854,11 +2905,11 @@ typedef enum
  */
 typedef enum
 {
-    DcgmModuleStatusNotLoaded   = 0, //!< Module has not been loaded yet
-    DcgmModuleStatusBlacklisted = 1, //!< Module has been blacklisted from being loaded
-    DcgmModuleStatusFailed      = 2, //!< Loading the module failed
-    DcgmModuleStatusLoaded      = 3, //!< Module has been loaded
-    DcgmModuleStatusUnloaded    = 4, //!< Module has been unloaded, happens during shutdown
+    DcgmModuleStatusNotLoaded  = 0, //!< Module has not been loaded yet
+    DcgmModuleStatusDenylisted = 1, //!< Module is on the denylist; can't be loaded
+    DcgmModuleStatusFailed     = 2, //!< Loading the module failed
+    DcgmModuleStatusLoaded     = 3, //!< Module has been loaded
+    DcgmModuleStatusUnloaded   = 4, //!< Module has been unloaded, happens during shutdown
 } dcgmModuleStatus_t;
 
 /**
@@ -2899,9 +2950,9 @@ typedef struct
     dcgmHandle_t dcgmHandle;        /*!< OUT: DCGM Handle to use for API calls */
     const char *logFile;            /*!< IN: File that DCGM should log to. NULL = do not log. '-' = stdout */
     DcgmLoggingSeverity_t severity; /*!< IN: Severity at which DCGM should log to logFile */
-    unsigned int blackListCount;    /*!< IN: Number of modules that to be blacklisted in blackList[] */
-    dcgmModuleId_t blackList[DcgmModuleIdCount]; /* IN: IDs of modules to blacklist */
-    unsigned int unused;                         /*!< IN: Unused. Set to 0. Aligns structure to 8-bytes */
+    unsigned int denyListCount;     /*!< IN: Number of modules in denyList[] */
+    dcgmModuleId_t denyList[DcgmModuleIdCount]; /* IN: IDs of modules to add to the denylist */
+    unsigned int unused;                        /*!< IN: Unused. Set to 0. Aligns structure to 8-bytes */
 } dcgmStartEmbeddedV2Params_v1;
 
 /**
@@ -2910,9 +2961,9 @@ typedef struct
 #define dcgmStartEmbeddedV2Params_version1 MAKE_DCGM_VERSION(dcgmStartEmbeddedV2Params_v1, 1)
 
 /**
- * Options for dcgmStartEmbedded_v2
+ * Options for dcgmStartEmbeddedV2Params_v2
  *
- * Added in DCGM 2.4.0
+ * Added in DCGM 2.4.0, renamed members in 3.0.0
  */
 typedef struct
 {
@@ -2921,26 +2972,26 @@ typedef struct
     dcgmHandle_t dcgmHandle;        /*!< OUT: DCGM Handle to use for API calls */
     const char *logFile;            /*!< IN: File that DCGM should log to. NULL = do not log. '-' = stdout */
     DcgmLoggingSeverity_t severity; /*!< IN: Severity at which DCGM should log to logFile */
-    unsigned int blackListCount;    /*!< IN: Number of modules that to be blacklisted in blackList[] */
+    unsigned int denyListCount;     /*!< IN: Number of modules to be added to the denylist in denyList[] */
     const char *serviceAccount;     /*!< IN: Service account for unprivileged processes */
-    dcgmModuleId_t blackList[DcgmModuleIdCount]; /*!< IN: IDs of modules to blacklist */
-    char _padding[4];                            /*!< IN: Unused. Aligns the struct to 8 bytes. */
+    dcgmModuleId_t denyList[DcgmModuleIdCount]; /*!< IN: IDs of modules to be added to the denylist */
+    char _padding[4];                           /*!< IN: Unused. Aligns the struct to 8 bytes. */
 } dcgmStartEmbeddedV2Params_v2;
 
 /**
- * Version 2 for \ref dcgmStartEmbeddedV2Params
+ * Version 3 for \ref dcgmStartEmbeddedV2Params
  */
 #define dcgmStartEmbeddedV2Params_version2 MAKE_DCGM_VERSION(dcgmStartEmbeddedV2Params_v2, 2)
 
 /**
  * Maximum number of metric ID groups that can exist in DCGM
  */
-#define DCGM_PROF_MAX_NUM_GROUPS 10
+#define DCGM_PROF_MAX_NUM_GROUPS_V2 10
 
 /**
  * Maximum number of field IDs that can be in a single DCGM profiling metric group
  */
-#define DCGM_PROF_MAX_FIELD_IDS_PER_GROUP 8
+#define DCGM_PROF_MAX_FIELD_IDS_PER_GROUP_V2 64
 
 /**
  * Structure to return all of the profiling metric groups that are available for the given groupId.
@@ -2952,10 +3003,10 @@ typedef struct
     unsigned short minorId;   //!< Minor ID of this metric group. This distinguishes metric groups within the same
                               //!< major metric group from each other
     unsigned int numFieldIds; //!< Number of field IDs that are populated in fieldIds[]
-    unsigned short fieldIds[DCGM_PROF_MAX_FIELD_IDS_PER_GROUP]; //!< DCGM Field IDs that are part of this profiling
-                                                                //!< group. See DCGM_FI_PROF_* definitions in
-                                                                //!< dcgm_fields.h for details.
-} dcgmProfMetricGroupInfo_t;
+    unsigned short fieldIds[DCGM_PROF_MAX_FIELD_IDS_PER_GROUP_V2]; //!< DCGM Field IDs that are part of this profiling
+                                                                   //!< group. See DCGM_FI_PROF_* definitions in
+                                                                   //!< dcgm_fields.h for details.
+} dcgmProfMetricGroupInfo_v2;
 
 typedef struct
 {
@@ -2964,8 +3015,7 @@ typedef struct
      */
     unsigned int version; //!< Version of this request. Should be dcgmProfGetMetricGroups_version
     unsigned int unused;  //!< Not used for now. Set to 0
-    dcgmGpuGrp_t groupId; //!< Group of GPUs we should get the metric groups for. These must all be the
-                          //!< exact same GPU or DCGM_ST_GROUP_INCOMPATIBLE will be returned
+    unsigned int gpuId;   //!< GPU ID we should get the metric groups for.
     /**
      * @}
      */
@@ -2974,20 +3024,20 @@ typedef struct
      * @{
      */
     unsigned int numMetricGroups; //!< Number of entries in metricGroups[] that are populated
-    unsigned int unused1;         //!< Not used for now. Set to 0
-    dcgmProfMetricGroupInfo_t metricGroups[DCGM_PROF_MAX_NUM_GROUPS]; //!< Info for each metric group
+    dcgmProfMetricGroupInfo_v2 metricGroups[DCGM_PROF_MAX_NUM_GROUPS_V2]; //!< Info for each metric group
     /**
      * @}
      */
-} dcgmProfGetMetricGroups_v2;
+} dcgmProfGetMetricGroups_v3;
 
 /**
- * Version 1 of dcgmProfGetMetricGroups_t
+ * Version 3 of dcgmProfGetMetricGroups_t. See dcgm_structs_24.h for v2
  */
-#define dcgmProfGetMetricGroups_version2 MAKE_DCGM_VERSION(dcgmProfGetMetricGroups_v2, 2)
-#define dcgmProfGetMetricGroups_version  dcgmProfGetMetricGroups_version2
-typedef dcgmProfGetMetricGroups_v2 dcgmProfGetMetricGroups_t;
+#define dcgmProfGetMetricGroups_version3 MAKE_DCGM_VERSION(dcgmProfGetMetricGroups_v3, 3)
+#define dcgmProfGetMetricGroups_version  dcgmProfGetMetricGroups_version3
+typedef dcgmProfGetMetricGroups_v3 dcgmProfGetMetricGroups_t;
 
+// Legacy version of dcgmProfWatchFields() to support DCGM 2.x
 /**
  * Structure to pass to dcgmProfWatchFields() when watching profiling metrics
  */


### PR DESCRIPTION
Summary: DCGM released 3.0 that has some major API changes, we need to tweak the dcgm_structs.h file to make DCGM support both 2.0 and 3.0 through a gflag `dcgm_major_version`, currently we support `--dcgm_major_version=2` and `--dcgm_major_version=3`

Reviewed By: jj10306

Differential Revision: D41588360

