### PR TITLE
dynamically read version from shared libs

### DIFF
--- a/dynolog/src/gpumon/DcgmApiStub.h
+++ b/dynolog/src/gpumon/DcgmApiStub.h
@@ -78,10 +78,10 @@ dcgmReturn_t dcgmGroupAddEntity_stub(
  * Used to create a group of fields and return the handle in dcgmFieldGroupId
  *
  * @param dcgmHandle         IN: DCGM handle
- * @param numFieldIds        IN: Number of field IDs that are being provided in
- * fieldIds[]. Must be between 1 and DCGM_MAX_FIELD_IDS_PER_FIELD_GROUP.
  * @param fieldIds           IN: Field IDs to be added to the newly-created
  * field group
+ * @param profFieldIds       IN: Prof Field IDs to be added to the newly-created
+ * field group, needed for DCGM 3.0
  * @param fieldGroupName     IN: Unique name for this group of fields. This must
  * not be the same as any existing field groups.
  * @param dcgmFieldGroupId  OUT: Handle to the newly-created field group
@@ -97,8 +97,8 @@ dcgmReturn_t dcgmGroupAddEntity_stub(
  */
 dcgmReturn_t dcgmFieldGroupCreate_stub(
     dcgmHandle_t dcgmHandle,
-    int numFieldIds,
-    unsigned short* fieldIds,
+    std::vector<unsigned short> fieldIds,
+    const std::vector<unsigned short>& profFieldIds,
     char* fieldGroupName,
     dcgmFieldGrp_t* dcgmFieldGroupId);
 

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -37,12 +37,14 @@ class DcgmGroupInfo {
 
  private:
   DcgmGroupInfo(
-      std::vector<unsigned short> fields,
+      const std::vector<unsigned short>& fields,
       const std::vector<unsigned short>& prof_fields,
       int updateIntervalMs);
   void init();
   void createGroups();
-  void createFieldGroups(const std::vector<unsigned short>& fields);
+  void createFieldGroups(
+      const std::vector<unsigned short>& fields,
+      const std::vector<unsigned short>& prof_fields);
   void watchFields();
   void watchProfFields(const std::vector<unsigned short>& prof_fields);
 


### PR DESCRIPTION
Summary:
This diff adds dynamic parsing of shared lib libdcgm.so version to identify DCGM versioning, so that it can supports both 2.x and 3.x versions.

It moves the versioning logic from DcgmGroupInfo level to stub library level which encapsulates the complexity

Differential Revision: D41694034

