### PR TITLE
Update unittests in hbt/src/perf_event

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -483,7 +483,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                "retired_instructions",
                EventExtraAttr{},
                {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 
@@ -500,7 +500,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                "cpu_cycles",
                EventExtraAttr{},
                {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 
@@ -527,7 +527,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                    "retired_instructions",
                    EventExtraAttr{},
                    {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 
@@ -572,7 +572,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                "DynoPerfCounter::DRAM_ACCESS_READS",
                EventExtraAttr{},
                {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 
@@ -611,7 +611,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                    "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
                    EventExtraAttr{},
                    {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 
@@ -649,7 +649,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                    "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
                    EventExtraAttr{},
                    {}}}}},
-      0,
+      100'000'000,
       System::Permissions{},
       std::vector<std::string>{}));
 

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -452,6 +452,7 @@ struct GroupReadValues {
     if (t->time_enabled == 0) {
       return 0;
     }
+
     return static_cast<uint64_t>(
         static_cast<double>(t->count[i]) *
         static_cast<double>(t->time_enabled) /

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -38,6 +38,7 @@ TEST(PerCpuThreadSwitchGenerator, SmokeTest) {
 
   g.open(2);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -66,6 +67,7 @@ TEST(PerCpuCountSampleGenerator, SmokeTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -140,6 +142,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Open without pinning the events.
   g.open(false);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -255,6 +258,7 @@ TEST(BPerfCountReader, SmokeTest) {
       std::make_unique<FdWrapper>(cgroup_path));
 
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -311,6 +315,7 @@ TEST(PerCpuCountSampleGenerator, TracePointTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -338,6 +343,7 @@ TEST(PerCpuDummyGenerator, SmokeTest) {
 
   g.open();
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.now();
   g.tstampFromTsc(1000000);
@@ -380,6 +386,8 @@ TEST(CpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   sleep(1);
   g.disable();
   // we should receive a itrace start perf event
@@ -435,6 +443,8 @@ TEST(PerCpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   *phase = 1;
   while (*phase == 1)
     ;


### PR DESCRIPTION
Summary:
Many of the tests require running as root, so these test definitions have been updated to use `sudo_cpp_unittests` to allow for normal testing with `buck2 test`.

`BuiltinMetricsTest -- Init` was updated to account for some counters have a default sampling period of 0.

`BuiltinMetricsTest, PerfEventAttrPreciseJson` was updated to account for that newer Intel Processors do not have "UOPS_RETIRED.ALL" and when they do not "UOPS_RETIRED.RETIRE_SLOTS" lacks the `pebs` feature and therefore not precise.

"CpuEventsGroup.h:getCount()" was modified check for time_running == 0 as there were occasionaly failures from "BPerfCountReader --SmokeTest" due to USAN on a nan being converted to unit. (nan was from dividing by zero.)

Differential Revision: D42173995

