### PR TITLE
Update ipcfabric to be cpp14 backwards compatible and build with (#693)

### DIFF
--- a/dynolog/src/ipcfabric/CMakeLists.txt
+++ b/dynolog/src/ipcfabric/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 add_library (dynolog_ipcfabric_lib INTERFACE)
+target_compile_options(dynolog_ipcfabric_lib INTERFACE "-DENABLE_IPC_FABRIC")

--- a/dynolog/src/ipcfabric/FabricManager.h
+++ b/dynolog/src/ipcfabric/FabricManager.h
@@ -13,8 +13,20 @@
 #include "dynolog/src/ipcfabric/Endpoint.h"
 #include "dynolog/src/ipcfabric/Utils.h"
 
-namespace dynolog {
-namespace ipcfabric {
+// If building inside Kineto, use its logger, otherwise use glog
+#if defined(KINETO_NAMESPACE) && defined(ENABLE_IPC_FABRIC)
+// We need to include the Logger header here for LOG() macros.
+// However this can alias with other files that include this and
+// also use glog. TODO(T131440833). Thus, the user should also set
+#include "Logger.h" // @manual
+// add to namespace to get logger
+using namespace libkineto;
+
+#else // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+#include <glog/logging.h>
+#endif // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+
+namespace dynolog::ipcfabric {
 
 constexpr int TYPE_SIZE = 32;
 
@@ -30,17 +42,26 @@ struct Message {
       const std::string& type) {
     std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
     memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
-    if constexpr (std::is_same_v<std::string, T>) {
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // if constexpr (std::is_same_v<std::string, T>) {
+    // Without constexpr following is not possible
+#if __cplusplus >= 201703L
+    if constexpr (std::is_same<std::string, T>::value == true) {
       msg->metadata.size = data.size();
       msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
       memcpy(msg->buf.get(), data.c_str(), msg->metadata.size);
     } else {
+#endif
       // ensure memcpy works on T
-      static_assert(std::is_trivially_copyable_v<T>);
+      // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+      // static_assert(std::is_trivially_copyable_v<T>);
+      static_assert(std::is_trivially_copyable<T>::value);
       msg->metadata.size = sizeof(data);
       msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
       memcpy(msg->buf.get(), &data, msg->metadata.size);
+#if __cplusplus >= 201703L
     }
+#endif
     return msg;
   }
 
@@ -53,8 +74,11 @@ struct Message {
     std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
     memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
     // ensure memcpy works on T and U
-    static_assert(std::is_trivially_copyable_v<T>);
-    static_assert(std::is_trivially_copyable_v<U>);
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // static_assert(std::is_trivially_copyable_v<T>);
+    // static_assert(std::is_trivially_copyable_v<U>);
+    static_assert(std::is_trivially_copyable<T>::value);
+    static_assert(std::is_trivially_copyable<U>::value);
     msg->metadata.size = sizeof(data) + sizeof(U) * n;
     msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
     memcpy(msg->buf.get(), &data, msg->metadata.size);
@@ -67,6 +91,7 @@ struct Message {
   std::string src;
 };
 
+#if !defined(KINETO_NAMESPACE) || defined(ENABLE_IPC_FABRIC)
 class FabricManager {
  public:
   FabricManager(const FabricManager&) = delete;
@@ -114,52 +139,57 @@ class FabricManager {
   }
 
   bool recv() {
-    Metadata receive_metadata;
-    std::vector<Payload> peek_payload{
-        Payload(sizeof(struct Metadata), &receive_metadata)};
-    auto peek_ctxt = ep_.buildRcvCtxt(peek_payload);
-    // unix socket only fills the data for the iov that have a non NULL buffer.
-    // Leverage that to read metadata to find buffer size by:
-    //   1) FabricManager assumes metadata in first iov, data in second
-    //   2) peek with only metadata buffer in iov
-    //   3) read metadata
-    //   4) use metadata to find the desired size for the buffer to allocate.
-    //   5) read metadata + data with allocated buffer
-    bool success;
     try {
-      success = ep_.tryPeekMsg(*peek_ctxt);
-    } catch (std::exception& e) {
-      LOG(ERROR) << "Error when tryPeekMsg(): " << e.what();
-      return false;
-    }
-    if (success) {
-      std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
-      msg->metadata = receive_metadata;
-      // new unsigned char[N] guarantees the maximum alignment to hold any
-      // object thus we don't need to worry about memory alignment here see
-      // https://stackoverflow.com/questions/10587879/does-new-char-actually-guarantee-aligned-memory-for-a-class-type
-      // and
-      // https://stackoverflow.com/questions/39668561/allocate-n-bytes-by-new-and-fill-it-with-any-type
-      msg->buf = std::unique_ptr<unsigned char[]>(
-          new unsigned char[receive_metadata.size]);
-      msg->src = std::string(ep_.getName(*peek_ctxt));
-      std::vector<Payload> payload{
-          Payload(sizeof(struct Metadata), (void*)&msg->metadata),
-          Payload(receive_metadata.size, msg->buf.get())};
-      auto recv_ctxt = ep_.buildRcvCtxt(payload);
-
-      // the deque can potentially grow very large
+      Metadata receive_metadata;
+      std::vector<Payload> peek_payload{
+          Payload(sizeof(struct Metadata), &receive_metadata)};
+      auto peek_ctxt = ep_.buildRcvCtxt(peek_payload);
+      // unix socket only fills the data for the iov that have a non NULL
+      // buffer. Leverage that to read metadata to find buffer size by:
+      //   1) FabricManager assumes metadata in first iov, data in second
+      //   2) peek with only metadata buffer in iov
+      //   3) read metadata
+      //   4) use metadata to find the desired size for the buffer to allocate.
+      //   5) read metadata + data with allocated buffer
+      bool success;
       try {
-        success = ep_.tryRcvMsg(*recv_ctxt);
+        success = ep_.tryPeekMsg(*peek_ctxt);
       } catch (std::exception& e) {
-        LOG(ERROR) << "Error when tryRcvMsg(): " << e.what();
+        LOG(ERROR) << "Error when tryPeekMsg(): " << e.what();
         return false;
       }
       if (success) {
-        std::lock_guard<std::mutex> wguard(dequeLock_);
-        message_deque_.push_back(std::move(msg));
-        return true;
+        std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+        msg->metadata = receive_metadata;
+        // new unsigned char[N] guarantees the maximum alignment to hold any
+        // object thus we don't need to worry about memory alignment here see
+        // https://stackoverflow.com/questions/10587879/does-new-char-actually-guarantee-aligned-memory-for-a-class-type
+        // and
+        // https://stackoverflow.com/questions/39668561/allocate-n-bytes-by-new-and-fill-it-with-any-type
+        msg->buf = std::unique_ptr<unsigned char[]>(
+            new unsigned char[receive_metadata.size]);
+        msg->src = std::string(ep_.getName(*peek_ctxt));
+        std::vector<Payload> payload{
+            Payload(sizeof(struct Metadata), (void*)&msg->metadata),
+            Payload(receive_metadata.size, msg->buf.get())};
+        auto recv_ctxt = ep_.buildRcvCtxt(payload);
+
+        // the deque can potentially grow very large
+        try {
+          success = ep_.tryRcvMsg(*recv_ctxt);
+        } catch (std::exception& e) {
+          LOG(ERROR) << "Error when tryRcvMsg(): " << e.what();
+          return false;
+        }
+        if (success) {
+          std::lock_guard<std::mutex> wguard(dequeLock_);
+          message_deque_.push_back(std::move(msg));
+          return true;
+        }
       }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error in recv(): " << e.what();
+      return false;
     }
     return false;
   }
@@ -193,5 +223,32 @@ class FabricManager {
   std::mutex dequeLock_;
 };
 
-} // namespace ipcfabric
-} // namespace dynolog
+#else
+
+// Adds an empty implementation so compilation works.
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    return nullptr;
+  }
+
+  bool sync_send(
+      const Message& msg,
+      const std::string& dest_name,
+      int num_retries = 10,
+      int sleep_time_us = 10000) {
+    return false;
+  }
+
+  std::unique_ptr<Message> poll_recv(int max_retries, int sleep_time_us) {
+    return nullptr;
+  }
+};
+
+#endif // !KINETO_NAMESPACE || ENABLE_IPC_FABRIC
+
+} // namespace dynolog::ipcfabric


### PR DESCRIPTION
Summary:
This PR is basically pulling in the changes to ipcfabric in Kineto repo.
Yes, we do not want two copies of this module so we will be removing the kineto copy and making a git submodule dependency on dyno.

Step 1 is to sync the changes in Kineto making it backwards compatible with C++14
X-link: https://github.com/pytorch/kineto/pull/693

Differential Revision: D41878371

