### PR TITLE
Change dynolog's gputrace jobId from integer to string

### DIFF
--- a/dynolog/src/LibkinetoConfigManager.cpp
+++ b/dynolog/src/LibkinetoConfigManager.cpp
@@ -127,7 +127,7 @@ void LibkinetoConfigManager::runGc() {
 }
 
 int32_t LibkinetoConfigManager::registerLibkinetoContext(
-    int64_t jobId,
+    const std::string& jobId,
     int32_t pid,
     int32_t gpu) {
   std::lock_guard<std::mutex> guard(mutex_);
@@ -144,7 +144,7 @@ int32_t LibkinetoConfigManager::registerLibkinetoContext(
 // LibkinetoConfigManager::run() periodically scans the table
 // for processes no longer calling this function and removes them.
 std::string LibkinetoConfigManager::obtainOnDemandConfig(
-    int64_t jobId,
+    const std::string& jobId,
     const std::vector<int32_t>& pids,
     int32_t configType) {
   VLOG(2) << fmt::format(
@@ -229,7 +229,7 @@ void LibkinetoConfigManager::setOnDemandConfigForProcess(
 // For example, when specifying a pid with 8 child processes,
 // the limit argument can be used to profile 2 of those.
 GpuProfilerResult LibkinetoConfigManager::setOnDemandConfig(
-    int64_t jobId,
+    const std::string& jobId,
     const std::set<int32_t>& pids,
     const std::string& config,
     int32_t configType /* LibkinetoConfigType */,
@@ -288,7 +288,7 @@ GpuProfilerResult LibkinetoConfigManager::setOnDemandConfig(
   return res;
 }
 
-int LibkinetoConfigManager::processCount(int64_t jobId) const {
+int LibkinetoConfigManager::processCount(const std::string& jobId) const {
   int count = 0;
   std::lock_guard<std::mutex> guard(mutex_);
   auto it = jobs_.find(jobId);

--- a/dynolog/src/LibkinetoConfigManager.h
+++ b/dynolog/src/LibkinetoConfigManager.h
@@ -25,7 +25,8 @@ class LibkinetoConfigManager {
   LibkinetoConfigManager();
   virtual ~LibkinetoConfigManager();
 
-  int32_t registerLibkinetoContext(int64_t jobId, int32_t pid, int32_t gpu);
+  int32_t
+  registerLibkinetoContext(const std::string& jobId, int32_t pid, int32_t gpu);
   static std::shared_ptr<LibkinetoConfigManager> getInstance();
 
   std::string getBaseConfig() {
@@ -34,12 +35,12 @@ class LibkinetoConfigManager {
   }
 
   std::string obtainOnDemandConfig(
-      int64_t jobId,
+      const std::string& jobId,
       const std::vector<int32_t>& pids,
       int32_t configType);
 
   GpuProfilerResult setOnDemandConfig(
-      int64_t jobId,
+      const std::string& jobId,
       const std::set<int32_t>& pids,
       const std::string& config,
       int32_t configType,
@@ -47,7 +48,7 @@ class LibkinetoConfigManager {
 
   // Return the number of active libkineto processes
   // with the given Chronos / Tangram Job Id
-  int processCount(int64_t jobId) const;
+  int processCount(const std::string& jobId) const;
 
  protected:
   struct LibkinetoProcess {
@@ -68,12 +69,12 @@ class LibkinetoConfigManager {
 
   // Map of pid ancestry -> LibkinetoProcess
   using ProcessMap = std::map<std::set<int32_t>, LibkinetoProcess>;
-  std::map<int64_t, ProcessMap> jobs_;
+  std::map<std::string, ProcessMap> jobs_;
 
   // Map of gpu id -> pids
   using InstancesPerGpuMap = std::map<int32_t, std::set<int32_t>>;
   // Job id -> InstancesPerGpu
-  std::map<int64_t, InstancesPerGpuMap> jobInstancesPerGpu_;
+  std::map<std::string, InstancesPerGpuMap> jobInstancesPerGpu_;
   mutable std::mutex mutex_;
 
   void setOnDemandConfigForProcess(

--- a/dynolog/src/ServiceHandler.cpp
+++ b/dynolog/src/ServiceHandler.cpp
@@ -18,7 +18,13 @@ GpuProfilerResult ServiceHandler::setKinetOnDemandRequest(
     const std::string& config,
     int limit) {
   return LibkinetoConfigManager::getInstance()->setOnDemandConfig(
-      job_id, pids, config, (int)LibkinetoConfigType::ACTIVITIES, limit);
+      // Temporarily cast to string while we iteratively migrate to string job
+      // id
+      std::to_string(job_id),
+      pids,
+      config,
+      (int)LibkinetoConfigType::ACTIVITIES,
+      limit);
 }
 
 } // namespace dynolog

--- a/dynolog/src/tracing/IPCMonitor.cpp
+++ b/dynolog/src/tracing/IPCMonitor.cpp
@@ -27,7 +27,7 @@ IPCMonitor::IPCMonitor(const std::string& ipc_fabric_name) {
   ipc_manager_ = FabricManager::factory(ipc_fabric_name);
   // below ensures singleton exists
   LOG(INFO) << "Kineto config manager : active processes = "
-            << LibkinetoConfigManager::getInstance()->processCount(0);
+            << LibkinetoConfigManager::getInstance()->processCount("0");
 }
 
 void IPCMonitor::loop() {
@@ -71,7 +71,7 @@ void IPCMonitor::getLibkinetoOnDemandRequest(
   std::vector<int32_t> pids(req->pids, req->pids + req->n);
   try {
     ret_config = LibkinetoConfigManager::getInstance()->obtainOnDemandConfig(
-        req->jobid, pids, req->type);
+        std::to_string(req->jobid), pids, req->type);
     VLOG(0) << "getLibkinetoOnDemandRequest() : job id " << req->jobid
             << " pids = " << pids[0];
   } catch (const std::runtime_error& ex) {
@@ -98,7 +98,7 @@ void IPCMonitor::registerLibkinetoContext(
   int32_t size = -1;
   try {
     size = LibkinetoConfigManager::getInstance()->registerLibkinetoContext(
-        ctxt->jobid, ctxt->pid, ctxt->gpu);
+        std::to_string(ctxt->jobid), ctxt->pid, ctxt->gpu);
   } catch (const std::runtime_error& ex) {
     LOG(ERROR) << "Kineto config manager exception : " << ex.what();
   }

--- a/dynolog/tests/tracing/IPCMonitorTest.cpp
+++ b/dynolog/tests/tracing/IPCMonitorTest.cpp
@@ -80,7 +80,7 @@ TEST(IPCMonitorTest, LibkinetoRegisterAndOndemandTest) {
   } else {
     // Receiver side - IPC Monitor
     auto monitor = std::make_unique<IPCMonitor>("dynolog_unittest");
-    EXPECT_EQ(LibkinetoConfigManager::getInstance()->processCount(0), 0);
+    EXPECT_EQ(LibkinetoConfigManager::getInstance()->processCount("0"), 0);
 
     /* sleep override */
     std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -102,7 +102,10 @@ TEST(IPCMonitorTest, LibkinetoRegisterAndOndemandTest) {
 
     monitor->processMsg(std::move(msg));
 
-    EXPECT_EQ(LibkinetoConfigManager::getInstance()->processCount(kJobID), 1);
+    EXPECT_EQ(
+        LibkinetoConfigManager::getInstance()->processCount(
+            std::to_string(kJobID)),
+        1);
 
     // Wait for child thread to either change state or stopped.
     int wstatus;


### PR DESCRIPTION
Summary: Server side (dynolog) changes to prepare for supporting string job ids

Reviewed By: haowangludx

Differential Revision: D41559928

