### PR TITLE
add docs for DCGM 2.0 and 3.0 and scuba logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ I20221208 15:29:34.731690 3345417 Logger.cpp:56] time = 1969-12-31T16:00:00.000Z
 
 ### GPU Monitoring<!-- {#gpu-monitoring} -->
 
-Dynolog uses NVIDIA Datacenter GPU Manager [DCGM](https://developer.nvidia.com/dcgm) to monitor NVIDIA GPUs today. DCGM supports GPU models from Kepler/Volta V100 onwards, please see [this page]([https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#supported-platforms](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#supported-platforms) for details.
+Dynolog uses NVIDIA Datacenter GPU Manager [DCGM](https://developer.nvidia.com/dcgm) to monitor NVIDIA GPUs today. DCGM supports GPU models from Kepler/Volta V100 onwards, please see [this page]([https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#supported-platforms](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#supported-platforms) for details. Currently Dynolog dynamically supports both DCGM 2.x and DCGM 3.x based on the version of the shared library libdcgm.so.
 
 **Prerequisite:** Install DCGM on your system following the instructions [here]([https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#ubuntu-lts-and-debian](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#ubuntu-lts-and-debian)). After the installation please make sure to initialize the dcgm service using -
 
@@ -236,12 +236,12 @@ By default dynolog will save monitoring metrics to the std output -
 I20220721 23:42:34.141104 3632432 Logger.cpp:38] time = 2022-07-21T23:42:34.141Z data = {"cpu_i":"71.342" ...
 ```
 
-Dynolog includes an abstract Logger class that can be specialized for different logging destinations. Currently, Dynolog support logging to Meta ODS datastore, instructions can be found in [docs/logging_to_ods.md](docs/logging_to_ods.md). Dynolog team is happy to support new loggers.
+Dynolog includes an abstract Logger class that can be specialized for different logging destinations. Currently, Dynolog support logging to Meta ODS datastore, and Meta Scuba data system, instructions can be found in [docs/logging_to_ods.md](docs/logging_to_ods.md) and [docs/logging_to_scuba.md](docs/logging_to_scuba.md). Dynolog team is happy to support new loggers.
 
 ## Releases<!-- {#release} -->
-The current 0.0.2 release supports the following-
+The current 0.1.0 release supports the following-
 * CPU utilization and network utilization metrics.
-* GPU performance monitoring for NVIDIA GPUs using DCGM.
+* GPU performance monitoring for NVIDIA GPUs using DCGM 2.x and 3.x.
 * Capability to interface with pytorch profiler and support remote on-demand tracing.
 * CPU performance counters (PMUs) are still a work in progress at this point.
 

--- a/docs/logging_to_scuba.md
+++ b/docs/logging_to_scuba.md
@@ -1,0 +1,21 @@
+# Logging to Scuba
+
+[Scuba](https://research.facebook.com/publications/scuba-diving-into-data-at-facebook/) is the data management system Meta uses for most real-time analysis. Scuba is a fast, scalable, distributed, in-memory database built at Meta, and supports logging from the public internet through Graph API. The open source Dynolog supports a Graph API based Scuba Logger with user specified access token and certificate.
+
+## Scuba Table and Scribe Category
+
+Scuba listens to [Scribe](https://engineering.fb.com/2019/10/07/data-infrastructure/scribe/), a distributed, buffered queueing system for data ingestion. To create a Scuba table, we first need to register a Scribe category that Scuba will listen to, the scribe category name will be following perfpipe_<scuba_table_name>.
+
+Scuba will listen to the scribe category and dynamically generates the Scuba table schema based on the data schema it receives.
+
+# How to enable Scuba logging
+
+To enable Scuba logging, users will need to obtain an access token and category id, create a scribe category, and passes these through the required gflags, set the --use_scuba flag to true, and pass in the scribe category name with --scribe_category flag.
+
+## Supported/Required Gflags
+
+* `--use_scuba` (default=false): enable Scuba logging.
+* `--access_token` (required): the access token string to validate the Graph API access.
+* `--category_id` (required): the category id the Scuba logger belongs to, used for admission control and identifying data owners.
+* `--certificate_path` (default=/etc/ssl/certs/ca-certificates.crt): path to the SSL certificate on the host that the Scuba logger runs on.
+* `--scribe_category` (required): the scribe category name that sends data and generates the Scuba table.

--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -132,7 +132,7 @@ void gpu_monitor_loop() {
   std::unique_ptr<gpumon::DcgmGroupInfo> dcgm = gpumon::DcgmGroupInfo::factory(
       gpumon::FLAGS_dcgm_fields, FLAGS_dcgm_reporting_interval_s * 1000);
 
-  auto logger = getLogger(FLAGS_fair_scribe_category);
+  auto logger = getLogger(FLAGS_scribe_category);
 
   LOG(INFO) << "Running DCGM loop : interval = "
             << FLAGS_dcgm_reporting_interval_s << " s.";

--- a/dynolog/src/ScubaLogger.cpp
+++ b/dynolog/src/ScubaLogger.cpp
@@ -19,9 +19,9 @@ namespace dynolog {
 constexpr int HOSTNAME_MAX = 50;
 constexpr char kScubaUrl[] = "https://graph.facebook.com/scribe_logs";
 DEFINE_string(
-    fair_scribe_category,
+    scribe_category,
     "perfpipe_fair_cluster_gpu_stats",
-    "The scribe category name for fair gpu stats, used for scuba logging");
+    "The scribe category name for scuba logging");
 
 ScubaLogger::ScubaLogger(const std::string& scribe_category)
     : scribe_category_(scribe_category) {

--- a/dynolog/src/ScubaLogger.h
+++ b/dynolog/src/ScubaLogger.h
@@ -9,7 +9,7 @@
 
 namespace dynolog {
 
-DECLARE_string(fair_scribe_category);
+DECLARE_string(scribe_category);
 
 class ScubaLogger final : public Logger {
  public:


### PR DESCRIPTION
Summary:
This diff
- Adds DCGM 2.X and 3.X support in README
- bump dynolog version to 0.1.0 in README
- change scribe category flag to be more generic name than for fair

Differential Revision:
D42015665

LaMa Project: L1137347

