### PR TITLE
Download and generate Intel events from Github: NHM-EX, SNB

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -153,9 +153,10 @@ bool BPerfEventsGroup::reenable_() {
 
 [[nodiscard]] bool BPerfEventsGroup::enable() {
   int attr_map_fd, err;
-  struct bperf_attr_map_elem entry = {};
-  struct bpf_perf_event_value val = {};
   bool success = false;
+  struct bperf_attr_map_elem entry = {};
+  std::vector<struct bpf_perf_event_value> val;
+  val.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE, {});
 
   if (enabled_) {
     HBT_LOG_WARNING() << "BPerfEventsGroup is already enabled";
@@ -212,10 +213,15 @@ bool BPerfEventsGroup::reenable_() {
       break;
     case BPerfEventType::Cgroup:
       output_fd_ = ::bpf_map_get_fd_by_id(entry.cgroup_output_map_id);
-      err = ::bpf_map_lookup_elem(output_fd_, &id_, &val);
+      err = ::bpf_map_lookup_elem(output_fd_, &id_, val.data());
       if (err) {
-        ::bpf_map_update_elem(output_fd_, &id_, &val, BPF_ANY);
+        err = ::bpf_map_update_elem(output_fd_, &id_, val.data(), BPF_ANY);
+        if (err) {
+          HBT_LOG_ERROR() << "Failed to initlize map elem: " << err;
+          goto out;
+        }
       }
+
       break;
   }
 
@@ -348,14 +354,16 @@ out:
     struct bpf_perf_event_value* output,
     bool skip_offset) {
   auto event_cnt = confs_.size();
-  struct bpf_perf_event_value values[cpu_cnt_ * BPERF_MAX_GROUP_SIZE];
+  std::vector<struct bpf_perf_event_value> values;
+  values.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE);
 
   if (!enabled_) {
     return -1;
   }
 
   syncGlobal_();
-  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values); ret) {
+  HBT_LOG_WARNING() << "id_:" << id_;
+  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values.data()); ret) {
     HBT_LOG_ERROR() << "cannot look up key " << id_
                     << " from output map. Return value: " << ret;
     return -1;

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -449,9 +449,10 @@ struct GroupReadValues {
   uint64_t getCount(size_t i) const {
     HBT_DCHECK_LE(t->time_running, t->time_enabled);
     HBT_ARG_CHECK_LT(i, getNumEvents()) << "Index out of range";
-    if (t->time_enabled == 0) {
+    if (t->time_enabled == 0 || t->time_running == 0) {
       return 0;
     }
+
     return static_cast<uint64_t>(
         static_cast<double>(t->count[i]) *
         static_cast<double>(t->time_enabled) /

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -10,21 +10,21 @@
 
 namespace facebook::hbt::perf_event::generated {
 
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 
 namespace goldmont_core_v13 {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace goldmont_core_v13
 
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 
 namespace ivybridge_core_v21 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -149,10 +149,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(42, 0x13): // fall-through
     case toCpuKey(42, 0x14): // fall-through
     case toCpuKey(42, 0x15): // fall-through
-      // from sandybridge_core_v16.json
-      sandybridge_core_v16::addEvents(pmu_manager);
-      // from sandybridge_uncore_v16.json
-      sandybridge_uncore_v16::addEvents(pmu_manager);
+      // from sandybridge_core.json
+      sandybridge_core::addEvents(pmu_manager);
+      // from sandybridge_uncore.json
+      sandybridge_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(46, 0x0): // fall-through
@@ -171,8 +171,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(46, 0x13): // fall-through
     case toCpuKey(46, 0x14): // fall-through
     case toCpuKey(46, 0x15): // fall-through
-      // from NehalemEX_core_V2.json
-      nehalemex_core_v2::addEvents(pmu_manager);
+      // from NehalemEX_core.json
+      nehalemex_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(58, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from NehalemEX_core_V2.json (553 events).
+    Events from NehalemEX_core.json (553 events).
 
     Supported SKUs:
         - Arch: x86, Model: NHM-EX id: 46
@@ -5085,8 +5085,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.IO_CSR_MMIO",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x8033}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5098,8 +5098,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_NO_OTHER_CORE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x133}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5111,8 +5111,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x233}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5124,8 +5124,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x433}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5163,8 +5163,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LOCAL_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x4033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5202,8 +5202,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1033}},
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5215,8 +5215,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x833}},
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5228,8 +5228,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x2033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7304,5 +7304,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_core_v16.json (406 events).
+    Events from sandybridge_core.json (406 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -88,7 +88,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x03, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Cases when loads get true Block-on-Store blocking code preventing store forwarding.)",
-      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceeding smaller uncompleted store.  See the table of not supported store forwards in the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
+      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceding smaller uncompleted store.  See the table of not supported store forwards in the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -235,8 +235,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -320,8 +320,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "FP_COMP_OPS_EXE.X87",
       EventDef::Encoding{
           .code = 0x10, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -816,8 +816,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.PENDING",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(L1D miss oustandings duration in cycles.)",
-      R"(L1D miss oustandings duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -856,8 +856,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.FB_FULL",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1025,7 +1025,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x20, .cmask = 1, .msr_values = {0}},
       R"(Performance sensitive flags-merging uops added by Sandy Bridge u-arch.)",
-      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.)",
+      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1037,7 +1037,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x40, .cmask = 0, .msr_values = {0}},
       R"(Cycles with at least one slow LEA uop being allocated.)",
-      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
+      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1345,8 +1345,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1357,8 +1357,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1373,8 +1373,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1409,8 +1409,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_MITE_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1445,8 +1445,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1457,8 +1457,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2405,8 +2405,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_REQUESTS.DEMAND_CODE_RD",
       EventDef::Encoding{
           .code = 0xB0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cacheable and noncachaeble code read requests.)",
-      R"(Cacheable and noncachaeble code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3194,7 +3194,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -3206,7 +3206,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -4136,8 +4136,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.COREWB.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10008}},
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5064,7 +5064,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.ANY_REQUEST.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80408fff}},
-      R"( REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       R"(This event counts any requests that miss the LLC where the data was returned from local DRAM)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5077,8 +5077,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10433}},
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5090,8 +5090,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN_SOCKET.LLC_MISS_LOCAL.ANY_LLC_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x17004001b3}},
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5103,8 +5103,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400004}},
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5116,8 +5116,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_HIT_M.HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1000040002}},
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5129,8 +5129,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400010}},
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5142,8 +5142,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10040}},
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5155,8 +5155,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400040}},
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5168,8 +5168,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5181,8 +5181,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5194,8 +5194,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5207,8 +5207,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5216,5 +5216,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_uncore_v16.json (34 events).
+    Events from sandybridge_uncore.json (34 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -427,5 +427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -38,6 +38,7 @@ TEST(PerCpuThreadSwitchGenerator, SmokeTest) {
 
   g.open(2);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -66,6 +67,7 @@ TEST(PerCpuCountSampleGenerator, SmokeTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -140,6 +142,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Open without pinning the events.
   g.open(false);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -255,6 +258,7 @@ TEST(BPerfCountReader, SmokeTest) {
       std::make_unique<FdWrapper>(cgroup_path));
 
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -311,6 +315,7 @@ TEST(PerCpuCountSampleGenerator, TracePointTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -338,6 +343,7 @@ TEST(PerCpuDummyGenerator, SmokeTest) {
 
   g.open();
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.now();
   g.tstampFromTsc(1000000);
@@ -380,6 +386,8 @@ TEST(CpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   sleep(1);
   g.disable();
   // we should receive a itrace start perf event
@@ -435,6 +443,8 @@ TEST(PerCpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   *phase = 1;
   while (*phase == 1)
     ;


### PR DESCRIPTION
Summary:
This is an intermidate diff to keep ShipIt from OOMing, full summary of changes in D42151461.

Intel has retired download.01.org json events and moved them over to github with several changes.
* Version json files no longer exist
* Json files now included a header and event section.
* List of events in the Event section is equivalent to old files
* mapfiles.csv has three new sections: Core Type, Native Model ID, and Core Role Name

Differential Revision: D42201402

