### PR TITLE
[dyno] Fix iteration tracing command 

### DIFF
--- a/cli/src/commands/gputrace.rs
+++ b/cli/src/commands/gputrace.rs
@@ -27,17 +27,17 @@ pub fn run_gputrace(
 ) -> Result<()> {
     let trigger_config = if iterations > 0 {
         format!(
-            r#"PROFILE_START_ITERATION_ROUNDUP={}\nACTIVITIES_ITERATIONS={}"#,
+            r#"PROFILE_START_ITERATION=0\nPROFILE_START_ITERATION_ROUNDUP={}\nACTIVITIES_ITERATIONS={}"#,
             profile_start_iteration_roundup, iterations
         )
     } else {
-        format!(r#"ACTIVITIES_DURATION_MSECS={}"#, duration_ms)
+        format!(
+            r#"PROFILE_START_TIME={}\nACTIVITIES_DURATION_MSECS={}"#,
+            profile_start_time, duration_ms
+        )
     };
 
-    let kineto_config = format!(
-        r#"PROFILE_START_TIME={}\nACTIVITIES_LOG_FILE={}\n{}"#,
-        profile_start_time, log_file, trigger_config
-    );
+    let kineto_config = format!(r#"ACTIVITIES_LOG_FILE={}\n{}"#, log_file, trigger_config);
 
     println!("Kineto config = \n{}", kineto_config);
 

--- a/scripts/pytorch/xor.py
+++ b/scripts/pytorch/xor.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+class Xor(nn.Module):
+    def __init__(self):
+        super(Xor, self).__init__()
+        self.fc1 = nn.Linear(2, 3, True)
+        self.fc2 = nn.Linear(3, 1, True)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = torch.sigmoid(x)
+        x = self.fc2(x)
+        return x
+
+
+def train_xor():
+    xor = Xor()
+    xor.to("cuda:0")
+    inputs = torch.Tensor([[0, 0], [0, 1], [1, 0], [1, 1]])
+    targets = torch.Tensor([0, 1, 1, 0]).view(-1, 1)
+
+    criterion = nn.MSELoss()
+    optimizer = optim.SGD(xor.parameters(), lr=0.01)
+    xor.train()
+
+    for idx in range(0, 15001):
+
+        for input, target in zip(inputs, targets):
+            input, target = input.to(device="cuda:0"), target.to(device="cuda:0")
+            optimizer.zero_grad()
+            output = xor(input)
+
+            loss = criterion(output, target)
+            loss.backward()
+            optimizer.step()
+
+        if idx % 5000 == 0:
+            print(f"Epoch {idx} Loss: {loss.data.cpu().numpy()}")
+
+
+train_xor()


### PR DESCRIPTION
Fixes issue with setting the right options in kineto configuration.

Test Plan:
Build pytorch and run sample application (see docs/pytorch for instructions)
Run dynolog enabling ipc monitor

Trigger trace
` dyno gputrace --profiler_iterations 10`