### PR TITLE
Generalize IPCMonitor to facilitate different usecases of processing messages

### DIFF
--- a/dynolog/src/tracing/IPCMonitor.h
+++ b/dynolog/src/tracing/IPCMonitor.h
@@ -15,11 +15,12 @@ class IPCMonitor {
  public:
   using FabricManager = dynolog::ipcfabric::FabricManager;
   IPCMonitor(const std::string& ipc_fabric_name = "dynolog");
+  virtual ~IPCMonitor(){};
 
   void loop();
 
  public:
-  void processMsg(std::unique_ptr<ipcfabric::Message> msg);
+  virtual void processMsg(std::unique_ptr<ipcfabric::Message> msg);
   void getLibkinetoOnDemandRequest(std::unique_ptr<ipcfabric::Message> msg);
   void registerLibkinetoContext(std::unique_ptr<ipcfabric::Message> msg);
 


### PR DESCRIPTION
Summary: Generalize oss dyno's IPCMonitor to faciliate processing of messages

Differential Revision: D42048255

