### PR TITLE
Download and generate Intel events from Github: BDX, BDW, BDW-BE

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -153,9 +153,10 @@ bool BPerfEventsGroup::reenable_() {
 
 [[nodiscard]] bool BPerfEventsGroup::enable() {
   int attr_map_fd, err;
-  struct bperf_attr_map_elem entry = {};
-  struct bpf_perf_event_value val = {};
   bool success = false;
+  struct bperf_attr_map_elem entry = {};
+  std::vector<struct bpf_perf_event_value> val;
+  val.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE, {});
 
   if (enabled_) {
     HBT_LOG_WARNING() << "BPerfEventsGroup is already enabled";
@@ -212,10 +213,15 @@ bool BPerfEventsGroup::reenable_() {
       break;
     case BPerfEventType::Cgroup:
       output_fd_ = ::bpf_map_get_fd_by_id(entry.cgroup_output_map_id);
-      err = ::bpf_map_lookup_elem(output_fd_, &id_, &val);
+      err = ::bpf_map_lookup_elem(output_fd_, &id_, val.data());
       if (err) {
-        ::bpf_map_update_elem(output_fd_, &id_, &val, BPF_ANY);
+        err = ::bpf_map_update_elem(output_fd_, &id_, val.data(), BPF_ANY);
+        if (err) {
+          HBT_LOG_ERROR() << "Failed to initlize map elem: " << err;
+          goto out;
+        }
       }
+
       break;
   }
 
@@ -348,14 +354,16 @@ out:
     struct bpf_perf_event_value* output,
     bool skip_offset) {
   auto event_cnt = confs_.size();
-  struct bpf_perf_event_value values[cpu_cnt_ * BPERF_MAX_GROUP_SIZE];
+  std::vector<struct bpf_perf_event_value> values;
+  values.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE);
 
   if (!enabled_) {
     return -1;
   }
 
   syncGlobal_();
-  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values); ret) {
+  HBT_LOG_WARNING() << "id_:" << id_;
+  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values.data()); ret) {
     HBT_LOG_ERROR() << "cannot look up key " << id_
                     << " from output map. Return value: " << ret;
     return -1;

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -449,9 +449,10 @@ struct GroupReadValues {
   uint64_t getCount(size_t i) const {
     HBT_DCHECK_LE(t->time_running, t->time_enabled);
     HBT_ARG_CHECK_LT(i, getNumEvents()) << "Index out of range";
-    if (t->time_enabled == 0) {
+    if (t->time_enabled == 0 || t->time_running == 0) {
       return 0;
     }
+
     return static_cast<uint64_t>(
         static_cast<double>(t->count[i]) *
         static_cast<double>(t->time_enabled) /

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -14,9 +14,9 @@ namespace nehalemex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace nehalemex_core
 
-namespace goldmont_core_v13 {
+namespace goldmont_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace goldmont_core_v13
+} // namespace goldmont_core
 
 namespace sandybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -26,21 +26,21 @@ namespace sandybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace sandybridge_uncore
 
-namespace ivybridge_core_v21 {
+namespace ivybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace ivybridge_core_v21
+} // namespace ivybridge_core
 
-namespace ivybridge_uncore_v21 {
+namespace ivybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace ivybridge_uncore_v21
+} // namespace ivybridge_uncore
 
-namespace haswellx_core_v20 {
+namespace haswellx_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace haswellx_core_v20
+} // namespace haswellx_core
 
-namespace haswellx_uncore_v20 {
+namespace haswellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace haswellx_uncore_v20
+} // namespace haswellx_uncore
 
 namespace broadwell_core_v25 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -191,10 +191,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(58, 0x13): // fall-through
     case toCpuKey(58, 0x14): // fall-through
     case toCpuKey(58, 0x15): // fall-through
-      // from ivybridge_core_v21.json
-      ivybridge_core_v21::addEvents(pmu_manager);
-      // from ivybridge_uncore_v21.json
-      ivybridge_uncore_v21::addEvents(pmu_manager);
+      // from ivybridge_core.json
+      ivybridge_core::addEvents(pmu_manager);
+      // from ivybridge_uncore.json
+      ivybridge_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(61, 0x0): // fall-through
@@ -235,10 +235,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(63, 0x13): // fall-through
     case toCpuKey(63, 0x14): // fall-through
     case toCpuKey(63, 0x15): // fall-through
-      // from haswellx_core_v20.json
-      haswellx_core_v20::addEvents(pmu_manager);
-      // from haswellx_uncore_v20.json
-      haswellx_uncore_v20::addEvents(pmu_manager);
+      // from haswellx_core.json
+      haswellx_core::addEvents(pmu_manager);
+      // from haswellx_uncore.json
+      haswellx_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(71, 0x0): // fall-through
@@ -399,8 +399,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(92, 0x13): // fall-through
     case toCpuKey(92, 0x14): // fall-through
     case toCpuKey(92, 0x15): // fall-through
-      // from goldmont_core_v13.json
-      goldmont_core_v13::addEvents(pmu_manager);
+      // from goldmont_core.json
+      goldmont_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(94, 0x0): // fall-through
@@ -441,8 +441,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(95, 0x13): // fall-through
     case toCpuKey(95, 0x14): // fall-through
     case toCpuKey(95, 0x15): // fall-through
-      // from goldmont_core_v13.json
-      goldmont_core_v13::addEvents(pmu_manager);
+      // from goldmont_core.json
+      goldmont_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(126, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -42,29 +42,29 @@ namespace haswellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace haswellx_uncore
 
-namespace broadwell_core_v25 {
+namespace broadwell_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwell_core_v25
+} // namespace broadwell_core
 
-namespace broadwell_uncore_v25 {
+namespace broadwell_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwell_uncore_v25
+} // namespace broadwell_uncore
 
-namespace broadwellx_core_v14 {
+namespace broadwellx_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellx_core_v14
+} // namespace broadwellx_core
 
-namespace broadwellx_uncore_v14 {
+namespace broadwellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellx_uncore_v14
+} // namespace broadwellx_uncore
 
-namespace broadwellde_core_v7 {
+namespace broadwellde_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellde_core_v7
+} // namespace broadwellde_core
 
-namespace broadwellde_uncore_v7 {
+namespace broadwellde_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellde_uncore_v7
+} // namespace broadwellde_uncore
 
 namespace skylake_core_v48 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -213,10 +213,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(61, 0x13): // fall-through
     case toCpuKey(61, 0x14): // fall-through
     case toCpuKey(61, 0x15): // fall-through
-      // from broadwell_core_v25.json
-      broadwell_core_v25::addEvents(pmu_manager);
-      // from broadwell_uncore_v25.json
-      broadwell_uncore_v25::addEvents(pmu_manager);
+      // from broadwell_core.json
+      broadwell_core::addEvents(pmu_manager);
+      // from broadwell_uncore.json
+      broadwell_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(63, 0x0): // fall-through
@@ -257,10 +257,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(71, 0x13): // fall-through
     case toCpuKey(71, 0x14): // fall-through
     case toCpuKey(71, 0x15): // fall-through
-      // from broadwell_core_v25.json
-      broadwell_core_v25::addEvents(pmu_manager);
-      // from broadwell_uncore_v25.json
-      broadwell_uncore_v25::addEvents(pmu_manager);
+      // from broadwell_core.json
+      broadwell_core::addEvents(pmu_manager);
+      // from broadwell_uncore.json
+      broadwell_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(78, 0x0): // fall-through
@@ -301,10 +301,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(79, 0x13): // fall-through
     case toCpuKey(79, 0x14): // fall-through
     case toCpuKey(79, 0x15): // fall-through
-      // from broadwellx_core_v14.json
-      broadwellx_core_v14::addEvents(pmu_manager);
-      // from broadwellx_uncore_v14.json
-      broadwellx_uncore_v14::addEvents(pmu_manager);
+      // from broadwellx_core.json
+      broadwellx_core::addEvents(pmu_manager);
+      // from broadwellx_uncore.json
+      broadwellx_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(85, 0x0): // fall-through
@@ -355,10 +355,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(86, 0x13): // fall-through
     case toCpuKey(86, 0x14): // fall-through
     case toCpuKey(86, 0x15): // fall-through
-      // from broadwellde_core_v7.json
-      broadwellde_core_v7::addEvents(pmu_manager);
-      // from broadwellde_uncore_v7.json
-      broadwellde_uncore_v7::addEvents(pmu_manager);
+      // from broadwellde_core.json
+      broadwellde_core::addEvents(pmu_manager);
+      // from broadwellde_uncore.json
+      broadwellde_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(87, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -10,21 +10,21 @@
 
 namespace facebook::hbt::perf_event::generated {
 
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 
 namespace goldmont_core_v13 {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace goldmont_core_v13
 
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 
 namespace ivybridge_core_v21 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -149,10 +149,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(42, 0x13): // fall-through
     case toCpuKey(42, 0x14): // fall-through
     case toCpuKey(42, 0x15): // fall-through
-      // from sandybridge_core_v16.json
-      sandybridge_core_v16::addEvents(pmu_manager);
-      // from sandybridge_uncore_v16.json
-      sandybridge_uncore_v16::addEvents(pmu_manager);
+      // from sandybridge_core.json
+      sandybridge_core::addEvents(pmu_manager);
+      // from sandybridge_uncore.json
+      sandybridge_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(46, 0x0): // fall-through
@@ -171,8 +171,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(46, 0x13): // fall-through
     case toCpuKey(46, 0x14): // fall-through
     case toCpuKey(46, 0x15): // fall-through
-      // from NehalemEX_core_V2.json
-      nehalemex_core_v2::addEvents(pmu_manager);
+      // from NehalemEX_core.json
+      nehalemex_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(58, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwell_core_v25 {
+namespace broadwell_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwell_core_v25.json (741 events).
+    Events from broadwell_core.json (741 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW id: 61
@@ -3031,7 +3031,7 @@ Note: Writeback pending FIFO has six entries.)",
       R"(This event counts all actually retired uops. Counting increments by two for micro-fused uops, and by one for macro-fused and other uops. Maximal increment value for one cycle is eight.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
+      EventDef::IntelFeatures{.pebs = 1},
       R"(0)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3703,96 +3703,96 @@ Note: Writeback pending FIFO has six entries.)",
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4)",
       R"(Counts randomly selected loads with latency value being above four.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8)",
       R"(Counts randomly selected loads with latency value being above eight.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16)",
       R"(Counts randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32)",
       R"(Counts randomly selected loads with latency value being above 32.)",
       100007,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64)",
       R"(Counts randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128)",
       R"(Counts randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256)",
       R"(Counts randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512)",
       R"(Counts randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3838,7 +3838,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -3850,7 +3850,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -10256,5 +10256,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       R"(0)"));
 }
 
-} // namespace broadwell_core_v25
+} // namespace broadwell_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwell_uncore_v25 {
+namespace broadwell_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwell_uncore_v25.json (23 events).
+    Events from broadwell_uncore.json (23 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW id: 61
@@ -296,5 +296,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwell_uncore_v25
+} // namespace broadwell_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellde_core_v7 {
+namespace broadwellde_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellde_core_v7.json (340 events).
+    Events from broadwellde_core.json (340 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW-DE id: 86
@@ -4086,7 +4086,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.(Precise Event - PEBS))",
-      R"(This is a precise version (that is, uses PEBS) of the event that counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This is a precise version (that is, uses PEBS) of the event that counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -4099,7 +4099,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary. (Precise Event - PEBS))",
-      R"(This is a precise version (that is, uses PEBS) of the event that counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This is a precise version (that is, uses PEBS) of the event that counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -4518,5 +4518,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       ));
 }
 
-} // namespace broadwellde_core_v7
+} // namespace broadwellde_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellde_uncore_v7 {
+namespace broadwellde_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellde_uncore_v7.json (900 events).
+    Events from broadwellde_uncore.json (900 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW-DE id: 86
@@ -1907,7 +1907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10819,5 +10819,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwellde_uncore_v7
+} // namespace broadwellde_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellx_core_v14 {
+namespace broadwellx_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellx_core_v14.json (371 events).
+    Events from broadwellx_core.json (372 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDX id: 79
@@ -30,7 +30,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -42,7 +43,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -58,7 +60,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -71,7 +74,8 @@ Note: On all current platforms this event stops counting during 'throttling (TM)
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -91,7 +95,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -103,7 +108,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -115,7 +121,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -127,7 +134,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -139,7 +147,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -223,7 +232,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -235,7 +245,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -247,7 +258,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -259,7 +271,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -275,7 +288,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -287,7 +301,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -299,7 +314,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -315,7 +331,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -328,7 +345,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -340,7 +358,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -352,7 +371,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -364,7 +384,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -376,7 +397,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -388,7 +410,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -400,7 +423,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -412,7 +436,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -424,7 +449,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -436,7 +462,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -448,7 +475,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -460,7 +488,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -472,7 +501,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -484,7 +514,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -496,7 +527,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -508,7 +540,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -520,7 +553,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -532,7 +566,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -544,7 +579,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -556,7 +592,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -568,7 +605,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -580,7 +618,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -592,7 +631,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -604,7 +644,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -620,7 +661,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -629,10 +671,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(This is a fixed-frequency event programmed to general counters. It counts when the core is unhalted at 100 Mhz.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -645,10 +688,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .msr_values = {0}},
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -657,10 +701,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -673,10 +718,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .msr_values = {0x00}},
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -685,10 +731,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3c, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -697,10 +744,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -713,7 +761,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -725,7 +774,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -741,7 +791,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -753,7 +804,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -837,7 +889,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -849,7 +902,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -861,7 +915,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -873,7 +928,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -885,7 +941,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -897,7 +954,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -909,7 +967,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -921,7 +980,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -933,7 +993,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -945,7 +1006,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -957,7 +1019,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -969,7 +1032,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -981,7 +1045,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -993,7 +1058,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1005,7 +1071,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1017,7 +1084,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1029,7 +1097,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1041,7 +1110,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1053,7 +1123,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1069,7 +1140,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1081,7 +1153,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1093,7 +1166,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1105,7 +1179,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1117,7 +1192,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1129,7 +1205,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1141,7 +1218,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1154,7 +1232,8 @@ Note: In ST-mode, not active thread should drive 0. This is usually caused by se
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1171,7 +1250,8 @@ Note: In ST-mode, not active thread should drive 0. This is usually caused by se
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1280,7 +1360,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1292,7 +1373,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1304,7 +1386,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1316,7 +1399,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1328,7 +1412,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1340,7 +1425,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1352,7 +1438,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1364,7 +1451,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1376,7 +1464,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1392,7 +1481,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1404,7 +1494,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1416,7 +1507,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1428,7 +1520,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1440,7 +1533,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1452,7 +1546,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1464,7 +1559,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1476,7 +1572,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1492,7 +1589,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1504,7 +1602,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1516,7 +1615,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1528,7 +1628,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1540,7 +1641,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1624,7 +1726,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1636,7 +1739,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1648,7 +1752,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1660,7 +1765,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1672,7 +1778,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1684,7 +1791,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1696,7 +1804,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1708,7 +1817,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1720,7 +1830,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1732,7 +1843,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1744,7 +1856,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1756,7 +1869,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1768,7 +1882,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1780,7 +1895,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1792,7 +1908,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1804,7 +1921,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1816,7 +1934,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1828,7 +1947,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1840,7 +1960,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1852,7 +1973,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1864,7 +1986,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1876,7 +1999,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1888,7 +2012,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1900,7 +2025,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1912,7 +2038,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1927,7 +2054,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1939,7 +2067,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1951,7 +2080,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1963,7 +2093,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1975,7 +2106,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1991,7 +2123,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2003,7 +2136,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2015,7 +2149,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2031,7 +2166,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2043,7 +2179,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2055,7 +2192,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2071,7 +2209,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2083,7 +2222,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2095,7 +2235,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2111,7 +2252,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2123,7 +2265,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2135,7 +2278,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2151,7 +2295,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2163,7 +2308,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2175,7 +2321,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2191,7 +2338,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2203,7 +2351,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2215,7 +2364,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2231,7 +2381,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2243,7 +2394,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2255,7 +2407,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2271,7 +2424,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2283,7 +2437,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2295,7 +2450,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2311,7 +2467,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2323,7 +2480,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2335,7 +2493,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2347,7 +2506,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2359,7 +2519,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2371,7 +2532,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2383,7 +2545,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2395,7 +2558,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2407,7 +2571,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2419,7 +2584,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2431,7 +2597,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2443,7 +2610,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2455,7 +2623,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2467,7 +2636,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2479,7 +2649,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2491,7 +2662,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2503,7 +2675,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2515,7 +2688,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2527,7 +2701,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2539,7 +2714,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2551,7 +2727,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2563,7 +2740,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2575,7 +2753,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2589,7 +2768,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2601,7 +2781,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2613,7 +2794,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2625,7 +2807,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2637,7 +2820,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2649,7 +2833,21 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS.ALL_REQUESTS",
+      EventDef::Encoding{
+          .code = 0xb0, .umask = 0x80, .cmask = 0, .msr_values = {0}},
+      R"(Any memory transaction that reached the SQ.)",
+      R"(This event counts memory transactions reached the super queue including requests initiated by the core, all L3 prefetches, page walks, and so on.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2661,7 +2859,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2677,7 +2876,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2689,7 +2889,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2701,7 +2902,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2713,7 +2915,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2725,7 +2928,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2737,7 +2941,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2749,7 +2954,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2761,7 +2967,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2773,7 +2980,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2785,7 +2993,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2801,7 +3010,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2814,7 +3024,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2923,7 +3134,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2935,7 +3147,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2971,7 +3184,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3007,7 +3221,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3018,8 +3233,9 @@ Note: Writeback pending FIFO has six entries.)",
       R"(This event counts all actually retired uops. Counting increments by two for micro-fused uops, and by one for macro-fused and other uops. Maximal increment value for one cycle is eight.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3035,7 +3251,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3044,14 +3261,15 @@ Note: Writeback pending FIFO has six entries.)",
           .code = 0xC2,
           .umask = 0x01,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Number of cycles using always true condition (uops_ret < 16) applied to non PEBS uops retired event.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3063,7 +3281,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3075,7 +3294,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3091,7 +3311,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3106,7 +3327,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3118,7 +3340,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3130,7 +3353,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3142,7 +3366,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3154,7 +3379,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3166,7 +3392,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3178,7 +3405,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3202,7 +3430,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3214,7 +3443,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3226,7 +3456,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3250,7 +3481,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3262,7 +3494,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3274,7 +3507,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3286,7 +3520,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3298,127 +3533,138 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x03, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational scalar floating-point instructions retired. Applies to SSE* and AVX* scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RSQRT RCP SQRT FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single precision?))",
-      R"(Number of SSE/AVX computational scalar floating-point instructions retired. Applies to SSE* and AVX* scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RSQRT RCP SQRT FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single precision?))",
+          .code = 0xc7, .umask = 0x03, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational scalar floating-point instructions retired; some instructions will count twice as noted below. Each count represents 1 computation operation.   Applies to SSE* and AVX* scalar double and single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar single precision and double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired.  Each count represents 2 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired.  Each count represents 2 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 4 calculations per element.)",
+      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 4 calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x15, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational double precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational double precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x15, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational double precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational double precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000006,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xc7, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired.  Each count represents 8 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired.  Each count represents 8 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 8 calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x2A, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational single precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational single precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x2a, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational single precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational single precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000005,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.PACKED",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x3C, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational packed floating-point instructions retired. Applies to SSE* and AVX*, packed, double and single precision floating-point: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single-precision?))",
-      R"(Number of SSE/AVX computational packed floating-point instructions retired. Applies to SSE* and AVX*, packed, double and single precision floating-point: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single-precision?))",
+          .code = 0xc7, .umask = 0x3c, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational packed floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* packed double and single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational packed floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* packed double and single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000004,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3431,7 +3677,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3443,7 +3690,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3455,7 +3703,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3467,7 +3716,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3479,7 +3729,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3491,7 +3742,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3503,7 +3755,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3515,7 +3768,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3528,7 +3782,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3540,7 +3795,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3552,7 +3808,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3564,7 +3821,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3576,7 +3834,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3588,7 +3847,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3600,7 +3860,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3612,7 +3873,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3624,7 +3886,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3636,7 +3899,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3648,7 +3912,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3660,7 +3925,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3672,7 +3938,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3684,102 +3951,103 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4)",
       R"(Counts randomly selected loads with latency value being above four.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8)",
       R"(Counts randomly selected loads with latency value being above eight.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16)",
       R"(Counts randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32)",
       R"(Counts randomly selected loads with latency value being above 32.)",
       100007,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64)",
       R"(Counts randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128)",
       R"(Counts randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256)",
       R"(Counts randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512)",
       R"(Counts randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3792,7 +4060,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3805,7 +4074,8 @@ Note: Writeback pending FIFO has six entries.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3825,11 +4095,12 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3837,12 +4108,13 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3855,7 +4127,8 @@ Note: This event counts AVX-256bit load/store double-pump memory uops as a singl
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3869,7 +4142,8 @@ Note: This event counts AVX-256bit load/store double-pump memory uops as a singl
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3882,7 +4156,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3918,7 +4193,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3930,7 +4206,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3955,7 +4232,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4063,7 +4341,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4075,7 +4354,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4087,7 +4367,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4099,7 +4380,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4111,7 +4393,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4123,7 +4406,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4135,7 +4419,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4147,7 +4432,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4159,7 +4445,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4171,7 +4458,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4183,7 +4471,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4195,7 +4484,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4207,7 +4497,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4219,7 +4510,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4231,7 +4523,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4241,7 +4534,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC08FFF}},
-      R"(Counts all requests miss in the L3 )",
+      R"(Counts all requests miss in the L3)",
       R"(Counts all requests miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4257,7 +4550,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C8FFF}},
-      R"(Counts all requests hit in the L3 )",
+      R"(Counts all requests hit in the L3)",
       R"(Counts all requests hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4269,11 +4562,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x087FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x87FC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4289,7 +4579,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4301,11 +4591,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063BC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63BC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4317,11 +4604,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x06040007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x6040007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4337,7 +4621,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3 )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4353,7 +4637,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4365,11 +4649,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C07F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4381,11 +4662,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000244}},
-      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000244}},
+      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4401,7 +4679,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00244}},
-      R"(Counts all demand & prefetch code reads miss in the L3 )",
+      R"(Counts all demand & prefetch code reads miss in the L3)",
       R"(Counts all demand & prefetch code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4413,11 +4691,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0244}},
-      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0244}},
+      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4429,11 +4704,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000122}},
-      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000122}},
+      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4449,7 +4721,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00122}},
-      R"(Counts all demand & prefetch RFOs miss in the L3 )",
+      R"(Counts all demand & prefetch RFOs miss in the L3)",
       R"(Counts all demand & prefetch RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4465,7 +4737,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4477,11 +4749,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0122}},
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4493,11 +4762,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x087FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x87FC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4513,7 +4779,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4525,11 +4791,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063BC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63BC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4541,11 +4804,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4561,7 +4821,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00091}},
-      R"(Counts all demand & prefetch data reads miss in the L3 )",
+      R"(Counts all demand & prefetch data reads miss in the L3)",
       R"(Counts all demand & prefetch data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4577,7 +4837,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4589,11 +4849,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0091}},
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4609,7 +4866,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4625,7 +4882,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4641,7 +4898,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4657,7 +4914,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4673,7 +4930,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4689,7 +4946,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00002}},
-      R"(Counts all demand data writes (RFOs) miss in the L3 )",
+      R"(Counts all demand data writes (RFOs) miss in the L3)",
       R"(Counts all demand data writes (RFOs) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4705,7 +4962,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4721,7 +4978,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 )",
+      R"(Counts all demand data writes (RFOs) hit in the L3)",
       R"(Counts all demand data writes (RFOs) hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4730,5 +4987,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       ));
 }
 
-} // namespace broadwellx_core_v14
+} // namespace broadwellx_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellx_uncore_v14 {
+namespace broadwellx_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellx_uncore_v14.json (1284 events).
+    Events from broadwellx_uncore.json (1284 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDX id: 79
@@ -23,7 +23,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_BOUNCE_CONTROL",
       EventDef::Encoding{.code = 0xA, .umask = 0x0, .msr_values = {0x00}},
       R"(Bounce Control)",
-      R"(Bounce Control)",
+      R"(UNC_C_BOUNCE_CONTROL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -35,7 +35,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_CLOCKTICKS",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
       R"(Uncore Clocks)",
-      R"(Uncore Clocks)",
+      R"(UNC_C_CLOCKTICKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -539,7 +539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.AD",
       EventDef::Encoding{.code = 0x5, .umask = 0x1, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; AD)",
-      R"(Number of LLC responses that bounced on the Ring.; AD)",
+      R"(UNC_C_RING_BOUNCES.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -551,7 +551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.AK",
       EventDef::Encoding{.code = 0x5, .umask = 0x2, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; AK)",
-      R"(Number of LLC responses that bounced on the Ring.; AK)",
+      R"(UNC_C_RING_BOUNCES.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -563,7 +563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.BL",
       EventDef::Encoding{.code = 0x5, .umask = 0x4, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; BL)",
-      R"(Number of LLC responses that bounced on the Ring.; BL)",
+      R"(UNC_C_RING_BOUNCES.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -575,7 +575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.IV",
       EventDef::Encoding{.code = 0x5, .umask = 0x10, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
-      R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
+      R"(UNC_C_RING_BOUNCES.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -635,7 +635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SRC_THRTL",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
       R"(Number of cycles the Cbo is actively throttling traffic onto the Ring in order to limit bounce traffic.)",
-      R"(Number of cycles the Cbo is actively throttling traffic onto the Ring in order to limit bounce traffic.)",
+      R"(UNC_C_RING_SRC_THRTL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1631,7 +1631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
       R"(Onto AD Ring)",
-      R"(Onto AD Ring)",
+      R"(UNC_C_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1643,7 +1643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
       R"(Onto AK Ring)",
-      R"(Onto AK Ring)",
+      R"(UNC_C_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1655,7 +1655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
       R"(Onto BL Ring)",
-      R"(Onto BL Ring)",
+      R"(UNC_C_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1739,7 +1739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0x00}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1823,7 +1823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.AD",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
       R"(AD)",
-      R"(AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1835,7 +1835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.AK",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
       R"(AK)",
-      R"(AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1847,7 +1847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.IV",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
       R"(IV)",
-      R"(IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1859,7 +1859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.BL",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
       R"(BL)",
-      R"(BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1967,7 +1967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.FILT",
       EventDef::Encoding{.code = 0x20, .umask = 0x3, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Address & Opcode Match)",
-      R"(QPI Address/Opcode Match; Address & Opcode Match)",
+      R"(UNC_H_ADDR_OPC_MATCH.FILT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1979,7 +1979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.ADDR",
       EventDef::Encoding{.code = 0x20, .umask = 0x1, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Address)",
-      R"(QPI Address/Opcode Match; Address)",
+      R"(UNC_H_ADDR_OPC_MATCH.ADDR)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1991,7 +1991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.OPC",
       EventDef::Encoding{.code = 0x20, .umask = 0x2, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Opcode)",
-      R"(QPI Address/Opcode Match; Opcode)",
+      R"(UNC_H_ADDR_OPC_MATCH.OPC)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2003,7 +2003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.AD",
       EventDef::Encoding{.code = 0x20, .umask = 0x4, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; AD Opcodes)",
-      R"(QPI Address/Opcode Match; AD Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2015,7 +2015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.BL",
       EventDef::Encoding{.code = 0x20, .umask = 0x8, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; BL Opcodes)",
-      R"(QPI Address/Opcode Match; BL Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2027,7 +2027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.AK",
       EventDef::Encoding{.code = 0x20, .umask = 0x10, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; AK Opcodes)",
-      R"(QPI Address/Opcode Match; AK Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2195,7 +2195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x71, .umask = 0x1, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Counts Number of Hits in HitMe Cache; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_HIT.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2207,7 +2207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.WBMTOI",
       EventDef::Encoding{.code = 0x71, .umask = 0x2, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is WbMtoI)",
-      R"(Counts Number of Hits in HitMe Cache; op is WbMtoI)",
+      R"(UNC_H_HITME_HIT.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2219,7 +2219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x71, .umask = 0x4, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is AckCnfltWbI)",
-      R"(Counts Number of Hits in HitMe Cache; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_HIT.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2231,7 +2231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x71, .umask = 0x8, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is WbMtoE or WbMtoS)",
-      R"(Counts Number of Hits in HitMe Cache; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_HIT.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2243,7 +2243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x71, .umask = 0x10, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_HIT.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2255,7 +2255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x71, .umask = 0x20, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_HIT.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2267,7 +2267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDS",
       EventDef::Encoding{.code = 0x71, .umask = 0x40, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RsSFwd or RspSFwdWb)",
-      R"(Counts Number of Hits in HitMe Cache; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_HIT.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2279,7 +2279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSP",
       EventDef::Encoding{.code = 0x71, .umask = 0x80, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_HIT.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2291,7 +2291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ALLOCS",
       EventDef::Encoding{.code = 0x71, .umask = 0x70, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Allocations)",
-      R"(Counts Number of Hits in HitMe Cache; Allocations)",
+      R"(UNC_H_HITME_HIT.ALLOCS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2303,7 +2303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.EVICTS",
       EventDef::Encoding{.code = 0x71, .umask = 0x42, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Allocations)",
-      R"(Counts Number of Hits in HitMe Cache; Allocations)",
+      R"(UNC_H_HITME_HIT.EVICTS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2315,7 +2315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.INVALS",
       EventDef::Encoding{.code = 0x71, .umask = 0x26, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Invalidations)",
-      R"(Counts Number of Hits in HitMe Cache; Invalidations)",
+      R"(UNC_H_HITME_HIT.INVALS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2327,7 +2327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ALL",
       EventDef::Encoding{.code = 0x71, .umask = 0xFF, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; All Requests)",
-      R"(Counts Number of Hits in HitMe Cache; All Requests)",
+      R"(UNC_H_HITME_HIT.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2339,7 +2339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.HOM",
       EventDef::Encoding{.code = 0x71, .umask = 0xF, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; HOM Requests)",
-      R"(Counts Number of Hits in HitMe Cache; HOM Requests)",
+      R"(UNC_H_HITME_HIT.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2351,7 +2351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x72, .umask = 0x1, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2363,7 +2363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.WBMTOI",
       EventDef::Encoding{.code = 0x72, .umask = 0x2, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2375,7 +2375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x72, .umask = 0x4, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is AckCnfltWbI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2387,7 +2387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x72, .umask = 0x8, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoE or WbMtoS)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2399,7 +2399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x72, .umask = 0x10, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2411,7 +2411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x72, .umask = 0x20, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2423,7 +2423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDS",
       EventDef::Encoding{.code = 0x72, .umask = 0x40, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RsSFwd or RspSFwdWb)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2435,7 +2435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSP",
       EventDef::Encoding{.code = 0x72, .umask = 0x80, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2447,7 +2447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.ALL",
       EventDef::Encoding{.code = 0x72, .umask = 0xFF, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; All Requests)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; All Requests)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2459,7 +2459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.HOM",
       EventDef::Encoding{.code = 0x72, .umask = 0xF, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; HOM Requests)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; HOM Requests)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2471,7 +2471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x70, .umask = 0x1, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_LOOKUP.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2483,7 +2483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.WBMTOI",
       EventDef::Encoding{.code = 0x70, .umask = 0x2, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is WbMtoI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is WbMtoI)",
+      R"(UNC_H_HITME_LOOKUP.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2495,7 +2495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x70, .umask = 0x4, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is AckCnfltWbI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_LOOKUP.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2507,7 +2507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x70, .umask = 0x8, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is WbMtoE or WbMtoS)",
-      R"(Counts Number of times HitMe Cache is accessed; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_LOOKUP.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2519,7 +2519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x70, .umask = 0x10, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2531,7 +2531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x70, .umask = 0x20, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2543,7 +2543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDS",
       EventDef::Encoding{.code = 0x70, .umask = 0x40, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RsSFwd or RspSFwdWb)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2555,7 +2555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSP",
       EventDef::Encoding{.code = 0x70, .umask = 0x80, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_LOOKUP.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2567,7 +2567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ALLOCS",
       EventDef::Encoding{.code = 0x70, .umask = 0x70, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; Allocations)",
-      R"(Counts Number of times HitMe Cache is accessed; Allocations)",
+      R"(UNC_H_HITME_LOOKUP.ALLOCS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2579,7 +2579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.INVALS",
       EventDef::Encoding{.code = 0x70, .umask = 0x26, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; Invalidations)",
-      R"(Counts Number of times HitMe Cache is accessed; Invalidations)",
+      R"(UNC_H_HITME_LOOKUP.INVALS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2591,7 +2591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ALL",
       EventDef::Encoding{.code = 0x70, .umask = 0xFF, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; All Requests)",
-      R"(Counts Number of times HitMe Cache is accessed; All Requests)",
+      R"(UNC_H_HITME_LOOKUP.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2603,7 +2603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.HOM",
       EventDef::Encoding{.code = 0x70, .umask = 0xF, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; HOM Requests)",
-      R"(Counts Number of times HitMe Cache is accessed; HOM Requests)",
+      R"(UNC_H_HITME_LOOKUP.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2699,7 +2699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IMC_RETRY",
       EventDef::Encoding{.code = 0x1E, .umask = 0x0, .msr_values = {0x00}},
       R"(Retry Events)",
-      R"(Retry Events)",
+      R"(UNC_H_IMC_RETRY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4235,7 +4235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IOT_BACKPRESSURE.SAT",
       EventDef::Encoding{.code = 0x61, .umask = 0x1, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_H_IOT_BACKPRESSURE.SAT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4247,7 +4247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IOT_BACKPRESSURE.HUB",
       EventDef::Encoding{.code = 0x61, .umask = 0x2, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_H_IOT_BACKPRESSURE.HUB)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4811,7 +4811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REQ",
       EventDef::Encoding{.code = 0x14, .umask = 0x1, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Requests)",
-      R"(Misc Events - Set 0; Fastpath Requests)",
+      R"(UNC_I_MISC0.FAST_REQ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4823,7 +4823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REJ",
       EventDef::Encoding{.code = 0x14, .umask = 0x2, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Rejects)",
-      R"(Misc Events - Set 0; Fastpath Rejects)",
+      R"(UNC_I_MISC0.FAST_REJ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4835,7 +4835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_RD_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x4, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_RD_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4847,7 +4847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_WR_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x8, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_WR_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4859,7 +4859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_ATOMIC_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_ATOMIC_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4871,7 +4871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_XFER",
       EventDef::Encoding{.code = 0x14, .umask = 0x20, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
-      R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
+      R"(UNC_I_MISC0.FAST_XFER)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4883,7 +4883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.PF_ACK_HINT",
       EventDef::Encoding{.code = 0x14, .umask = 0x40, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
-      R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
+      R"(UNC_I_MISC0.PF_ACK_HINT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4955,7 +4955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC1.LOST_FWD",
       EventDef::Encoding{.code = 0x15, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 1)",
-      R"(Misc Events - Set 1)",
+      R"(UNC_I_MISC1.LOST_FWD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5014,7 +5014,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x4, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5038,7 +5038,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_OCCUPANCY",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5050,7 +5050,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_CYCLES_FULL",
       EventDef::Encoding{.code = 0x5, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5074,7 +5074,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_OCCUPANCY",
       EventDef::Encoding{.code = 0x8, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5086,7 +5086,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x6, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5110,7 +5110,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_OCCUPANCY",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5123,7 +5123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.MISS",
       EventDef::Encoding{.code = 0x17, .umask = 0x1, .msr_values = {0x00}},
       R"(Snoop Responses; Miss)",
-      R"(Snoop Responses; Miss)",
+      R"(UNC_I_SNOOP_RESP.MISS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5135,7 +5135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_I",
       EventDef::Encoding{.code = 0x17, .umask = 0x2, .msr_values = {0x00}},
       R"(Snoop Responses; Hit I)",
-      R"(Snoop Responses; Hit I)",
+      R"(UNC_I_SNOOP_RESP.HIT_I)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5147,7 +5147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_ES",
       EventDef::Encoding{.code = 0x17, .umask = 0x4, .msr_values = {0x00}},
       R"(Snoop Responses; Hit E or S)",
-      R"(Snoop Responses; Hit E or S)",
+      R"(UNC_I_SNOOP_RESP.HIT_ES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5159,7 +5159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_M",
       EventDef::Encoding{.code = 0x17, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses; Hit M)",
-      R"(Snoop Responses; Hit M)",
+      R"(UNC_I_SNOOP_RESP.HIT_M)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5171,7 +5171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPCODE",
       EventDef::Encoding{.code = 0x17, .umask = 0x10, .msr_values = {0x00}},
       R"(Snoop Responses; SnpCode)",
-      R"(Snoop Responses; SnpCode)",
+      R"(UNC_I_SNOOP_RESP.SNPCODE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5183,7 +5183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPDATA",
       EventDef::Encoding{.code = 0x17, .umask = 0x20, .msr_values = {0x00}},
       R"(Snoop Responses; SnpData)",
-      R"(Snoop Responses; SnpData)",
+      R"(UNC_I_SNOOP_RESP.SNPDATA)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5195,7 +5195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPINV",
       EventDef::Encoding{.code = 0x17, .umask = 0x40, .msr_values = {0x00}},
       R"(Snoop Responses; SnpInv)",
-      R"(Snoop Responses; SnpInv)",
+      R"(UNC_I_SNOOP_RESP.SNPINV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5938,7 +5938,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_UFS_TRANSITIONS_RING_GV",
       EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_RING_GV (Description is auto-generated))",
+      R"(UNC_P_UFS_TRANSITIONS_RING_GV)",
       R"(Ring GV with same final and initial frequency)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5951,7 +5951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_VR_HOT_CYCLES",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
       R"(VR Hot)",
-      R"(VR Hot)",
+      R"(UNC_P_VR_HOT_CYCLES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6191,7 +6191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_BYPASSED",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Rx Flit Buffer Bypassed)",
-      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6371,7 +6371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G0.IDLE",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 0; Idle and Null Flits)",
-      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
+      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6383,7 +6383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x2, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 1; SNP Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6395,7 +6395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6407,7 +6407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6419,7 +6419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x2, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6431,7 +6431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6443,7 +6443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6455,7 +6455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x2, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6467,7 +6467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AD)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6479,7 +6479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AK)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6491,7 +6491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6503,7 +6503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent non-data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6515,7 +6515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x3, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6527,7 +6527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent standard Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6899,7 +6899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Data Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6911,7 +6911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.NON_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Non-Data protocol Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6923,7 +6923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x0, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; SNP Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6935,7 +6935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6947,7 +6947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6959,7 +6959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x0, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6971,7 +6971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6983,7 +6983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6995,7 +6995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x0, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7007,7 +7007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AD)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7019,7 +7019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x1, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AK)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7031,7 +7031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7043,7 +7043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent non-data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7055,7 +7055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x1, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent Bypass Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7067,7 +7067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x1, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent standard Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7474,8 +7474,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_qpi,
       "UNC_Q_RxL_CRC_ERRORS.NORMAL_OP",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
-      R"(CRC Errors Detected; Normal Operations)",
-      R"(Number of CRC errors detected in the QPI Agent.  Each QPI flit incorporates 8 bits of CRC for error detection.  This counts the number of flits where the CRC was able to detect an error.  After an error has been detected, the QPI agent will send a request to the transmitting socket to resend the flit (as well as any flits that came after it).; CRC errors detected during normal operation.)",
+      R"(UNC_Q_RxL_CRC_ERRORS.NORMAL_OP)",
+      R"(UNC_Q_RxL_CRC_ERRORS.NORMAL_OP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7834,8 +7834,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7846,8 +7846,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7858,8 +7858,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7870,8 +7870,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10115,7 +10115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.AD",
       EventDef::Encoding{.code = 0x33, .umask = 0x1, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10127,7 +10127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.BL",
       EventDef::Encoding{.code = 0x33, .umask = 0x4, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10211,7 +10211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_IOT_BACKPRESSURE.SAT",
       EventDef::Encoding{.code = 0xB, .umask = 0x1, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_R3_IOT_BACKPRESSURE.SAT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10223,7 +10223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_IOT_BACKPRESSURE.HUB",
       EventDef::Encoding{.code = 0xB, .umask = 0x2, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_R3_IOT_BACKPRESSURE.HUB)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10367,7 +10367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_BOUNCE_CONTROL",
       EventDef::Encoding{.code = 0xA, .umask = 0x0, .msr_values = {0x00}},
       R"(Bounce Control)",
-      R"(Bounce Control)",
+      R"(UNC_S_BOUNCE_CONTROL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10379,7 +10379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_CLOCKTICKS",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
       R"(Uncore Clocks)",
-      R"(Uncore Clocks)",
+      R"(UNC_S_CLOCKTICKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10619,7 +10619,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.AD_CACHE",
       EventDef::Encoding{.code = 0x5, .umask = 0x1, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.)",
-      R"(Number of LLC responses that bounced on the Ring.)",
+      R"(UNC_S_RING_BOUNCES.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10631,7 +10631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.AK_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x2, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Acknowledgements to core)",
-      R"(Number of LLC responses that bounced on the Ring.; Acknowledgements to core)",
+      R"(UNC_S_RING_BOUNCES.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10643,7 +10643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.BL_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x4, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Data Responses to core)",
-      R"(Number of LLC responses that bounced on the Ring.; Data Responses to core)",
+      R"(UNC_S_RING_BOUNCES.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10655,7 +10655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.IV_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x8, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
-      R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
+      R"(UNC_S_RING_BOUNCES.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10906,8 +10906,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AD)",
+      R"(UNC_S_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10918,8 +10918,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AK)",
+      R"(UNC_S_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10930,8 +10930,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.BL)",
+      R"(UNC_S_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11086,8 +11086,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AD_CACHE",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11098,8 +11098,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AK_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11110,8 +11110,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.BL_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11122,8 +11122,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.IV_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11579,7 +11579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.ACT",
       EventDef::Encoding{.code = 0xA1, .umask = 0x1, .msr_values = {0x00}},
       R"(ACT command issued by 2 cycle bypass)",
-      R"(ACT command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.ACT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11591,7 +11591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.CAS",
       EventDef::Encoding{.code = 0xA1, .umask = 0x2, .msr_values = {0x00}},
       R"(CAS command issued by 2 cycle bypass)",
-      R"(CAS command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.CAS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11603,7 +11603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.PRE",
       EventDef::Encoding{.code = 0xA1, .umask = 0x4, .msr_values = {0x00}},
       R"(PRE command issued by 2 cycle bypass)",
-      R"(PRE command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.PRE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11962,8 +11962,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_imc,
       "UNC_M_POWER_PCU_THROTTLING",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12167,7 +12167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.LOW",
       EventDef::Encoding{.code = 0xA0, .umask = 0x1, .msr_values = {0x00}},
       R"(Read CAS issued with LOW priority)",
-      R"(Read CAS issued with LOW priority)",
+      R"(UNC_M_RD_CAS_PRIO.LOW)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12179,7 +12179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.MED",
       EventDef::Encoding{.code = 0xA0, .umask = 0x2, .msr_values = {0x00}},
       R"(Read CAS issued with MEDIUM priority)",
-      R"(Read CAS issued with MEDIUM priority)",
+      R"(UNC_M_RD_CAS_PRIO.MED)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12191,7 +12191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.HIGH",
       EventDef::Encoding{.code = 0xA0, .umask = 0x4, .msr_values = {0x00}},
       R"(Read CAS issued with HIGH priority)",
-      R"(Read CAS issued with HIGH priority)",
+      R"(UNC_M_RD_CAS_PRIO.HIGH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12203,7 +12203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.PANIC",
       EventDef::Encoding{.code = 0xA0, .umask = 0x8, .msr_values = {0x00}},
       R"(Read CAS issued with PANIC NON ISOCH priority (starved))",
-      R"(Read CAS issued with PANIC NON ISOCH priority (starved))",
+      R"(UNC_M_RD_CAS_PRIO.PANIC)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12215,7 +12215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 1)",
-      R"(RD_CAS Access to Rank 0; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK0.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12227,7 +12227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 2)",
-      R"(RD_CAS Access to Rank 0; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK0.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12239,7 +12239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB0, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 4)",
-      R"(RD_CAS Access to Rank 0; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK0.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12251,7 +12251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB0, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 8)",
-      R"(RD_CAS Access to Rank 0; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK0.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12263,7 +12263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB0, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; All Banks)",
-      R"(RD_CAS Access to Rank 0; All Banks)",
+      R"(UNC_M_RD_CAS_RANK0.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12275,7 +12275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 0)",
-      R"(RD_CAS Access to Rank 0; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK0.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12287,7 +12287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 3)",
-      R"(RD_CAS Access to Rank 0; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK0.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12299,7 +12299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB0, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 5)",
-      R"(RD_CAS Access to Rank 0; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK0.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12311,7 +12311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB0, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 6)",
-      R"(RD_CAS Access to Rank 0; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK0.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12323,7 +12323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB0, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 7)",
-      R"(RD_CAS Access to Rank 0; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK0.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12335,7 +12335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB0, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 9)",
-      R"(RD_CAS Access to Rank 0; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK0.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12347,7 +12347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB0, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 10)",
-      R"(RD_CAS Access to Rank 0; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK0.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12359,7 +12359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB0, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 11)",
-      R"(RD_CAS Access to Rank 0; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK0.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12371,7 +12371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB0, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 12)",
-      R"(RD_CAS Access to Rank 0; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK0.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12383,7 +12383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB0, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 13)",
-      R"(RD_CAS Access to Rank 0; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK0.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12395,7 +12395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB0, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 14)",
-      R"(RD_CAS Access to Rank 0; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK0.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12407,7 +12407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB0, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 15)",
-      R"(RD_CAS Access to Rank 0; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK0.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12419,7 +12419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12431,7 +12431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12443,7 +12443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12455,7 +12455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12467,7 +12467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 1)",
-      R"(RD_CAS Access to Rank 1; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK1.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12479,7 +12479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 2)",
-      R"(RD_CAS Access to Rank 1; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK1.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12491,7 +12491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB1, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 4)",
-      R"(RD_CAS Access to Rank 1; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK1.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12503,7 +12503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB1, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 8)",
-      R"(RD_CAS Access to Rank 1; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK1.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12515,7 +12515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB1, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; All Banks)",
-      R"(RD_CAS Access to Rank 1; All Banks)",
+      R"(UNC_M_RD_CAS_RANK1.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12527,7 +12527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 0)",
-      R"(RD_CAS Access to Rank 1; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK1.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12539,7 +12539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 3)",
-      R"(RD_CAS Access to Rank 1; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK1.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12551,7 +12551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB1, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 5)",
-      R"(RD_CAS Access to Rank 1; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK1.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12563,7 +12563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB1, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 6)",
-      R"(RD_CAS Access to Rank 1; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK1.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12575,7 +12575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB1, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 7)",
-      R"(RD_CAS Access to Rank 1; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK1.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12587,7 +12587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB1, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 9)",
-      R"(RD_CAS Access to Rank 1; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK1.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12599,7 +12599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB1, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 10)",
-      R"(RD_CAS Access to Rank 1; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK1.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12611,7 +12611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB1, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 11)",
-      R"(RD_CAS Access to Rank 1; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK1.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12623,7 +12623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB1, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 12)",
-      R"(RD_CAS Access to Rank 1; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK1.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12635,7 +12635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB1, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 13)",
-      R"(RD_CAS Access to Rank 1; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK1.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12647,7 +12647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB1, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 14)",
-      R"(RD_CAS Access to Rank 1; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK1.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12659,7 +12659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB1, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 15)",
-      R"(RD_CAS Access to Rank 1; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK1.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12671,7 +12671,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12683,7 +12683,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12695,7 +12695,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12707,7 +12707,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12719,7 +12719,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK2.BANK0",
       EventDef::Encoding{.code = 0xB2, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 2; Bank 0)",
-      R"(RD_CAS Access to Rank 2; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK2.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12731,7 +12731,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 1)",
-      R"(RD_CAS Access to Rank 4; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK4.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12743,7 +12743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 2)",
-      R"(RD_CAS Access to Rank 4; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK4.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12755,7 +12755,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xB4, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 4)",
-      R"(RD_CAS Access to Rank 4; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK4.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12767,7 +12767,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xB4, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 8)",
-      R"(RD_CAS Access to Rank 4; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK4.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12779,7 +12779,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xB4, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; All Banks)",
-      R"(RD_CAS Access to Rank 4; All Banks)",
+      R"(UNC_M_RD_CAS_RANK4.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12791,7 +12791,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 0)",
-      R"(RD_CAS Access to Rank 4; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK4.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12803,7 +12803,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 3)",
-      R"(RD_CAS Access to Rank 4; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK4.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12815,7 +12815,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xB4, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 5)",
-      R"(RD_CAS Access to Rank 4; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK4.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12827,7 +12827,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xB4, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 6)",
-      R"(RD_CAS Access to Rank 4; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK4.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12839,7 +12839,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xB4, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 7)",
-      R"(RD_CAS Access to Rank 4; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK4.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12851,7 +12851,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xB4, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 9)",
-      R"(RD_CAS Access to Rank 4; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK4.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12863,7 +12863,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xB4, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 10)",
-      R"(RD_CAS Access to Rank 4; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK4.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12875,7 +12875,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xB4, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 11)",
-      R"(RD_CAS Access to Rank 4; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK4.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12887,7 +12887,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xB4, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 12)",
-      R"(RD_CAS Access to Rank 4; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK4.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12899,7 +12899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xB4, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 13)",
-      R"(RD_CAS Access to Rank 4; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK4.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12911,7 +12911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xB4, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 14)",
-      R"(RD_CAS Access to Rank 4; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK4.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12923,7 +12923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xB4, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 15)",
-      R"(RD_CAS Access to Rank 4; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK4.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12935,7 +12935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12947,7 +12947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12959,7 +12959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12971,7 +12971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12983,7 +12983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 1)",
-      R"(RD_CAS Access to Rank 5; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK5.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12995,7 +12995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 2)",
-      R"(RD_CAS Access to Rank 5; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK5.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13007,7 +13007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xB5, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 4)",
-      R"(RD_CAS Access to Rank 5; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK5.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13019,7 +13019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xB5, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 8)",
-      R"(RD_CAS Access to Rank 5; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK5.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13031,7 +13031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xB5, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; All Banks)",
-      R"(RD_CAS Access to Rank 5; All Banks)",
+      R"(UNC_M_RD_CAS_RANK5.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13043,7 +13043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 0)",
-      R"(RD_CAS Access to Rank 5; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK5.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13055,7 +13055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 3)",
-      R"(RD_CAS Access to Rank 5; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK5.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13067,7 +13067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xB5, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 5)",
-      R"(RD_CAS Access to Rank 5; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK5.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13079,7 +13079,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xB5, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 6)",
-      R"(RD_CAS Access to Rank 5; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK5.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13091,7 +13091,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xB5, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 7)",
-      R"(RD_CAS Access to Rank 5; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK5.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13103,7 +13103,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xB5, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 9)",
-      R"(RD_CAS Access to Rank 5; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK5.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13115,7 +13115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xB5, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 10)",
-      R"(RD_CAS Access to Rank 5; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK5.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13127,7 +13127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xB5, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 11)",
-      R"(RD_CAS Access to Rank 5; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK5.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13139,7 +13139,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xB5, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 12)",
-      R"(RD_CAS Access to Rank 5; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK5.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13151,7 +13151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xB5, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 13)",
-      R"(RD_CAS Access to Rank 5; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK5.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13163,7 +13163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xB5, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 14)",
-      R"(RD_CAS Access to Rank 5; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK5.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13175,7 +13175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xB5, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 15)",
-      R"(RD_CAS Access to Rank 5; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK5.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13187,7 +13187,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13199,7 +13199,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13211,7 +13211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13223,7 +13223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13235,7 +13235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 1)",
-      R"(RD_CAS Access to Rank 6; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK6.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13247,7 +13247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 2)",
-      R"(RD_CAS Access to Rank 6; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK6.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13259,7 +13259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xB6, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 4)",
-      R"(RD_CAS Access to Rank 6; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK6.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13271,7 +13271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xB6, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 8)",
-      R"(RD_CAS Access to Rank 6; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK6.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13283,7 +13283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xB6, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; All Banks)",
-      R"(RD_CAS Access to Rank 6; All Banks)",
+      R"(UNC_M_RD_CAS_RANK6.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13295,7 +13295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 0)",
-      R"(RD_CAS Access to Rank 6; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK6.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13307,7 +13307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 3)",
-      R"(RD_CAS Access to Rank 6; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK6.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13319,7 +13319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xB6, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 5)",
-      R"(RD_CAS Access to Rank 6; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK6.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13331,7 +13331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xB6, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 6)",
-      R"(RD_CAS Access to Rank 6; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK6.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13343,7 +13343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xB6, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 7)",
-      R"(RD_CAS Access to Rank 6; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK6.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13355,7 +13355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xB6, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 9)",
-      R"(RD_CAS Access to Rank 6; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK6.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13367,7 +13367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xB6, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 10)",
-      R"(RD_CAS Access to Rank 6; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK6.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13379,7 +13379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xB6, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 11)",
-      R"(RD_CAS Access to Rank 6; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK6.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13391,7 +13391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xB6, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 12)",
-      R"(RD_CAS Access to Rank 6; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK6.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13403,7 +13403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xB6, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 13)",
-      R"(RD_CAS Access to Rank 6; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK6.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13415,7 +13415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xB6, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 14)",
-      R"(RD_CAS Access to Rank 6; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK6.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13427,7 +13427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xB6, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 15)",
-      R"(RD_CAS Access to Rank 6; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK6.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13439,7 +13439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13451,7 +13451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13463,7 +13463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13475,7 +13475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13487,7 +13487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 1)",
-      R"(RD_CAS Access to Rank 7; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK7.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13499,7 +13499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 2)",
-      R"(RD_CAS Access to Rank 7; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK7.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13511,7 +13511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xB7, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 4)",
-      R"(RD_CAS Access to Rank 7; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK7.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13523,7 +13523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xB7, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 8)",
-      R"(RD_CAS Access to Rank 7; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK7.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13535,7 +13535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xB7, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; All Banks)",
-      R"(RD_CAS Access to Rank 7; All Banks)",
+      R"(UNC_M_RD_CAS_RANK7.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13547,7 +13547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 0)",
-      R"(RD_CAS Access to Rank 7; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK7.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13559,7 +13559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 3)",
-      R"(RD_CAS Access to Rank 7; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK7.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13571,7 +13571,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xB7, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 5)",
-      R"(RD_CAS Access to Rank 7; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK7.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13583,7 +13583,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xB7, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 6)",
-      R"(RD_CAS Access to Rank 7; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK7.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13595,7 +13595,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xB7, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 7)",
-      R"(RD_CAS Access to Rank 7; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK7.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13607,7 +13607,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xB7, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 9)",
-      R"(RD_CAS Access to Rank 7; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK7.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13619,7 +13619,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xB7, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 10)",
-      R"(RD_CAS Access to Rank 7; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK7.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13631,7 +13631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xB7, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 11)",
-      R"(RD_CAS Access to Rank 7; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK7.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13643,7 +13643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xB7, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 12)",
-      R"(RD_CAS Access to Rank 7; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK7.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13655,7 +13655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xB7, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 13)",
-      R"(RD_CAS Access to Rank 7; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK7.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13667,7 +13667,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xB7, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 14)",
-      R"(RD_CAS Access to Rank 7; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK7.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13679,7 +13679,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xB7, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 15)",
-      R"(RD_CAS Access to Rank 7; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK7.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13691,7 +13691,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13703,7 +13703,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13715,7 +13715,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13727,7 +13727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13763,7 +13763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_MXB_WR_OCCUPANCY",
       EventDef::Encoding{.code = 0x91, .umask = 0x0, .msr_values = {0x00}},
       R"(VMSE MXB write buffer occupancy)",
-      R"(VMSE MXB write buffer occupancy)",
+      R"(UNC_M_VMSE_MXB_WR_OCCUPANCY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13775,7 +13775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_WR_PUSH.WMM",
       EventDef::Encoding{.code = 0x90, .umask = 0x1, .msr_values = {0x00}},
       R"(VMSE WR PUSH issued; VMSE write PUSH issued in WMM)",
-      R"(VMSE WR PUSH issued; VMSE write PUSH issued in WMM)",
+      R"(UNC_M_VMSE_WR_PUSH.WMM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13787,7 +13787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_WR_PUSH.RMM",
       EventDef::Encoding{.code = 0x90, .umask = 0x2, .msr_values = {0x00}},
       R"(VMSE WR PUSH issued; VMSE write PUSH issued in RMM)",
-      R"(VMSE WR PUSH issued; VMSE write PUSH issued in RMM)",
+      R"(UNC_M_VMSE_WR_PUSH.RMM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13799,7 +13799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.LOW_THRESH",
       EventDef::Encoding{.code = 0xC0, .umask = 0x1, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold; Transition from WMM to RMM because of starve counter)",
-      R"(Transition from WMM to RMM because of low threshold; Transition from WMM to RMM because of starve counter)",
+      R"(UNC_M_WMM_TO_RMM.LOW_THRESH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13811,7 +13811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.STARVE",
       EventDef::Encoding{.code = 0xC0, .umask = 0x2, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold)",
-      R"(Transition from WMM to RMM because of low threshold)",
+      R"(UNC_M_WMM_TO_RMM.STARVE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13823,7 +13823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.VMSE_RETRY",
       EventDef::Encoding{.code = 0xC0, .umask = 0x4, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold)",
-      R"(Transition from WMM to RMM because of low threshold)",
+      R"(UNC_M_WMM_TO_RMM.VMSE_RETRY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13883,7 +13883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WRONG_MM",
       EventDef::Encoding{.code = 0xC1, .umask = 0x0, .msr_values = {0x00}},
       R"(Not getting the requested Major Mode)",
-      R"(Not getting the requested Major Mode)",
+      R"(UNC_M_WRONG_MM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13895,7 +13895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 1)",
-      R"(WR_CAS Access to Rank 0; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK0.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13907,7 +13907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 2)",
-      R"(WR_CAS Access to Rank 0; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK0.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13919,7 +13919,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB8, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 4)",
-      R"(WR_CAS Access to Rank 0; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK0.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13931,7 +13931,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB8, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 8)",
-      R"(WR_CAS Access to Rank 0; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK0.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13943,7 +13943,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB8, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; All Banks)",
-      R"(WR_CAS Access to Rank 0; All Banks)",
+      R"(UNC_M_WR_CAS_RANK0.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13955,7 +13955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 0)",
-      R"(WR_CAS Access to Rank 0; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK0.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13967,7 +13967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 3)",
-      R"(WR_CAS Access to Rank 0; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK0.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13979,7 +13979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB8, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 5)",
-      R"(WR_CAS Access to Rank 0; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK0.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13991,7 +13991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB8, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 6)",
-      R"(WR_CAS Access to Rank 0; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK0.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14003,7 +14003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB8, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 7)",
-      R"(WR_CAS Access to Rank 0; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK0.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14015,7 +14015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB8, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 9)",
-      R"(WR_CAS Access to Rank 0; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK0.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14027,7 +14027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB8, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 10)",
-      R"(WR_CAS Access to Rank 0; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK0.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14039,7 +14039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB8, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 11)",
-      R"(WR_CAS Access to Rank 0; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK0.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14051,7 +14051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB8, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 12)",
-      R"(WR_CAS Access to Rank 0; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK0.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14063,7 +14063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB8, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 13)",
-      R"(WR_CAS Access to Rank 0; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK0.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14075,7 +14075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB8, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 14)",
-      R"(WR_CAS Access to Rank 0; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK0.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14087,7 +14087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB8, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 15)",
-      R"(WR_CAS Access to Rank 0; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK0.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14099,7 +14099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14111,7 +14111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14123,7 +14123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14135,7 +14135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14147,7 +14147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 1)",
-      R"(WR_CAS Access to Rank 1; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK1.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14159,7 +14159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 2)",
-      R"(WR_CAS Access to Rank 1; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK1.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14171,7 +14171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB9, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 4)",
-      R"(WR_CAS Access to Rank 1; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK1.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14183,7 +14183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB9, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 8)",
-      R"(WR_CAS Access to Rank 1; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK1.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14195,7 +14195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB9, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; All Banks)",
-      R"(WR_CAS Access to Rank 1; All Banks)",
+      R"(UNC_M_WR_CAS_RANK1.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14207,7 +14207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 0)",
-      R"(WR_CAS Access to Rank 1; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK1.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14219,7 +14219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 3)",
-      R"(WR_CAS Access to Rank 1; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK1.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14231,7 +14231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB9, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 5)",
-      R"(WR_CAS Access to Rank 1; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK1.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14243,7 +14243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB9, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 6)",
-      R"(WR_CAS Access to Rank 1; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK1.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14255,7 +14255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB9, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 7)",
-      R"(WR_CAS Access to Rank 1; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK1.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14267,7 +14267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB9, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 9)",
-      R"(WR_CAS Access to Rank 1; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK1.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14279,7 +14279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB9, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 10)",
-      R"(WR_CAS Access to Rank 1; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK1.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14291,7 +14291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB9, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 11)",
-      R"(WR_CAS Access to Rank 1; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK1.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14303,7 +14303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB9, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 12)",
-      R"(WR_CAS Access to Rank 1; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK1.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14315,7 +14315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB9, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 13)",
-      R"(WR_CAS Access to Rank 1; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK1.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14327,7 +14327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB9, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 14)",
-      R"(WR_CAS Access to Rank 1; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK1.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14339,7 +14339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB9, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 15)",
-      R"(WR_CAS Access to Rank 1; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK1.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14351,7 +14351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14363,7 +14363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14375,7 +14375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14387,7 +14387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14399,7 +14399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 1)",
-      R"(WR_CAS Access to Rank 4; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK4.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14411,7 +14411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 2)",
-      R"(WR_CAS Access to Rank 4; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK4.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14423,7 +14423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xBC, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 4)",
-      R"(WR_CAS Access to Rank 4; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK4.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14435,7 +14435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xBC, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 8)",
-      R"(WR_CAS Access to Rank 4; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK4.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14447,7 +14447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xBC, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; All Banks)",
-      R"(WR_CAS Access to Rank 4; All Banks)",
+      R"(UNC_M_WR_CAS_RANK4.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14459,7 +14459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 0)",
-      R"(WR_CAS Access to Rank 4; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK4.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14471,7 +14471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 3)",
-      R"(WR_CAS Access to Rank 4; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK4.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14483,7 +14483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xBC, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 5)",
-      R"(WR_CAS Access to Rank 4; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK4.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14495,7 +14495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xBC, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 6)",
-      R"(WR_CAS Access to Rank 4; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK4.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14507,7 +14507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xBC, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 7)",
-      R"(WR_CAS Access to Rank 4; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK4.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14519,7 +14519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xBC, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 9)",
-      R"(WR_CAS Access to Rank 4; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK4.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14531,7 +14531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xBC, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 10)",
-      R"(WR_CAS Access to Rank 4; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK4.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14543,7 +14543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xBC, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 11)",
-      R"(WR_CAS Access to Rank 4; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK4.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14555,7 +14555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xBC, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 12)",
-      R"(WR_CAS Access to Rank 4; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK4.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14567,7 +14567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xBC, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 13)",
-      R"(WR_CAS Access to Rank 4; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK4.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14579,7 +14579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xBC, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 14)",
-      R"(WR_CAS Access to Rank 4; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK4.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14591,7 +14591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xBC, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 15)",
-      R"(WR_CAS Access to Rank 4; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK4.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14603,7 +14603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14615,7 +14615,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14627,7 +14627,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14639,7 +14639,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14651,7 +14651,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 1)",
-      R"(WR_CAS Access to Rank 5; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK5.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14663,7 +14663,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 2)",
-      R"(WR_CAS Access to Rank 5; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK5.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14675,7 +14675,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xBD, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 4)",
-      R"(WR_CAS Access to Rank 5; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK5.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14687,7 +14687,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xBD, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 8)",
-      R"(WR_CAS Access to Rank 5; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK5.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14699,7 +14699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xBD, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; All Banks)",
-      R"(WR_CAS Access to Rank 5; All Banks)",
+      R"(UNC_M_WR_CAS_RANK5.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14711,7 +14711,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 0)",
-      R"(WR_CAS Access to Rank 5; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK5.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14723,7 +14723,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 3)",
-      R"(WR_CAS Access to Rank 5; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK5.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14735,7 +14735,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xBD, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 5)",
-      R"(WR_CAS Access to Rank 5; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK5.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14747,7 +14747,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xBD, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 6)",
-      R"(WR_CAS Access to Rank 5; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK5.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14759,7 +14759,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xBD, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 7)",
-      R"(WR_CAS Access to Rank 5; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK5.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14771,7 +14771,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xBD, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 9)",
-      R"(WR_CAS Access to Rank 5; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK5.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14783,7 +14783,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xBD, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 10)",
-      R"(WR_CAS Access to Rank 5; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK5.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14795,7 +14795,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xBD, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 11)",
-      R"(WR_CAS Access to Rank 5; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK5.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14807,7 +14807,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xBD, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 12)",
-      R"(WR_CAS Access to Rank 5; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK5.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14819,7 +14819,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xBD, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 13)",
-      R"(WR_CAS Access to Rank 5; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK5.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14831,7 +14831,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xBD, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 14)",
-      R"(WR_CAS Access to Rank 5; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK5.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14843,7 +14843,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xBD, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 15)",
-      R"(WR_CAS Access to Rank 5; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK5.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14855,7 +14855,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14867,7 +14867,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14879,7 +14879,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14891,7 +14891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14903,7 +14903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 1)",
-      R"(WR_CAS Access to Rank 6; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK6.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14915,7 +14915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 2)",
-      R"(WR_CAS Access to Rank 6; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK6.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14927,7 +14927,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xBE, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 4)",
-      R"(WR_CAS Access to Rank 6; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK6.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14939,7 +14939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xBE, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 8)",
-      R"(WR_CAS Access to Rank 6; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK6.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14951,7 +14951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xBE, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; All Banks)",
-      R"(WR_CAS Access to Rank 6; All Banks)",
+      R"(UNC_M_WR_CAS_RANK6.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14963,7 +14963,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 0)",
-      R"(WR_CAS Access to Rank 6; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK6.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14975,7 +14975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 3)",
-      R"(WR_CAS Access to Rank 6; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK6.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14987,7 +14987,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xBE, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 5)",
-      R"(WR_CAS Access to Rank 6; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK6.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14999,7 +14999,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xBE, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 6)",
-      R"(WR_CAS Access to Rank 6; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK6.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15011,7 +15011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xBE, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 7)",
-      R"(WR_CAS Access to Rank 6; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK6.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15023,7 +15023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xBE, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 9)",
-      R"(WR_CAS Access to Rank 6; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK6.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15035,7 +15035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xBE, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 10)",
-      R"(WR_CAS Access to Rank 6; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK6.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15047,7 +15047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xBE, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 11)",
-      R"(WR_CAS Access to Rank 6; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK6.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15059,7 +15059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xBE, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 12)",
-      R"(WR_CAS Access to Rank 6; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK6.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15071,7 +15071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xBE, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 13)",
-      R"(WR_CAS Access to Rank 6; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK6.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15083,7 +15083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xBE, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 14)",
-      R"(WR_CAS Access to Rank 6; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK6.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15095,7 +15095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xBE, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 15)",
-      R"(WR_CAS Access to Rank 6; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK6.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15107,7 +15107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15119,7 +15119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15131,7 +15131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15143,7 +15143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15155,7 +15155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 1)",
-      R"(WR_CAS Access to Rank 7; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK7.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15167,7 +15167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 2)",
-      R"(WR_CAS Access to Rank 7; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK7.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15179,7 +15179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xBF, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 4)",
-      R"(WR_CAS Access to Rank 7; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK7.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15191,7 +15191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xBF, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 8)",
-      R"(WR_CAS Access to Rank 7; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK7.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15203,7 +15203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xBF, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; All Banks)",
-      R"(WR_CAS Access to Rank 7; All Banks)",
+      R"(UNC_M_WR_CAS_RANK7.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15215,7 +15215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 0)",
-      R"(WR_CAS Access to Rank 7; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK7.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15227,7 +15227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 3)",
-      R"(WR_CAS Access to Rank 7; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK7.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15239,7 +15239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xBF, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 5)",
-      R"(WR_CAS Access to Rank 7; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK7.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15251,7 +15251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xBF, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 6)",
-      R"(WR_CAS Access to Rank 7; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK7.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15263,7 +15263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xBF, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 7)",
-      R"(WR_CAS Access to Rank 7; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK7.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15275,7 +15275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xBF, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 9)",
-      R"(WR_CAS Access to Rank 7; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK7.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15287,7 +15287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xBF, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 10)",
-      R"(WR_CAS Access to Rank 7; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK7.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15299,7 +15299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xBF, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 11)",
-      R"(WR_CAS Access to Rank 7; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK7.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15311,7 +15311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xBF, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 12)",
-      R"(WR_CAS Access to Rank 7; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK7.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15323,7 +15323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xBF, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 13)",
-      R"(WR_CAS Access to Rank 7; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK7.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15335,7 +15335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xBF, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 14)",
-      R"(WR_CAS Access to Rank 7; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK7.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15347,7 +15347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xBF, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 15)",
-      R"(WR_CAS Access to Rank 7; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK7.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15359,7 +15359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15371,7 +15371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15383,7 +15383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15395,7 +15395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15427,5 +15427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwellx_uncore_v14
+} // namespace broadwellx_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/goldmont_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/goldmont_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace goldmont_core_v13 {
+namespace goldmont_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from goldmont_core_v13.json (169 events).
+    Events from goldmont_core.json (169 events).
 
     Supported SKUs:
         - Arch: x86, Model: GLM id: 92
@@ -2295,5 +2295,5 @@ This event counts differently than Intel processors based on Silvermont microarc
       R"(0)"));
 }
 
-} // namespace goldmont_core_v13
+} // namespace goldmont_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/haswellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/haswellx_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace haswellx_core_v20 {
+namespace haswellx_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from haswellx_core_v20.json (385 events).
+    Events from haswellx_core.json (385 events).
 
     Supported SKUs:
         - Arch: x86, Model: HSX id: 63
@@ -40,23 +40,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_ANY",
-      EventDef::Encoding{
-          .code = 0x00,
-          .umask = 0x02,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -68,7 +53,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -80,7 +66,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -92,7 +79,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -104,7 +92,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -116,7 +105,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -128,7 +118,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -140,7 +131,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -152,7 +144,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -164,7 +157,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -176,19 +170,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_LOAD_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Demand load Miss in all translation lookaside buffer (TLB) levels causes a page walk that completes of any page size.)",
-      R"(Completed page walks in any TLB of any page size due to demand load misses.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -200,7 +183,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -212,7 +196,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -224,19 +209,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_LOAD_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x08, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Load operations that miss the first DTLB level but hit the second and do not cause page walks)",
-      R"(Number of cache load STLB hits. No page walk.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -248,7 +222,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -260,23 +235,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "INT_MISC.RECOVERY_CYCLES_ANY",
-      EventDef::Encoding{
-          .code = 0x0D,
-          .umask = 0x03,
-          .any = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke))",
-      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -288,7 +248,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.FLAGS_MERGE",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Number of flags-merge uops being allocated. Such uops considered perf sensitive; added by GSR u-arch.)",
+      R"(Number of flags-merge uops allocated. Such uops add delay.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.SLOW_LEA",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Number of slow LEA uops being allocated. A uop is generally considered SlowLea if it has 3 sources (e.g. 2 sources + immediate) regardless if as a result of LEA instruction or not.)",
+      R"(Number of slow LEA or similar uops allocated. Such uop has 3 sources (for example, 2 sources + immediate) regardless of whether it is a result of LEA instruction or not.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.SINGLE_MUL",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x40, .cmask = 0, .msr_values = {0}},
+      R"(Number of Multiply packed/scalar single precision uops allocated)",
+      R"(Number of multiply packed/scalar single precision uops allocated.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -304,7 +304,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -321,43 +322,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.FLAGS_MERGE",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of flags-merge uops being allocated. Such uops considered perf sensitive; added by GSR u-arch.)",
-      R"(Number of flags-merge uops allocated. Such uops add delay.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.SLOW_LEA",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of slow LEA uops being allocated. A uop is generally considered SlowLea if it has 3 sources (e.g. 2 sources + immediate) regardless if as a result of LEA instruction or not.)",
-      R"(Number of slow LEA or similar uops allocated. Such uop has 3 sources (for example, 2 sources + immediate) regardless of whether it is a result of LEA instruction or not.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.SINGLE_MUL",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(Number of Multiply packed/scalar single precision uops allocated)",
-      R"(Number of multiply packed/scalar single precision uops allocated.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -369,7 +335,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -381,67 +348,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.RFO_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x22, .cmask = 0, .msr_values = {0}},
-      R"(RFO requests that miss L2 cache)",
-      R"(Counts the number of store RFO requests that miss the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.CODE_RD_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x24, .cmask = 0, .msr_values = {0}},
-      R"(L2 cache misses when fetching instructions)",
-      R"(Number of instruction fetches that missed the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.ALL_DEMAND_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x27, .cmask = 0, .msr_values = {0}},
-      R"(Demand requests that miss L2 cache)",
-      R"(Demand requests that miss L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.L2_PF_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(L2 prefetch requests that miss L2 cache)",
-      R"(Counts all L2 HW prefetcher requests that missed L2.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x3F, .cmask = 0, .msr_values = {0}},
-      R"(All requests that miss L2 cache)",
-      R"(All requests that missed L2.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -453,31 +360,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "L2_RQSTS.RFO_HIT",
+      "L2_RQSTS.L2_PF_MISS",
       EventDef::Encoding{
-          .code = 0x24, .umask = 0xc2, .cmask = 0, .msr_values = {0}},
-      R"(RFO requests that hit L2 cache)",
-      R"(Counts the number of store RFO requests that hit the L2 cache.)",
+          .code = 0x24, .umask = 0x30, .cmask = 0, .msr_values = {0}},
+      R"(L2 prefetch requests that miss L2 cache)",
+      R"(Counts all L2 HW prefetcher requests that missed L2.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.CODE_RD_HIT",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xc4, .cmask = 0, .msr_values = {0}},
-      R"(L2 cache hits when fetching instructions, code reads.)",
-      R"(Number of instruction fetches that hit the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -489,19 +385,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "L2_RQSTS.ALL_DEMAND_DATA_RD",
       EventDef::Encoding{
-          .code = 0x24, .umask = 0xE1, .cmask = 0, .msr_values = {0}},
+          .code = 0x24, .umask = 0xe1, .cmask = 0, .msr_values = {0}},
       R"(Demand Data Read requests)",
       R"(Counts any demand and L1 HW prefetch data load requests to L2.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -513,7 +410,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -525,19 +423,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.ALL_DEMAND_REFERENCES",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xe7, .cmask = 0, .msr_values = {0}},
-      R"(Demand requests to L2 cache)",
-      R"(Demand requests to L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -549,19 +436,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.REFERENCES",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xFF, .cmask = 0, .msr_values = {0}},
-      R"(All L2 requests)",
-      R"(All requests to L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -573,7 +449,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -585,7 +462,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -597,35 +475,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_P",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(Thread cycles when thread is not in halt state)",
-      R"(Counts the number of thread cycles while the thread is not in a halt state. The thread enters the halt state when it is running the HLT instruction. The core frequency may change from time to time due to power or thermal throttling.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_P_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x00,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -634,54 +485,11 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(Increments at the frequency of XCLK (100 MHz) when not halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.REF_XCLK",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
-      R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the thread is unhalted. (counts at 100 MHz rate))",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.REF_XCLK_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0x00}},
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -690,62 +498,24 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x3c, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
-      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "L1D_PEND_MISS.PENDING",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(L1D miss oustandings duration in cycles)",
+      R"(L1D miss outstanding duration in cycles)",
       R"(Increments the number of outstanding L1D misses every cycle. Set Cmask = 1 and Edge =1 to count occurrences.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L1D_PEND_MISS.PENDING_CYCLES",
-      EventDef::Encoding{
-          .code = 0x48, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles with L1D load Misses outstanding.)",
-      R"(Cycles with L1D load Misses outstanding.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L1D_PEND_MISS.PENDING_CYCLES_ANY",
-      EventDef::Encoding{
-          .code = 0x48,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 1,
-          .msr_values = {0x00}},
-      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
-      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -757,19 +527,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "L1D_PEND_MISS.FB_FULL",
+      "L1D_PEND_MISS.PENDING_CYCLES",
       EventDef::Encoding{
-          .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+          .code = 0x48, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles with L1D load Misses outstanding.)",
+      R"(Cycles with L1D load Misses outstanding.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -781,7 +553,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -793,7 +566,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -805,7 +579,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -817,19 +592,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_STORE_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Store misses in all DTLB levels that cause completed page walks)",
-      R"(Completed page walks due to store miss in any TLB levels of any page size (4K/2M/4M/1G).)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -841,7 +605,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -853,7 +618,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -865,19 +631,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_STORE_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x49, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks)",
-      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -889,7 +644,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -901,7 +657,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -913,7 +670,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -925,7 +683,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -937,7 +696,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -949,7 +709,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -961,7 +722,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -973,7 +735,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -985,7 +748,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -997,7 +761,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1009,7 +774,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1021,7 +787,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1033,7 +800,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1045,7 +813,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1057,7 +826,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1069,7 +839,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1081,7 +852,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPL_CYCLES.RING123",
+      EventDef::Encoding{
+          .code = 0x5C, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Unhalted core cycles when thread is in rings 1, 2, or 3)",
+      R"(Unhalted core cycles when the thread is not in ring 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1097,19 +882,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPL_CYCLES.RING123",
-      EventDef::Encoding{
-          .code = 0x5C, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Unhalted core cycles when thread is in rings 1, 2, or 3)",
-      R"(Unhalted core cycles when the thread is not in ring 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1121,7 +895,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1133,7 +908,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1145,7 +921,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1157,7 +934,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1169,7 +947,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1181,24 +960,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "RS_EVENTS.EMPTY_END",
-      EventDef::Encoding{
-          .code = 0x5E,
-          .umask = 0x01,
-          .edge = true,
-          .inv = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
-      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1210,31 +973,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_DATA_RD",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
-      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.DEMAND_DATA_RD_GE_6",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x01, .cmask = 6, .msr_values = {0x00}},
-      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
-      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1246,7 +985,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1258,19 +997,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x04, .cmask = 1, .msr_values = {0}},
-      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
-      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1282,7 +1009,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_DATA_RD",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
+      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1294,7 +1033,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x04, .cmask = 1, .msr_values = {0}},
+      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
+      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1306,7 +1057,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1318,7 +1070,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1342,19 +1095,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MITE_CYCLES",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x04, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1366,7 +1108,73 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_DSB_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by DSB. Set Cmask = 1 to count cycles. Add Edge=1 to count # of delivery.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_MITE_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by MITE. Set Cmask = 1 to count cycles.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(This event counts uops delivered by the Front-end with the assistance of the microcode sequencer.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_CYCLES",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(This event counts cycles during which the microcode sequencer assisted the Front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MITE_CYCLES",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x04, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1378,31 +1186,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_DSB_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by DSB. Set Cmask = 1 to count cycles. Add Edge=1 to count # of delivery.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "IDQ.MS_DSB_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1413,12 +1211,13 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1430,7 +1229,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1442,19 +1242,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_MITE_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by MITE. Set Cmask = 1 to count cycles.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1466,7 +1255,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1478,47 +1268,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(This event counts uops delivered by the Front-end with the assistance of the microcode sequencer.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_CYCLES",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(This event counts cycles during which the microcode sequencer assisted the Front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_SWITCHES",
-      EventDef::Encoding{
-          .code = 0x79,
-          .umask = 0x30,
-          .edge = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
-      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1530,7 +1281,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1542,7 +1294,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1554,7 +1307,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1566,19 +1320,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ICACHE.IFDATA_STALL",
-      EventDef::Encoding{
-          .code = 0x80, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
-      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1590,7 +1333,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1602,7 +1346,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1614,7 +1359,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1626,19 +1372,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ITLB_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Misses in all ITLB levels that cause completed page walks)",
-      R"(Completed page walks in ITLB of any page size.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1650,7 +1385,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1662,7 +1398,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1674,19 +1411,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ITLB_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x85, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Operations that miss the first ITLB level but hit the second and do not cause any page walks)",
-      R"(ITLB misses that hit STLB. No page walk.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1698,7 +1424,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1710,7 +1437,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1722,7 +1450,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1734,7 +1463,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1746,7 +1476,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1758,7 +1489,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1770,7 +1502,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1782,7 +1515,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1794,7 +1528,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1806,7 +1541,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1818,7 +1554,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1830,7 +1567,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1842,7 +1580,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1854,7 +1593,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1866,7 +1606,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1878,7 +1619,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1890,7 +1632,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1902,7 +1645,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1914,19 +1658,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_MISP_EXEC.TAKEN_INDIRECT_NEAR_CALL",
-      EventDef::Encoding{
-          .code = 0x89, .umask = 0xA0, .cmask = 0, .msr_values = {0}},
-      R"(Taken speculative and retired mispredicted indirect calls.)",
-      R"(Taken speculative and retired mispredicted indirect calls.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1938,7 +1671,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1950,7 +1684,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1962,7 +1697,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2050,35 +1786,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_0_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 0.)",
-      R"(Cycles per core when uops are exectuted in port 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_0",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 0.)",
-      R"(Cycles per thread when uops are executed in port 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2090,35 +1799,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_1_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x02,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 1.)",
-      R"(Cycles per core when uops are exectuted in port 1.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_1",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 1.)",
-      R"(Cycles per thread when uops are executed in port 1.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2130,35 +1812,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_2_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x04,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 2.)",
-      R"(Cycles per core when uops are dispatched to port 2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_2",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 2.)",
-      R"(Cycles per thread when uops are executed in port 2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2170,35 +1825,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_3_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x08,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 3.)",
-      R"(Cycles per core when uops are dispatched to port 3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_3",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 3.)",
-      R"(Cycles per thread when uops are executed in port 3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2210,35 +1838,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_4_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x10,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 4.)",
-      R"(Cycles per core when uops are exectuted in port 4.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_4",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 4.)",
-      R"(Cycles per thread when uops are executed in port 4.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2250,35 +1851,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_5_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x20,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 5.)",
-      R"(Cycles per core when uops are exectuted in port 5.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_5",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 5.)",
-      R"(Cycles per thread when uops are executed in port 5.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2290,35 +1864,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_6_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x40,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 6.)",
-      R"(Cycles per core when uops are exectuted in port 6.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_6",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 6.)",
-      R"(Cycles per thread when uops are executed in port 6.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2330,35 +1877,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_7_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x80,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 7.)",
-      R"(Cycles per core when uops are dispatched to port 7.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_7",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x80, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 7.)",
-      R"(Cycles per thread when uops are executed in port 7.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2382,7 +1902,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2394,7 +1915,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2406,67 +1928,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CYCLE_ACTIVITY.CYCLES_L2_PENDING",
       EventDef::Encoding{
-          .code = 0xA3, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+          .code = 0xa3, .umask = 0x01, .cmask = 1, .msr_values = {0}},
       R"(Cycles with pending L2 cache miss loads.)",
       R"(Cycles with pending L2 miss loads. Set Cmask=2 to count cycle.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.CYCLES_LDM_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x02, .cmask = 2, .msr_values = {0}},
-      R"(Cycles with pending memory loads.)",
-      R"(Cycles with pending memory loads. Set Cmask=2 to count cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.CYCLES_NO_EXECUTE",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x04, .cmask = 4, .msr_values = {0}},
-      R"(This event increments by 1 for every cycle where there was no execute for this thread.)",
-      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.STALLS_L2_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x05, .cmask = 5, .msr_values = {0}},
-      R"(Execution stalls due to L2 cache misses.)",
-      R"(Number of loads missed L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.STALLS_LDM_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x06, .cmask = 6, .msr_values = {0}},
-      R"(Execution stalls due to memory subsystem.)",
-      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline and there were memory instructions pending (waiting for data).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      R"(HSD78, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2478,7 +1953,59 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.CYCLES_LDM_PENDING",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x02, .cmask = 2, .msr_values = {0}},
+      R"(Cycles with pending memory loads.)",
+      R"(Cycles with pending memory loads. Set Cmask=2 to count cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.CYCLES_NO_EXECUTE",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x04, .cmask = 4, .msr_values = {0}},
+      R"(This event increments by 1 for every cycle where there was no execute for this thread.)",
+      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.STALLS_L2_PENDING",
+      EventDef::Encoding{
+          .code = 0xa3, .umask = 0x05, .cmask = 5, .msr_values = {0}},
+      R"(Execution stalls due to L2 cache misses.)",
+      R"(Number of loads missed L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSM63, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.STALLS_LDM_PENDING",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x06, .cmask = 6, .msr_values = {0}},
+      R"(Execution stalls due to memory subsystem.)",
+      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline and there were memory instructions pending (waiting for data).)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2490,7 +2017,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2502,31 +2030,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "LSD.CYCLES_ACTIVE",
-      EventDef::Encoding{
-          .code = 0xA8, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
-      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "LSD.CYCLES_4_UOPS",
-      EventDef::Encoding{
-          .code = 0xA8, .umask = 0x01, .cmask = 4, .msr_values = {0}},
-      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
-      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2538,7 +2043,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2550,31 +2056,33 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_REQUESTS.DEMAND_DATA_RD",
       EventDef::Encoding{
-          .code = 0xB0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+          .code = 0xb0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Demand Data Read requests sent to uncore)",
       R"(Demand data read requests sent to uncore.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_REQUESTS.DEMAND_CODE_RD",
       EventDef::Encoding{
           .code = 0xB0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cacheable and noncachaeble code read requests)",
+      R"(Cacheable and noncacheable code read requests)",
       R"(Demand code read requests sent to uncore.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2586,7 +2094,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2598,7 +2107,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of uops executed on the core.)",
+      R"(Counts total number of uops to be executed per-core each cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2618,148 +2140,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles where at least 1 uop was executed per-thread)",
-      R"(This events counts the cycles where at least one uop was executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 2, .msr_values = {0}},
-      R"(Cycles where at least 2 uops were executed per-thread)",
-      R"(This events counts the cycles where at least two uop were executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 3, .msr_values = {0}},
-      R"(Cycles where at least 3 uops were executed per-thread)",
-      R"(This events counts the cycles where at least three uop were executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_4_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 4, .msr_values = {0}},
-      R"(Cycles where at least 4 uops were executed per-thread.)",
-      R"(Cycles where at least 4 uops were executed per-thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of uops executed on the core.)",
-      R"(Counts total number of uops to be executed per-core each cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_1",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_2",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 2, .msr_values = {0x00}},
-      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_3",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 3, .msr_values = {0x00}},
-      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_4",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 4, .msr_values = {0x00}},
-      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_NONE",
-      EventDef::Encoding{
-          .code = 0xb1,
-          .umask = 0x02,
-          .inv = true,
-          .cmask = 0,
-          .msr_values = {0x00}},
-      R"(Cycles with no micro-ops executed from any thread on physical core.)",
-      R"(Cycles with no micro-ops executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
       "OFFCORE_REQUESTS_BUFFER.SQ_FULL",
       EventDef::Encoding{
           .code = 0xb2, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Offcore requests buffer cannot take more entries for this thread core.)",
       R"(Offcore requests buffer cannot take more entries for this thread core.)",
       2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_RESPONSE",
-      EventDef::Encoding{
-          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
-      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
       std::nullopt // Errata
@@ -2775,7 +2161,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.ITLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x21, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L1+FB)",
+      R"(Number of ITLB page walker loads that hit in the L1+FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_DTLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x41, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_ITLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x81, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2787,7 +2213,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.ITLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x22, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L2)",
+      R"(Number of ITLB page walker loads that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_DTLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x42, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_ITLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x82, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2803,11 +2269,11 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.DTLB_MEMORY",
+      "PAGE_WALKER_LOADS.ITLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x18, .cmask = 0, .msr_values = {0}},
-      R"(Number of DTLB page walker hits in Memory)",
-      R"(Number of DTLB page walker loads from memory.)",
+          .code = 0xBC, .umask = 0x24, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L3 + XSNP)",
+      R"(Number of ITLB page walker loads that hit in the L3.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2815,35 +2281,37 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L1",
+      "PAGE_WALKER_LOADS.EPT_DTLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x21, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L1+FB)",
-      R"(Number of ITLB page walker loads that hit in the L1+FB.)",
+          .code = 0xBC, .umask = 0x44, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L2",
+      "PAGE_WALKER_LOADS.EPT_ITLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x22, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L2)",
-      R"(Number of ITLB page walker loads that hit in the L2.)",
+          .code = 0xBC, .umask = 0x84, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L3",
+      "PAGE_WALKER_LOADS.DTLB_MEMORY",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x24, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L3 + XSNP)",
-      R"(Number of ITLB page walker loads that hit in the L3.)",
+          .code = 0xBC, .umask = 0x18, .cmask = 0, .msr_values = {0}},
+      R"(Number of DTLB page walker hits in Memory)",
+      R"(Number of DTLB page walker loads from memory.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2863,42 +2331,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L1",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x41, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L2",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x42, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L3",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x44, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
       "PAGE_WALKER_LOADS.EPT_DTLB_MEMORY",
       EventDef::Encoding{
           .code = 0xBC, .umask = 0x48, .cmask = 0, .msr_values = {0}},
@@ -2907,43 +2339,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L1",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x81, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L2",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x82, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L3",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x84, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2955,7 +2352,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2967,7 +2365,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2979,7 +2378,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2995,6 +2395,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "INST_RETIRED.X87",
+      EventDef::Encoding{
+          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(FP operations retired. X87 FP operations that have no exceptions: Counts also flows that have several X87 or flows that use X87 uops in the exception handling.)",
+      R"(This is a non-precise version (that is, does not use PEBS) of the event that counts FP operations retired. For X87 FP operations that have no exceptions counting also includes flows that have several X87, or flows that use X87 uops in the exception handling.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "INST_RETIRED.PREC_DIST",
       EventDef::Encoding{
           .code = 0xC0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
@@ -3004,18 +2417,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
       R"(HSD140)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "INST_RETIRED.X87",
-      EventDef::Encoding{
-          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(FP operations retired. X87 FP operations that have no exceptions: Counts also flows that have several X87 or flows that use X87 uops in the exception handling.)",
-      R"(This is a non-precise version (that is, does not use PEBS) of the event that counts FP operations retired. For X87 FP operations that have no exceptions counting also includes flows that have several X87, or flows that use X87 uops in the exception handling.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3051,7 +2452,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3062,8 +2464,22 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Counts the number of micro-ops retired. Use Cmask=1 and invert to count active cycles or stalled cycles.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_RETIRED.RETIRE_SLOTS",
+      EventDef::Encoding{
+          .code = 0xC2, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Retirement slots used.)",
+      R"(This event counts the number of retirement slots used each cycle.  There are potentially 4 slots that can be used each cycle - meaning, 4 uops or 4 instructions could retire each cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3079,7 +2495,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3088,14 +2505,15 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0xC2,
           .umask = 0x01,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Cycles with less than 10 actually retired uops.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3112,19 +2530,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_RETIRED.RETIRE_SLOTS",
-      EventDef::Encoding{
-          .code = 0xC2, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Retirement slots used.)",
-      R"(This event counts the number of retirement slots used each cycle.  There are potentially 4 slots that can be used each cycle - meaning, 4 uops or 4 instructions could retire each cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3136,23 +2543,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "MACHINE_CLEARS.COUNT",
-      EventDef::Encoding{
-          .code = 0xC3,
-          .umask = 0x01,
-          .edge = true,
-          .cmask = 1,
-          .msr_values = {0x00}},
-      R"(Number of machine clears (nukes) of any type.)",
-      R"(Number of machine clears (nukes) of any type.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3164,7 +2556,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3176,7 +2569,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3188,19 +2582,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_INST_RETIRED.ALL_BRANCHES",
-      EventDef::Encoding{
-          .code = 0xC4, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(All (macro) branch instructions retired.)",
-      R"(Branch instructions at retirement.)",
-      400009,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3212,7 +2595,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3224,31 +2608,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BR_INST_RETIRED.NEAR_CALL_R3",
+      "BR_INST_RETIRED.ALL_BRANCHES",
       EventDef::Encoding{
-          .code = 0xC4, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
-      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_INST_RETIRED.ALL_BRANCHES_PEBS",
-      EventDef::Encoding{
-          .code = 0xC4, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+          .code = 0xC4, .umask = 0x00, .cmask = 0, .msr_values = {0}},
       R"(All (macro) branch instructions retired.)",
-      R"(All (macro) branch instructions retired.)",
+      R"(Branch instructions at retirement.)",
       400009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3260,7 +2634,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3272,7 +2647,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3284,7 +2660,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3296,19 +2673,34 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BR_MISP_RETIRED.ALL_BRANCHES",
+      "BR_INST_RETIRED.ALL_BRANCHES_PEBS",
       EventDef::Encoding{
-          .code = 0xC5, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(All mispredicted macro branch instructions retired.)",
-      R"(Mispredicted branch instructions at retirement.)",
+          .code = 0xC4, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(All (macro) branch instructions retired.)",
+      R"(All (macro) branch instructions retired.)",
       400009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 2},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_INST_RETIRED.NEAR_CALL_R3",
+      EventDef::Encoding{
+          .code = 0xC4, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
+      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3320,7 +2712,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_RETIRED.ALL_BRANCHES",
+      EventDef::Encoding{
+          .code = 0xC5, .umask = 0x00, .cmask = 0, .msr_values = {0}},
+      R"(All mispredicted macro branch instructions retired.)",
+      R"(Mispredicted branch instructions at retirement.)",
+      400009,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3332,31 +2738,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_MISP_RETIRED.NEAR_TAKEN",
-      EventDef::Encoding{
-          .code = 0xC5, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(number of near branch instructions retired that were mispredicted and taken.)",
-      R"(Number of near branch instructions retired that were taken but mispredicted.)",
-      400009,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "AVX_INSTS.ALL",
-      EventDef::Encoding{
-          .code = 0xC6, .umask = 0x07, .cmask = 0, .msr_values = {0}},
-      R"(Approximate counts of AVX & AVX2 256-bit instructions, including non-arithmetic instructions, loads, and stores.  May count non-AVX instructions that employ 256-bit operations, including (but not necessarily limited to) rep string instructions that use 256-bit loads and stores for optimized performance, XSAVE* and XRSTOR*, and operations that transition the x87 FPU data registers between x87 and MMX.)",
-      R"(Note that a whole rep string only counts AVX_INST.ALL once.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3368,7 +2751,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3380,7 +2764,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3392,7 +2777,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3404,7 +2790,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3416,7 +2803,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3428,7 +2816,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3452,7 +2841,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3464,7 +2854,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3476,7 +2867,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3488,7 +2880,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3500,7 +2893,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3512,7 +2906,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3524,7 +2919,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3548,7 +2944,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3560,7 +2957,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3572,7 +2970,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3584,7 +2983,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3596,7 +2996,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3608,7 +3009,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3620,102 +3022,103 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4.)",
       R"(Randomly selected loads with latency value being above 4.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8.)",
       R"(Randomly selected loads with latency value being above 8.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16.)",
       R"(Randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32.)",
       R"(Randomly selected loads with latency value being above 32.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64.)",
       R"(Randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128.)",
       R"(Randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256.)",
       R"(Randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512.)",
       R"(Randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3785,8 +3188,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "MEM_UOPS_RETIRED.ALL_LOADS",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x81, .cmask = 0, .msr_values = {0}},
-      R"(All retired load uops.)",
-      R"(All retired load uops.)",
+      R"(Retired load uops.)",
+      R"(Counts all retired load uops. This event accounts for SW prefetch uops of PREFETCHNTA or PREFETCHT0/1/2 or PREFETCHW.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -3797,8 +3200,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "MEM_UOPS_RETIRED.ALL_STORES",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x82, .cmask = 0, .msr_values = {0}},
-      R"(All retired store uops.)",
-      R"(All retired store uops.)",
+      R"(Retired store uops.)",
+      R"(Counts all retired store uops.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -3987,15 +3390,16 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BACLEARS.ANY",
+      "CPU_CLK_UNHALTED.THREAD_P",
       EventDef::Encoding{
-          .code = 0xe6, .umask = 0x1f, .cmask = 0, .msr_values = {0}},
-      R"(Counts the total number when the front end is resteered, mainly when the BPU cannot provide a correct prediction and this is corrected by other branch handling mechanisms at the front end.)",
-      R"(Number of front end re-steers due to BPU misprediction.)",
-      100003,
+          .code = 0x3C, .umask = 0x00, .cmask = 0, .msr_values = {0}},
+      R"(Thread cycles when thread is not in halt state)",
+      R"(Counts the number of thread cycles while the thread is not in a halt state. The thread enters the halt state when it is running the HLT instruction. The core frequency may change from time to time due to power or thermal throttling.)",
+      2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4007,7 +3411,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4019,7 +3424,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4031,7 +3437,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4043,7 +3450,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4055,7 +3463,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4067,7 +3476,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4079,7 +3489,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4091,7 +3502,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4103,7 +3515,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4115,7 +3528,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4127,7 +3541,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4139,7 +3554,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4151,7 +3567,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4163,7 +3580,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4175,17 +3593,854 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_EXEC.TAKEN_INDIRECT_NEAR_CALL",
+      EventDef::Encoding{
+          .code = 0x89, .umask = 0xA0, .cmask = 0, .msr_values = {0}},
+      R"(Taken speculative and retired mispredicted indirect calls.)",
+      R"(Taken speculative and retired mispredicted indirect calls.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_0_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 0.)",
+      R"(Cycles per core when uops are executed in port 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_1_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x02,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 1.)",
+      R"(Cycles per core when uops are executed in port 1.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_2_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x04,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 2.)",
+      R"(Cycles per core when uops are dispatched to port 2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_3_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x08,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 3.)",
+      R"(Cycles per core when uops are dispatched to port 3.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_4_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x10,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 4.)",
+      R"(Cycles per core when uops are executed in port 4.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_5_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x20,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 5.)",
+      R"(Cycles per core when uops are executed in port 5.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_6_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x40,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 6.)",
+      R"(Cycles per core when uops are executed in port 6.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_7_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x80,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 7.)",
+      R"(Cycles per core when uops are dispatched to port 7.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_RETIRED.NEAR_TAKEN",
+      EventDef::Encoding{
+          .code = 0xC5, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(number of near branch instructions retired that were mispredicted and taken.)",
+      R"(Number of near branch instructions retired that were taken but mispredicted.)",
+      400009,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_LOAD_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Demand load Miss in all translation lookaside buffer (TLB) levels causes a page walk that completes of any page size.)",
+      R"(Completed page walks in any TLB of any page size due to demand load misses.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_LOAD_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x08, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Load operations that miss the first DTLB level but hit the second and do not cause page walks)",
+      R"(Number of cache load STLB hits. No page walk.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.RFO_HIT",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xc2, .cmask = 0, .msr_values = {0}},
+      R"(RFO requests that hit L2 cache)",
+      R"(Counts the number of store RFO requests that hit the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.RFO_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x22, .cmask = 0, .msr_values = {0}},
+      R"(RFO requests that miss L2 cache)",
+      R"(Counts the number of store RFO requests that miss the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.CODE_RD_HIT",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xc4, .cmask = 0, .msr_values = {0}},
+      R"(L2 cache hits when fetching instructions, code reads.)",
+      R"(Number of instruction fetches that hit the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.CODE_RD_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x24, .cmask = 0, .msr_values = {0}},
+      R"(L2 cache misses when fetching instructions)",
+      R"(Number of instruction fetches that missed the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.ALL_DEMAND_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x27, .cmask = 0, .msr_values = {0}},
+      R"(Demand requests that miss L2 cache)",
+      R"(Demand requests that miss L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.ALL_DEMAND_REFERENCES",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xe7, .cmask = 0, .msr_values = {0}},
+      R"(Demand requests to L2 cache)",
+      R"(Demand requests to L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x3f, .cmask = 0, .msr_values = {0}},
+      R"(All requests that miss L2 cache)",
+      R"(All requests that missed L2.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.REFERENCES",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xff, .cmask = 0, .msr_values = {0}},
+      R"(All L2 requests)",
+      R"(All requests to L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_STORE_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Store misses in all DTLB levels that cause completed page walks)",
+      R"(Completed page walks due to store miss in any TLB levels of any page size (4K/2M/4M/1G).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_STORE_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x49, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks)",
+      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ITLB_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Misses in all ITLB levels that cause completed page walks)",
+      R"(Completed page walks in ITLB of any page size.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ITLB_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x85, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Operations that miss the first ITLB level but hit the second and do not cause any page walks)",
+      R"(ITLB misses that hit STLB. No page walk.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles where at least 1 uop was executed per-thread)",
+      R"(This events counts the cycles where at least one uop was executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 2, .msr_values = {0}},
+      R"(Cycles where at least 2 uops were executed per-thread)",
+      R"(This events counts the cycles where at least two uop were executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 3, .msr_values = {0}},
+      R"(Cycles where at least 3 uops were executed per-thread)",
+      R"(This events counts the cycles where at least three uop were executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_4_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 4, .msr_values = {0}},
+      R"(Cycles where at least 4 uops were executed per-thread.)",
+      R"(Cycles where at least 4 uops were executed per-thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BACLEARS.ANY",
+      EventDef::Encoding{
+          .code = 0xe6, .umask = 0x1f, .cmask = 0, .msr_values = {0}},
+      R"(Counts the total number when the front end is resteered, mainly when the BPU cannot provide a correct prediction and this is corrected by other branch handling mechanisms at the front end.)",
+      R"(Number of front end re-steers due to BPU misprediction.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_RESPONSE",
+      EventDef::Encoding{
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "MACHINE_CLEARS.COUNT",
+      EventDef::Encoding{
+          .code = 0xC3,
+          .umask = 0x01,
+          .edge = true,
+          .cmask = 1,
+          .msr_values = {0x00}},
+      R"(Number of machine clears (nukes) of any type.)",
+      R"(Number of machine clears (nukes) of any type.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "LSD.CYCLES_ACTIVE",
+      EventDef::Encoding{
+          .code = 0xA8, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
+      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "LSD.CYCLES_4_UOPS",
+      EventDef::Encoding{
+          .code = 0xA8, .umask = 0x01, .cmask = 4, .msr_values = {0}},
+      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
+      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "RS_EVENTS.EMPTY_END",
+      EventDef::Encoding{
+          .code = 0x5E,
+          .umask = 0x01,
+          .edge = true,
+          .inv = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
+      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_SWITCHES",
+      EventDef::Encoding{
+          .code = 0x79,
+          .umask = 0x30,
+          .edge = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
+      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_0",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 0.)",
+      R"(Cycles per thread when uops are executed in port 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_1",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 1.)",
+      R"(Cycles per thread when uops are executed in port 1.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_2",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 2.)",
+      R"(Cycles per thread when uops are executed in port 2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_3",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x08, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 3.)",
+      R"(Cycles per thread when uops are executed in port 3.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_4",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 4.)",
+      R"(Cycles per thread when uops are executed in port 4.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_5",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 5.)",
+      R"(Cycles per thread when uops are executed in port 5.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_6",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x40, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 6.)",
+      R"(Cycles per thread when uops are executed in port 6.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_7",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x80, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 7.)",
+      R"(Cycles per thread when uops are executed in port 7.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.THREAD_ANY",
+      EventDef::Encoding{
+          .code = 0x00,
+          .umask = 0x02,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.THREAD_P_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x00,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "INT_MISC.RECOVERY_CYCLES_ANY",
+      EventDef::Encoding{
+          .code = 0x0D,
+          .umask = 0x03,
+          .any = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke))",
+      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke).)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_1",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
+      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_2",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 2, .msr_values = {0x00}},
+      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_3",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 3, .msr_values = {0x00}},
+      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_4",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 4, .msr_values = {0x00}},
+      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_NONE",
+      EventDef::Encoding{
+          .code = 0xb1,
+          .umask = 0x02,
+          .inv = true,
+          .cmask = 0,
+          .msr_values = {0x00}},
+      R"(Cycles with no micro-ops executed from any thread on physical core.)",
+      R"(Cycles with no micro-ops executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.DEMAND_DATA_RD_GE_6",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x01, .cmask = 6, .msr_values = {0x00}},
+      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
+      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L1D_PEND_MISS.PENDING_CYCLES_ANY",
+      EventDef::Encoding{
+          .code = 0x48,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 1,
+          .msr_values = {0x00}},
+      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
+      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L1D_PEND_MISS.FB_FULL",
+      EventDef::Encoding{
+          .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
+      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "AVX_INSTS.ALL",
+      EventDef::Encoding{
+          .code = 0xC6, .umask = 0x07, .cmask = 0, .msr_values = {0}},
+      R"(Approximate counts of AVX & AVX2 256-bit instructions, including non-arithmetic instructions, loads, and stores.  May count non-AVX instructions that employ 256-bit operations, including (but not necessarily limited to) rep string instructions that use 256-bit loads and stores for optimized performance, XSAVE* and XRSTOR*, and operations that transition the x87 FPU data registers between x87 and MMX.)",
+      R"(Note that a whole rep string only counts AVX_INST.ALL once.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ICACHE.IFDATA_STALL",
+      EventDef::Encoding{
+          .code = 0x80, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
+      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.REF_XCLK",
+      EventDef::Encoding{
+          .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
+      R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the thread is unhalted. (counts at 100 MHz rate))",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.REF_XCLK_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0x00}},
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE",
+      EventDef::Encoding{
+          .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
+      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
+      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0001}},
-      R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0001}},
+      R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4201,7 +4456,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0001}},
-      R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4217,7 +4472,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00001}},
-      R"(Counts demand data reads miss in the L3 )",
+      R"(Counts demand data reads miss in the L3)",
       R"(Counts demand data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4229,11 +4484,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400001}},
-      R"(Counts demand data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400001}},
+      R"(Counts demand data reads miss the L3 and the data is returned from local dram)",
       R"(Counts demand data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4245,11 +4497,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0002}},
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4265,7 +4514,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4281,7 +4530,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00002}},
-      R"(Counts all demand data writes (RFOs) miss in the L3 )",
+      R"(Counts all demand data writes (RFOs) miss in the L3)",
       R"(Counts all demand data writes (RFOs) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4293,11 +4542,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400002}},
+      R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4313,7 +4559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4325,11 +4571,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0004}},
-      R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0004}},
+      R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4345,7 +4588,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0004}},
-      R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4361,7 +4604,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00004}},
-      R"(Counts all demand code reads miss in the L3 )",
+      R"(Counts all demand code reads miss in the L3)",
       R"(Counts all demand code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4373,11 +4616,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400004}},
-      R"(Counts all demand code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400004}},
+      R"(Counts all demand code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4393,7 +4633,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0010}},
-      R"(Counts prefetch (that bring data to L2) data reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to L2) data reads hit in the L3)",
       R"(Counts prefetch (that bring data to L2) data reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4409,7 +4649,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00010}},
-      R"(Counts prefetch (that bring data to L2) data reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to L2) data reads miss in the L3)",
       R"(Counts prefetch (that bring data to L2) data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4425,7 +4665,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0020}},
-      R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4441,7 +4681,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00020}},
-      R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4457,7 +4697,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0040}},
-      R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4473,7 +4713,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00040}},
-      R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4489,7 +4729,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0080}},
-      R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4505,7 +4745,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00080}},
-      R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4521,7 +4761,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4537,7 +4777,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4553,7 +4793,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4569,7 +4809,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4581,11 +4821,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0091}},
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4601,7 +4838,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4617,7 +4854,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00091}},
-      R"(Counts all demand & prefetch data reads miss in the L3 )",
+      R"(Counts all demand & prefetch data reads miss in the L3)",
       R"(Counts all demand & prefetch data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4629,11 +4866,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4645,11 +4879,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063F800091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63F800091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4665,7 +4896,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4677,11 +4908,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4693,11 +4921,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0122}},
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4713,7 +4938,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4729,7 +4954,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00122}},
-      R"(Counts all demand & prefetch RFOs miss in the L3 )",
+      R"(Counts all demand & prefetch RFOs miss in the L3)",
       R"(Counts all demand & prefetch RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4741,11 +4966,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400122}},
-      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400122}},
+      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4757,11 +4979,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0244}},
-      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0244}},
+      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4777,7 +4996,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00244}},
-      R"(Counts all demand & prefetch code reads miss in the L3 )",
+      R"(Counts all demand & prefetch code reads miss in the L3)",
       R"(Counts all demand & prefetch code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4789,11 +5008,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400244}},
-      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400244}},
+      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4805,11 +5021,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C07F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4825,7 +5038,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4841,7 +5054,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3 )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4853,11 +5066,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x06004007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x6004007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4869,11 +5079,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063F8007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63F8007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4889,7 +5096,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4901,11 +5108,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4921,7 +5125,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C8FFF}},
-      R"(Counts all requests hit in the L3 )",
+      R"(Counts all requests hit in the L3)",
       R"(Counts all requests hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4937,7 +5141,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC08FFF}},
-      R"(Counts all requests miss in the L3 )",
+      R"(Counts all requests miss in the L3)",
       R"(Counts all requests miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4946,5 +5150,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace haswellx_core_v20
+} // namespace haswellx_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/haswellx_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/haswellx_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace haswellx_uncore_v20 {
+namespace haswellx_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from haswellx_uncore_v20.json (1278 events).
+    Events from haswellx_uncore.json (1278 events).
 
     Supported SKUs:
         - Arch: x86, Model: HSX id: 63
@@ -83,7 +83,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_LLC_LOOKUP.WRITE",
       EventDef::Encoding{.code = 0x34, .umask = 0x5, .msr_values = {0x00}},
       R"(Cache Lookups; Write Requests)",
-      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CBoGlCtrl[22:18] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cachable and UC.)",
+      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CBoGlCtrl[22:18] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cacheable and UC.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -706,8 +706,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.AD",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(AD)",
-      R"(AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -718,8 +718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.AK",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(AK)",
-      R"(AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -730,8 +730,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.IV",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(IV)",
-      R"(IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -742,8 +742,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.BL",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(BL)",
-      R"(BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1319,7 +1319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x1, .msr_values = {0x00}},
       R"(TOR Inserts; Opcode Match)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match an opcode (matched by Cn_MSR_PMON_BOX_FILTER.opc))",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match an opcode (matched by Cn_MSR_PMON_BOX_FILTER.opc))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1331,7 +1331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.EVICTION",
       EventDef::Encoding{.code = 0x35, .umask = 0x4, .msr_values = {0x00}},
       R"(TOR Inserts; Evictions)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Eviction transactions inserted into the TOR.  Evictions can be quick, such as when the line is in the F, S, or E states and no core valid bits are set.  They can also be longer if either CV bits are set (so the cores need to be snooped) and/or if there is a HitM (in which case it is necessary to write the request out to memory).)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Eviction transactions inserted into the TOR.  Evictions can be quick, such as when the line is in the F, S, or E states and no core valid bits are set.  They can also be longer if either CV bits are set (so the cores need to be snooped) and/or if there is a HitM (in which case it is necessary to write the request out to memory).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1343,7 +1343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x8, .msr_values = {0x00}},
       R"(TOR Inserts; All)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR.    This includes requests that reside in the TOR for a short time, such as LLC Hits that do not need to snoop cores or requests that get rejected and have to be retried through one of the ingress queues.  The TOR is more commonly a bottleneck in skews with smaller core counts, where the ratio of RTIDs to TOR entries is larger.  Note that there are reserved TOR entries for various request types, so it is possible that a given request type be blocked with an occupancy that is less than 20.  Also note that generally requests will not be able to arbitrate into the TOR pipeline if there are no available TOR slots.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR.    This includes requests that reside in the TOR for a short time, such as LLC Hits that do not need to snoop cores or requests that get rejected and have to be retried through one of the ingress queues.  The TOR is more commonly a bottleneck in skews with smaller core counts, where the ratio of RTIDs to TOR entries is larger.  Note that there are reserved TOR entries for various request types, so it is possible that a given request type be blocked with an occupancy that is less than 20.  Also note that generally requests will not be able to arbitrate into the TOR pipeline if there are no available TOR slots.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1355,7 +1355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.WB",
       EventDef::Encoding{.code = 0x35, .umask = 0x10, .msr_values = {0x00}},
       R"(TOR Inserts; Writebacks)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Write transactions inserted into the TOR.   This does not include RFO, but actual operations that contain data being sent from the core.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Write transactions inserted into the TOR.   This does not include RFO, but actual operations that contain data being sent from the core.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1367,7 +1367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x3, .msr_values = {0x00}},
       R"(TOR Inserts; Miss Opcode Match)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1379,7 +1379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x41, .msr_values = {0x00}},
       R"(TOR Inserts; NID and Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match a NID and an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match a NID and an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1391,7 +1391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_EVICTION",
       EventDef::Encoding{.code = 0x35, .umask = 0x44, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Evictions)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched eviction transactions inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched eviction transactions inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1403,7 +1403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x48, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched (matches an RTID destination) transactions inserted into the TOR.  The NID is programmed in Cn_MSR_PMON_BOX_FILTER.nid.  In conjunction with STATE = I, it is possible to monitor misses to specific NIDs in the system.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched (matches an RTID destination) transactions inserted into the TOR.  The NID is programmed in Cn_MSR_PMON_BOX_FILTER.nid.  In conjunction with STATE = I, it is possible to monitor misses to specific NIDs in the system.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1415,7 +1415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_WB",
       EventDef::Encoding{.code = 0x35, .umask = 0x50, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Writebacks)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched write transactions inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched write transactions inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1427,7 +1427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_MISS_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x43, .msr_values = {0x00}},
       R"(TOR Inserts; NID and Opcode Matched Miss)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match a NID and an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match a NID and an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1439,7 +1439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_MISS_ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x4A, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Miss All)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched miss requests that were inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched miss requests that were inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1451,7 +1451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_LOCAL",
       EventDef::Encoding{.code = 0x35, .umask = 0x2A, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Local Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1463,7 +1463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_REMOTE",
       EventDef::Encoding{.code = 0x35, .umask = 0x8A, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Remote Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1475,7 +1475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.LOCAL",
       EventDef::Encoding{.code = 0x35, .umask = 0x28, .msr_values = {0x00}},
       R"(TOR Inserts; Local Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1487,7 +1487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.REMOTE",
       EventDef::Encoding{.code = 0x35, .umask = 0x88, .msr_values = {0x00}},
       R"(TOR Inserts; Remote Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1499,7 +1499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x23, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Local Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisifed by an opcode, inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisfied by an opcode, inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1511,7 +1511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x83, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Remote Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1523,7 +1523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
       R"(TOR Inserts; Local Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent. There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1535,7 +1535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x81, .msr_values = {0x00}},
       R"(TOR Inserts; Remote Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1715,7 +1715,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.MISS_LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x23, .msr_values = {0x00}},
       R"(TOR Occupancy; Misses to Local Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisifed by an opcode, in the TOR that are satisifed by locally HOMed memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisfied by an opcode, in the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1727,7 +1727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.MISS_REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x83, .msr_values = {0x00}},
       R"(TOR Occupancy; Misses to Remote Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisifed by an opcode, in the TOR that are satisifed by remote caches or remote memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisfied by an opcode, in the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1739,7 +1739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
       R"(TOR Occupancy; Local Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisifed by an opcode,  in the TOR that are satisifed by locally HOMed memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisfied by an opcode,  in the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1751,7 +1751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x81, .msr_values = {0x00}},
       R"(TOR Occupancy; Remote Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisifed by an opcode,  in the TOR that are satisifed by remote caches or remote memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisfied by an opcode,  in the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1895,7 +1895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0x00}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1944,30 +1944,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Injection Starvation; Onto AD Ring (to core))",
       R"(Counts injection starvation.  This starvation is triggered when the Egress cannot send a transaction onto the ring for a long period of time.; cycles that the core AD egress spent in starvation)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_cbox,
-      "UNC_C_RxR_OCCUPANCY.IRQ_REJ",
-      EventDef::Encoding{.code = 0x11, .umask = 0x2, .msr_values = {0x00}},
-      R"(Ingress Occupancy; IRQ Rejected)",
-      R"(Counts number of entries in the specified Ingress queue in each cycle.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_cbox,
-      "UNC_C_LLC_VICTIMS.I_STATE",
-      EventDef::Encoding{.code = 0x37, .umask = 0x4, .msr_values = {0x00}},
-      R"(Lines Victimized; Lines in S State)",
-      R"(Counts the number of lines that were victimized on a fill.  This can be filtered by the state that the line was in.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2183,7 +2159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_DIRECTORY_LAT_OPT",
       EventDef::Encoding{.code = 0x41, .umask = 0x0, .msr_values = {0x00}},
       R"(Directory Lat Opt Return)",
-      R"(Directory Latency Optimization Data Return Path Taken. When directory mode is enabled and the directory retuned for a read is Dir=I, then data can be returned using a faster path if certain conditions are met (credits, free pipeline, etc).)",
+      R"(Directory Latency Optimization Data Return Path Taken. When directory mode is enabled and the directory returned for a read is Dir=I, then data can be returned using a faster path if certain conditions are met (credits, free pipeline, etc).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3683,7 +3659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_SNOOP_RESP.RSPSFWD",
       EventDef::Encoding{.code = 0x21, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses Received; RspSFwd)",
-      R"(Counts the total number of RspI snoop responses received.  Whenever a snoops are issued, one or more snoop responses will be returned depending on the topology of the system.   In systems larger than 2s, when multiple snoops are returned this will count all the snoops that are received.  For example, if 3 snoops were issued and returned RspI, RspS, and RspSFwd; then each of these sub-events would increment by 1.; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currentl copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
+      R"(Counts the total number of RspI snoop responses received.  Whenever a snoops are issued, one or more snoop responses will be returned depending on the topology of the system.   In systems larger than 2s, when multiple snoops are returned this will count all the snoops that are received.  For example, if 3 snoops were issued and returned RspI, RspS, and RspSFwd; then each of these sub-events would increment by 1.; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currently copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3767,7 +3743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_SNP_RESP_RECV_LOCAL.RSPSFWD",
       EventDef::Encoding{.code = 0x60, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses Received Local; RspSFwd)",
-      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currentl copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
+      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currently copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4627,42 +4603,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.LOCAL",
-      EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; Local Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from the local socket.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.REMOTE",
-      EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; Remote Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from remote sockets.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.ALL",
-      EventDef::Encoding{.code = 0x3, .umask = 0x3, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; All Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; Requests coming from both local and remote sockets.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_irp,
       "UNC_I_CACHE_TOTAL_OCCUPANCY.ANY",
       EventDef::Encoding{.code = 0x12, .umask = 0x1, .msr_values = {0x00}},
@@ -4799,7 +4739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REQ",
       EventDef::Encoding{.code = 0x14, .umask = 0x1, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Requests)",
-      R"(Misc Events - Set 0; Fastpath Requests)",
+      R"(Counts Timeouts - Set 0 : Fastpath Requests)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4811,7 +4751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REJ",
       EventDef::Encoding{.code = 0x14, .umask = 0x2, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Rejects)",
-      R"(Misc Events - Set 0; Fastpath Rejects)",
+      R"(Counts Timeouts - Set 0 : Fastpath Rejects)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4823,7 +4763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_RD_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x4, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Read Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4835,7 +4775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_WR_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x8, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Write Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4847,7 +4787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_ATOMIC_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Atomic Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4859,7 +4799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_XFER",
       EventDef::Encoding{.code = 0x14, .umask = 0x20, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
-      R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
+      R"(Counts Timeouts - Set 0 : Fastpath Transfers From Primary to Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4871,7 +4811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.PF_ACK_HINT",
       EventDef::Encoding{.code = 0x14, .umask = 0x40, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
-      R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
+      R"(Counts Timeouts - Set 0 : Prefetch Ack Hints From Primary to Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4931,7 +4871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC1.LOST_FWD",
       EventDef::Encoding{.code = 0x15, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 1)",
-      R"(Misc Events - Set 1)",
+      R"(Misc Events - Set 1 : Lost Forward : Snoop pulled away ownership before a write was committed)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4990,7 +4930,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x4, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5014,7 +4954,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_OCCUPANCY",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5026,7 +4966,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_CYCLES_FULL",
       EventDef::Encoding{.code = 0x5, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5050,7 +4990,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_OCCUPANCY",
       EventDef::Encoding{.code = 0x8, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5062,7 +5002,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x6, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5086,7 +5026,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_OCCUPANCY",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5099,7 +5039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.MISS",
       EventDef::Encoding{.code = 0x17, .umask = 0x1, .msr_values = {0x00}},
       R"(Snoop Responses; Miss)",
-      R"(Snoop Responses; Miss)",
+      R"(Snoop Responses : Miss)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5111,7 +5051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_I",
       EventDef::Encoding{.code = 0x17, .umask = 0x2, .msr_values = {0x00}},
       R"(Snoop Responses; Hit I)",
-      R"(Snoop Responses; Hit I)",
+      R"(Snoop Responses : Hit I)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5123,7 +5063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_ES",
       EventDef::Encoding{.code = 0x17, .umask = 0x4, .msr_values = {0x00}},
       R"(Snoop Responses; Hit E or S)",
-      R"(Snoop Responses; Hit E or S)",
+      R"(Snoop Responses : Hit E or S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5135,7 +5075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_M",
       EventDef::Encoding{.code = 0x17, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses; Hit M)",
-      R"(Snoop Responses; Hit M)",
+      R"(Snoop Responses : Hit M)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5147,7 +5087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPCODE",
       EventDef::Encoding{.code = 0x17, .umask = 0x10, .msr_values = {0x00}},
       R"(Snoop Responses; SnpCode)",
-      R"(Snoop Responses; SnpCode)",
+      R"(Snoop Responses : SnpCode)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5159,7 +5099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPDATA",
       EventDef::Encoding{.code = 0x17, .umask = 0x20, .msr_values = {0x00}},
       R"(Snoop Responses; SnpData)",
-      R"(Snoop Responses; SnpData)",
+      R"(Snoop Responses : SnpData)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5171,7 +5111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPINV",
       EventDef::Encoding{.code = 0x17, .umask = 0x40, .msr_values = {0x00}},
       R"(Snoop Responses; SnpInv)",
-      R"(Snoop Responses; SnpInv)",
+      R"(Snoop Responses : SnpInv)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5316,18 +5256,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0xD, .umask = 0x0, .msr_values = {0x00}},
       R"(Outbound Request Queue Occupancy)",
       R"(Accumultes the number of outstanding outbound requests from the IRP to the switch (towards the devices).  This can be used in conjuection with the allocations event in order to calculate average latency of outbound requests.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_MISC0.PF_TIMEOUT",
-      EventDef::Encoding{.code = 0x14, .umask = 0x80, .msr_values = {0x00}},
-      R"(Misc Events - Set 0; Prefetch TimeOut)",
-      R"(Indicates the fetch for a previous prefetch wasn't accepted by the prefetch.   This happens in the case of a prefetch TimeOut)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5963,7 +5891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C0",
       EventDef::Encoding{.code = 0x80, .umask = 0x40, .msr_values = {0x00}},
       R"(Number of cores in C-State; C0 and C1)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5975,7 +5903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C3",
       EventDef::Encoding{.code = 0x80, .umask = 0x80, .msr_values = {0x00}},
       R"(Number of cores in C-State; C3)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5987,7 +5915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C6",
       EventDef::Encoding{.code = 0x80, .umask = 0xC0, .msr_values = {0x00}},
       R"(Number of cores in C-State; C6 and C7)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6011,7 +5939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_PROCHOT_INTERNAL_CYCLES",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Internal Prochot)",
-      R"(Counts the number of cycles that we are in Interal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
+      R"(Counts the number of cycles that we are in Internal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6034,7 +5962,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_UFS_TRANSITIONS_NO_CHANGE",
       EventDef::Encoding{.code = 0x79, .umask = 0x00, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_NO_CHANGE (Description is auto-generated))",
+      R"(UNC_P_UFS_TRANSITIONS_NO_CHANGE)",
       R"(Ring GV with same final and initial frequency)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -6047,31 +5975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_VR_HOT_CYCLES",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
       R"(VR Hot)",
-      R"(VR Hot)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_pcu,
-      "UNC_P_PKG_RESIDENCY_C1E_CYCLES",
-      EventDef::Encoding{.code = 0x4E, .umask = 0x0, .msr_values = {0x00}},
-      R"(Package C State Residency - C1E)",
-      R"(Counts the number of cycles when the package was in C1E.  This event can be used in conjunction with edge detect to count C1E entrances (or exits using invert).  Residency events do not include transition times.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_pcu,
-      "UNC_P_UFS_TRANSITIONS_RING_GV",
-      EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_RING_GV (Description is auto-generated))",
-      R"(Ring GV with same final and initial frequency)",
+      R"(VR Hot : Number of cycles that a CPU SVID VR is hot.  Does not cover DRAM VRs)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6107,7 +6011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.SUCCESS_RBT_HIT",
       EventDef::Encoding{.code = 0x13, .umask = 0x1, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Success)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn was successful.  There were sufficient credits, the RBT valid bit was set and there was an RBT tag match.  The message was marked to spawn direct2core.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn was successful.  There were sufficient credits, the RBT valid bit was set and there was an RBT tag match.  The message was marked to spawn direct2core.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6119,7 +6023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS",
       EventDef::Encoding{.code = 0x13, .umask = 0x2, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress Credits)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits.  Had there been enough credits, the spawn would have worked as the RBT bit was set and the RBT tag matched.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits.  Had there been enough credits, the spawn would have worked as the RBT bit was set and the RBT tag matched.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6131,7 +6035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_RBT_HIT",
       EventDef::Encoding{.code = 0x13, .umask = 0x4, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the route-back table (RBT) specified that the transaction should not trigger a direct2core tranaction.  This is common for IO transactions.  There were enough Egress credits and the RBT tag matched but the valid bit was not set.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the route-back table (RBT) specified that the transaction should not trigger a direct2core transaction.  This is common for IO transactions.  There were enough Egress credits and the RBT tag matched but the valid bit was not set.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6143,7 +6047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_RBT",
       EventDef::Encoding{.code = 0x13, .umask = 0x8, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits AND the RBT bit was not set, but the RBT tag matched.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits AND the RBT bit was not set, but the RBT tag matched.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6155,7 +6059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x10, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Miss)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match although the valid bit was set and there were enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match although the valid bit was set and there were enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6167,7 +6071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x20, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Miss)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and there weren't enough Egress credits.   The valid bit was set.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and there weren't enough Egress credits.   The valid bit was set.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6179,7 +6083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_RBT_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x40, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Miss and Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and the valid bit was not set although there were enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and the valid bit was not set although there were enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6191,7 +6095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_RBT_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x80, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Miss, Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match, the valid bit was not set and there weren't enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match, the valid bit was not set and there weren't enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6239,7 +6143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_BYPASSED",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Rx Flit Buffer Bypassed)",
-      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6587,7 +6491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G0.IDLE",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 0; Idle and Null Flits)",
-      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
+      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generally not considered part of the QPI bandwidth.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6599,7 +6503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x2, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 1; SNP Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6611,7 +6515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6623,7 +6527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6635,7 +6539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x2, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6647,7 +6551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6659,7 +6563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6671,7 +6575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x2, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6683,7 +6587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AD)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6695,7 +6599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AK)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6707,7 +6611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6719,7 +6623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent non-data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6731,7 +6635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x3, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6743,7 +6647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent standard Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7307,7 +7211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Data Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7319,7 +7223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.NON_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Non-Data protocol Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7331,7 +7235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x0, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; SNP Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7343,7 +7247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7355,7 +7259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7367,7 +7271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x0, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7379,7 +7283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7391,7 +7295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7403,7 +7307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x0, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7415,7 +7319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AD)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7427,7 +7331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x1, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AK)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7439,7 +7343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7451,7 +7355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent non-data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7463,7 +7367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x1, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent Bypass Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7475,7 +7379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x1, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent standard Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7631,7 +7535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxR_AD_SNP_CREDIT_OCCUPANCY.VN0",
       EventDef::Encoding{.code = 0x23, .umask = 0x1, .msr_values = {0x00}},
       R"(R3QPI Egress Credit Occupancy - AD SNP; for VN0)",
-      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO fro Snoop messages on AD.)",
+      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO for Snoop messages on AD.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7643,7 +7547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxR_AD_SNP_CREDIT_OCCUPANCY.VN1",
       EventDef::Encoding{.code = 0x23, .umask = 0x2, .msr_values = {0x00}},
       R"(R3QPI Egress Credit Occupancy - AD SNP; for VN1)",
-      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO fro Snoop messages on AD.)",
+      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO for Snoop messages on AD.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7882,8 +7786,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7894,8 +7798,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7906,8 +7810,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7918,8 +7822,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10247,7 +10151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.AD",
       EventDef::Encoding{.code = 0x33, .umask = 0x1, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10259,7 +10163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.BL",
       EventDef::Encoding{.code = 0x33, .umask = 0x4, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10666,8 +10570,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AD_CACHE",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10678,8 +10582,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AK_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10690,8 +10594,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.BL_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10702,8 +10606,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.IV_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11062,8 +10966,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AD)",
+      R"(UNC_S_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11074,8 +10978,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AK)",
+      R"(UNC_S_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11086,8 +10990,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.BL)",
+      R"(UNC_S_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11467,18 +11371,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ubox,
-      "UNC_U_CLOCKTICKS",
-      EventDef::Encoding{.code = 0x00, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_U_CLOCKTICKS (Description is auto-generated))",
-      R"(UNC_U_CLOCKTICKS (Description is auto-generated))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_imc,
       "UNC_M_ACT_COUNT.RD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
@@ -11711,7 +11603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_ECC_CORRECTABLE_ERRORS",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(ECC Correctable Errors)",
-      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit erros in lockstep mode.)",
+      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit errors in lockstep mode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11902,8 +11794,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_imc,
       "UNC_M_POWER_PCU_THROTTLING",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12155,7 +12047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 1)",
-      R"(RD_CAS Access to Rank 0; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12167,7 +12059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 2)",
-      R"(RD_CAS Access to Rank 0; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12179,7 +12071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB0, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 4)",
-      R"(RD_CAS Access to Rank 0; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12191,7 +12083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB0, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 8)",
-      R"(RD_CAS Access to Rank 0; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12203,7 +12095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB0, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; All Banks)",
-      R"(RD_CAS Access to Rank 0; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12215,7 +12107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 0)",
-      R"(RD_CAS Access to Rank 0; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12227,7 +12119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 3)",
-      R"(RD_CAS Access to Rank 0; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12239,7 +12131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB0, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 5)",
-      R"(RD_CAS Access to Rank 0; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12251,7 +12143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB0, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 6)",
-      R"(RD_CAS Access to Rank 0; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12263,7 +12155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB0, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 7)",
-      R"(RD_CAS Access to Rank 0; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12275,7 +12167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB0, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 9)",
-      R"(RD_CAS Access to Rank 0; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12287,7 +12179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB0, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 10)",
-      R"(RD_CAS Access to Rank 0; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12299,7 +12191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB0, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 11)",
-      R"(RD_CAS Access to Rank 0; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12311,7 +12203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB0, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 12)",
-      R"(RD_CAS Access to Rank 0; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12323,7 +12215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB0, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 13)",
-      R"(RD_CAS Access to Rank 0; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12335,7 +12227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB0, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 14)",
-      R"(RD_CAS Access to Rank 0; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12347,7 +12239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB0, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 15)",
-      R"(RD_CAS Access to Rank 0; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12359,7 +12251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12371,7 +12263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12383,7 +12275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12395,7 +12287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12407,7 +12299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 1)",
-      R"(RD_CAS Access to Rank 1; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12419,7 +12311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 2)",
-      R"(RD_CAS Access to Rank 1; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12431,7 +12323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB1, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 4)",
-      R"(RD_CAS Access to Rank 1; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12443,7 +12335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB1, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 8)",
-      R"(RD_CAS Access to Rank 1; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12455,7 +12347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB1, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; All Banks)",
-      R"(RD_CAS Access to Rank 1; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12467,7 +12359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 0)",
-      R"(RD_CAS Access to Rank 1; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12479,7 +12371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 3)",
-      R"(RD_CAS Access to Rank 1; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12491,7 +12383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB1, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 5)",
-      R"(RD_CAS Access to Rank 1; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12503,7 +12395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB1, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 6)",
-      R"(RD_CAS Access to Rank 1; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12515,7 +12407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB1, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 7)",
-      R"(RD_CAS Access to Rank 1; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12527,7 +12419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB1, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 9)",
-      R"(RD_CAS Access to Rank 1; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12539,7 +12431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB1, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 10)",
-      R"(RD_CAS Access to Rank 1; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12551,7 +12443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB1, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 11)",
-      R"(RD_CAS Access to Rank 1; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12563,7 +12455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB1, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 12)",
-      R"(RD_CAS Access to Rank 1; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12575,7 +12467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB1, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 13)",
-      R"(RD_CAS Access to Rank 1; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12587,7 +12479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB1, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 14)",
-      R"(RD_CAS Access to Rank 1; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12599,7 +12491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB1, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 15)",
-      R"(RD_CAS Access to Rank 1; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12611,7 +12503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12623,7 +12515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12635,7 +12527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12647,7 +12539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12659,7 +12551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK2.BANK0",
       EventDef::Encoding{.code = 0xB2, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 2; Bank 0)",
-      R"(RD_CAS Access to Rank 2; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12671,7 +12563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 1)",
-      R"(RD_CAS Access to Rank 4; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12683,7 +12575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 2)",
-      R"(RD_CAS Access to Rank 4; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12695,7 +12587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xB4, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 4)",
-      R"(RD_CAS Access to Rank 4; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12707,7 +12599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xB4, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 8)",
-      R"(RD_CAS Access to Rank 4; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12719,7 +12611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xB4, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; All Banks)",
-      R"(RD_CAS Access to Rank 4; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12731,7 +12623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 0)",
-      R"(RD_CAS Access to Rank 4; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12743,7 +12635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 3)",
-      R"(RD_CAS Access to Rank 4; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12755,7 +12647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xB4, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 5)",
-      R"(RD_CAS Access to Rank 4; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12767,7 +12659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xB4, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 6)",
-      R"(RD_CAS Access to Rank 4; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12779,7 +12671,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xB4, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 7)",
-      R"(RD_CAS Access to Rank 4; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12791,7 +12683,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xB4, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 9)",
-      R"(RD_CAS Access to Rank 4; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12803,7 +12695,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xB4, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 10)",
-      R"(RD_CAS Access to Rank 4; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12815,7 +12707,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xB4, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 11)",
-      R"(RD_CAS Access to Rank 4; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12827,7 +12719,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xB4, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 12)",
-      R"(RD_CAS Access to Rank 4; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12839,7 +12731,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xB4, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 13)",
-      R"(RD_CAS Access to Rank 4; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12851,7 +12743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xB4, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 14)",
-      R"(RD_CAS Access to Rank 4; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12863,7 +12755,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xB4, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 15)",
-      R"(RD_CAS Access to Rank 4; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12875,7 +12767,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12887,7 +12779,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12899,7 +12791,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12911,7 +12803,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12923,7 +12815,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 1)",
-      R"(RD_CAS Access to Rank 5; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12935,7 +12827,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 2)",
-      R"(RD_CAS Access to Rank 5; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12947,7 +12839,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xB5, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 4)",
-      R"(RD_CAS Access to Rank 5; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12959,7 +12851,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xB5, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 8)",
-      R"(RD_CAS Access to Rank 5; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12971,7 +12863,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xB5, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; All Banks)",
-      R"(RD_CAS Access to Rank 5; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12983,7 +12875,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 0)",
-      R"(RD_CAS Access to Rank 5; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12995,7 +12887,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 3)",
-      R"(RD_CAS Access to Rank 5; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13007,7 +12899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xB5, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 5)",
-      R"(RD_CAS Access to Rank 5; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13019,7 +12911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xB5, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 6)",
-      R"(RD_CAS Access to Rank 5; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13031,7 +12923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xB5, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 7)",
-      R"(RD_CAS Access to Rank 5; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13043,7 +12935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xB5, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 9)",
-      R"(RD_CAS Access to Rank 5; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13055,7 +12947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xB5, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 10)",
-      R"(RD_CAS Access to Rank 5; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13067,7 +12959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xB5, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 11)",
-      R"(RD_CAS Access to Rank 5; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13079,7 +12971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xB5, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 12)",
-      R"(RD_CAS Access to Rank 5; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13091,7 +12983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xB5, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 13)",
-      R"(RD_CAS Access to Rank 5; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13103,7 +12995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xB5, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 14)",
-      R"(RD_CAS Access to Rank 5; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13115,7 +13007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xB5, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 15)",
-      R"(RD_CAS Access to Rank 5; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13127,7 +13019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13139,7 +13031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13151,7 +13043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13163,7 +13055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13175,7 +13067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 1)",
-      R"(RD_CAS Access to Rank 6; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13187,7 +13079,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 2)",
-      R"(RD_CAS Access to Rank 6; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13199,7 +13091,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xB6, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 4)",
-      R"(RD_CAS Access to Rank 6; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13211,7 +13103,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xB6, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 8)",
-      R"(RD_CAS Access to Rank 6; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13223,7 +13115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xB6, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; All Banks)",
-      R"(RD_CAS Access to Rank 6; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13235,7 +13127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 0)",
-      R"(RD_CAS Access to Rank 6; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13247,7 +13139,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 3)",
-      R"(RD_CAS Access to Rank 6; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13259,7 +13151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xB6, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 5)",
-      R"(RD_CAS Access to Rank 6; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13271,7 +13163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xB6, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 6)",
-      R"(RD_CAS Access to Rank 6; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13283,7 +13175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xB6, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 7)",
-      R"(RD_CAS Access to Rank 6; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13295,7 +13187,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xB6, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 9)",
-      R"(RD_CAS Access to Rank 6; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13307,7 +13199,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xB6, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 10)",
-      R"(RD_CAS Access to Rank 6; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13319,7 +13211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xB6, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 11)",
-      R"(RD_CAS Access to Rank 6; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13331,7 +13223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xB6, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 12)",
-      R"(RD_CAS Access to Rank 6; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13343,7 +13235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xB6, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 13)",
-      R"(RD_CAS Access to Rank 6; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13355,7 +13247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xB6, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 14)",
-      R"(RD_CAS Access to Rank 6; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13367,7 +13259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xB6, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 15)",
-      R"(RD_CAS Access to Rank 6; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13379,7 +13271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13391,7 +13283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13403,7 +13295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13415,7 +13307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13427,7 +13319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 1)",
-      R"(RD_CAS Access to Rank 7; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13439,7 +13331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 2)",
-      R"(RD_CAS Access to Rank 7; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13451,7 +13343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xB7, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 4)",
-      R"(RD_CAS Access to Rank 7; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13463,7 +13355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xB7, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 8)",
-      R"(RD_CAS Access to Rank 7; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13475,7 +13367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xB7, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; All Banks)",
-      R"(RD_CAS Access to Rank 7; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13487,7 +13379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 0)",
-      R"(RD_CAS Access to Rank 7; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13499,7 +13391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 3)",
-      R"(RD_CAS Access to Rank 7; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13511,7 +13403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xB7, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 5)",
-      R"(RD_CAS Access to Rank 7; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13523,7 +13415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xB7, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 6)",
-      R"(RD_CAS Access to Rank 7; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13535,7 +13427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xB7, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 7)",
-      R"(RD_CAS Access to Rank 7; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13547,7 +13439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xB7, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 9)",
-      R"(RD_CAS Access to Rank 7; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13559,7 +13451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xB7, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 10)",
-      R"(RD_CAS Access to Rank 7; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13571,7 +13463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xB7, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 11)",
-      R"(RD_CAS Access to Rank 7; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13583,7 +13475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xB7, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 12)",
-      R"(RD_CAS Access to Rank 7; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13595,7 +13487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xB7, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 13)",
-      R"(RD_CAS Access to Rank 7; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13607,7 +13499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xB7, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 14)",
-      R"(RD_CAS Access to Rank 7; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13619,7 +13511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xB7, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 15)",
-      R"(RD_CAS Access to Rank 7; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13631,7 +13523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13643,7 +13535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13655,7 +13547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13667,7 +13559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13835,7 +13727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 1)",
-      R"(WR_CAS Access to Rank 0; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13847,7 +13739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 2)",
-      R"(WR_CAS Access to Rank 0; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13859,7 +13751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB8, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 4)",
-      R"(WR_CAS Access to Rank 0; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13871,7 +13763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB8, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 8)",
-      R"(WR_CAS Access to Rank 0; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13883,7 +13775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB8, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; All Banks)",
-      R"(WR_CAS Access to Rank 0; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13895,7 +13787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 0)",
-      R"(WR_CAS Access to Rank 0; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13907,7 +13799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 3)",
-      R"(WR_CAS Access to Rank 0; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13919,7 +13811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB8, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 5)",
-      R"(WR_CAS Access to Rank 0; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13931,7 +13823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB8, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 6)",
-      R"(WR_CAS Access to Rank 0; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13943,7 +13835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB8, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 7)",
-      R"(WR_CAS Access to Rank 0; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13955,7 +13847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB8, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 9)",
-      R"(WR_CAS Access to Rank 0; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13967,7 +13859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB8, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 10)",
-      R"(WR_CAS Access to Rank 0; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13979,7 +13871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB8, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 11)",
-      R"(WR_CAS Access to Rank 0; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13991,7 +13883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB8, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 12)",
-      R"(WR_CAS Access to Rank 0; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14003,7 +13895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB8, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 13)",
-      R"(WR_CAS Access to Rank 0; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14015,7 +13907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB8, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 14)",
-      R"(WR_CAS Access to Rank 0; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14027,7 +13919,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB8, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 15)",
-      R"(WR_CAS Access to Rank 0; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14039,7 +13931,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14051,7 +13943,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14063,7 +13955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14075,7 +13967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14087,7 +13979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 1)",
-      R"(WR_CAS Access to Rank 1; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14099,7 +13991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 2)",
-      R"(WR_CAS Access to Rank 1; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14111,7 +14003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB9, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 4)",
-      R"(WR_CAS Access to Rank 1; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14123,7 +14015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB9, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 8)",
-      R"(WR_CAS Access to Rank 1; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14135,7 +14027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB9, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; All Banks)",
-      R"(WR_CAS Access to Rank 1; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14147,7 +14039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 0)",
-      R"(WR_CAS Access to Rank 1; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14159,7 +14051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 3)",
-      R"(WR_CAS Access to Rank 1; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14171,7 +14063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB9, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 5)",
-      R"(WR_CAS Access to Rank 1; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14183,7 +14075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB9, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 6)",
-      R"(WR_CAS Access to Rank 1; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14195,7 +14087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB9, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 7)",
-      R"(WR_CAS Access to Rank 1; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14207,7 +14099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB9, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 9)",
-      R"(WR_CAS Access to Rank 1; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14219,7 +14111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB9, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 10)",
-      R"(WR_CAS Access to Rank 1; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14231,7 +14123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB9, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 11)",
-      R"(WR_CAS Access to Rank 1; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14243,7 +14135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB9, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 12)",
-      R"(WR_CAS Access to Rank 1; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14255,7 +14147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB9, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 13)",
-      R"(WR_CAS Access to Rank 1; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14267,7 +14159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB9, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 14)",
-      R"(WR_CAS Access to Rank 1; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14279,7 +14171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB9, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 15)",
-      R"(WR_CAS Access to Rank 1; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14291,7 +14183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14303,7 +14195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14315,7 +14207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14327,7 +14219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14339,7 +14231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 1)",
-      R"(WR_CAS Access to Rank 4; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14351,7 +14243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 2)",
-      R"(WR_CAS Access to Rank 4; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14363,7 +14255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xBC, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 4)",
-      R"(WR_CAS Access to Rank 4; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14375,7 +14267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xBC, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 8)",
-      R"(WR_CAS Access to Rank 4; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14387,7 +14279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xBC, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; All Banks)",
-      R"(WR_CAS Access to Rank 4; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14399,7 +14291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 0)",
-      R"(WR_CAS Access to Rank 4; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14411,7 +14303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 3)",
-      R"(WR_CAS Access to Rank 4; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14423,7 +14315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xBC, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 5)",
-      R"(WR_CAS Access to Rank 4; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14435,7 +14327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xBC, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 6)",
-      R"(WR_CAS Access to Rank 4; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14447,7 +14339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xBC, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 7)",
-      R"(WR_CAS Access to Rank 4; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14459,7 +14351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xBC, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 9)",
-      R"(WR_CAS Access to Rank 4; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14471,7 +14363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xBC, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 10)",
-      R"(WR_CAS Access to Rank 4; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14483,7 +14375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xBC, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 11)",
-      R"(WR_CAS Access to Rank 4; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14495,7 +14387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xBC, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 12)",
-      R"(WR_CAS Access to Rank 4; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14507,7 +14399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xBC, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 13)",
-      R"(WR_CAS Access to Rank 4; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14519,7 +14411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xBC, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 14)",
-      R"(WR_CAS Access to Rank 4; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14531,7 +14423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xBC, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 15)",
-      R"(WR_CAS Access to Rank 4; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14543,7 +14435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14555,7 +14447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14567,7 +14459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14579,7 +14471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14591,7 +14483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 1)",
-      R"(WR_CAS Access to Rank 5; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14603,7 +14495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 2)",
-      R"(WR_CAS Access to Rank 5; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14615,7 +14507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xBD, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 4)",
-      R"(WR_CAS Access to Rank 5; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14627,7 +14519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xBD, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 8)",
-      R"(WR_CAS Access to Rank 5; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14639,7 +14531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xBD, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; All Banks)",
-      R"(WR_CAS Access to Rank 5; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14651,7 +14543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 0)",
-      R"(WR_CAS Access to Rank 5; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14663,7 +14555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 3)",
-      R"(WR_CAS Access to Rank 5; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14675,7 +14567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xBD, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 5)",
-      R"(WR_CAS Access to Rank 5; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14687,7 +14579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xBD, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 6)",
-      R"(WR_CAS Access to Rank 5; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14699,7 +14591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xBD, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 7)",
-      R"(WR_CAS Access to Rank 5; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14711,7 +14603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xBD, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 9)",
-      R"(WR_CAS Access to Rank 5; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14723,7 +14615,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xBD, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 10)",
-      R"(WR_CAS Access to Rank 5; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14735,7 +14627,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xBD, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 11)",
-      R"(WR_CAS Access to Rank 5; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14747,7 +14639,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xBD, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 12)",
-      R"(WR_CAS Access to Rank 5; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14759,7 +14651,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xBD, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 13)",
-      R"(WR_CAS Access to Rank 5; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14771,7 +14663,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xBD, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 14)",
-      R"(WR_CAS Access to Rank 5; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14783,7 +14675,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xBD, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 15)",
-      R"(WR_CAS Access to Rank 5; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14795,7 +14687,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14807,7 +14699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14819,7 +14711,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14831,7 +14723,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14843,7 +14735,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 1)",
-      R"(WR_CAS Access to Rank 6; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14855,7 +14747,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 2)",
-      R"(WR_CAS Access to Rank 6; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14867,7 +14759,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xBE, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 4)",
-      R"(WR_CAS Access to Rank 6; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14879,7 +14771,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xBE, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 8)",
-      R"(WR_CAS Access to Rank 6; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14891,7 +14783,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xBE, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; All Banks)",
-      R"(WR_CAS Access to Rank 6; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14903,7 +14795,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 0)",
-      R"(WR_CAS Access to Rank 6; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14915,7 +14807,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 3)",
-      R"(WR_CAS Access to Rank 6; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14927,7 +14819,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xBE, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 5)",
-      R"(WR_CAS Access to Rank 6; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14939,7 +14831,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xBE, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 6)",
-      R"(WR_CAS Access to Rank 6; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14951,7 +14843,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xBE, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 7)",
-      R"(WR_CAS Access to Rank 6; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14963,7 +14855,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xBE, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 9)",
-      R"(WR_CAS Access to Rank 6; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14975,7 +14867,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xBE, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 10)",
-      R"(WR_CAS Access to Rank 6; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14987,7 +14879,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xBE, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 11)",
-      R"(WR_CAS Access to Rank 6; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14999,7 +14891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xBE, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 12)",
-      R"(WR_CAS Access to Rank 6; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15011,7 +14903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xBE, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 13)",
-      R"(WR_CAS Access to Rank 6; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15023,7 +14915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xBE, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 14)",
-      R"(WR_CAS Access to Rank 6; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15035,7 +14927,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xBE, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 15)",
-      R"(WR_CAS Access to Rank 6; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15047,7 +14939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15059,7 +14951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15071,7 +14963,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15083,7 +14975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15095,7 +14987,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 1)",
-      R"(WR_CAS Access to Rank 7; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15107,7 +14999,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 2)",
-      R"(WR_CAS Access to Rank 7; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15119,7 +15011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xBF, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 4)",
-      R"(WR_CAS Access to Rank 7; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15131,7 +15023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xBF, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 8)",
-      R"(WR_CAS Access to Rank 7; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15143,7 +15035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xBF, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; All Banks)",
-      R"(WR_CAS Access to Rank 7; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15155,7 +15047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 0)",
-      R"(WR_CAS Access to Rank 7; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15167,7 +15059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 3)",
-      R"(WR_CAS Access to Rank 7; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15179,7 +15071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xBF, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 5)",
-      R"(WR_CAS Access to Rank 7; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15191,7 +15083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xBF, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 6)",
-      R"(WR_CAS Access to Rank 7; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15203,7 +15095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xBF, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 7)",
-      R"(WR_CAS Access to Rank 7; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15215,7 +15107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xBF, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 9)",
-      R"(WR_CAS Access to Rank 7; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15227,7 +15119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xBF, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 10)",
-      R"(WR_CAS Access to Rank 7; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15239,7 +15131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xBF, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 11)",
-      R"(WR_CAS Access to Rank 7; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15251,7 +15143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xBF, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 12)",
-      R"(WR_CAS Access to Rank 7; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15263,7 +15155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xBF, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 13)",
-      R"(WR_CAS Access to Rank 7; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15275,7 +15167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xBF, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 14)",
-      R"(WR_CAS Access to Rank 7; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15287,7 +15179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xBF, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 15)",
-      R"(WR_CAS Access to Rank 7; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15299,7 +15191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15311,7 +15203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15323,7 +15215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15335,7 +15227,79 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ubox,
+      "UNC_U_CLOCKTICKS",
+      EventDef::Encoding{.code = 0x00, .umask = 0x0, .msr_values = {0x00}},
+      R"(UNC_U_CLOCKTICKS)",
+      R"(UNC_U_CLOCKTICKS)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_cbox,
+      "UNC_C_RxR_OCCUPANCY.IRQ_REJ",
+      EventDef::Encoding{.code = 0x11, .umask = 0x2, .msr_values = {0x00}},
+      R"(Ingress Occupancy; IRQ Rejected)",
+      R"(Counts number of entries in the specified Ingress queue in each cycle.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.LOCAL",
+      EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; Local Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from the local socket.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.REMOTE",
+      EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; Remote Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from remote sockets.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.ALL",
+      EventDef::Encoding{.code = 0x3, .umask = 0x3, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; All Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; Requests coming from both local and remote sockets.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_MISC0.PF_TIMEOUT",
+      EventDef::Encoding{.code = 0x14, .umask = 0x80, .msr_values = {0x00}},
+      R"(Misc Events - Set 0; Prefetch TimeOut)",
+      R"(Indicates the fetch for a previous prefetch wasn't accepted by the prefetch.   This happens in the case of a prefetch TimeOut)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15353,7 +15317,43 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_cbox,
+      "UNC_C_LLC_VICTIMS.I_STATE",
+      EventDef::Encoding{.code = 0x37, .umask = 0x4, .msr_values = {0x00}},
+      R"(Lines Victimized; Lines in S State)",
+      R"(Counts the number of lines that were victimized on a fill.  This can be filtered by the state that the line was in.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_PKG_RESIDENCY_C1E_CYCLES",
+      EventDef::Encoding{.code = 0x4E, .umask = 0x0, .msr_values = {0x00}},
+      R"(Package C State Residency - C1E)",
+      R"(Counts the number of cycles when the package was in C1E.  This event can be used in conjunction with edge detect to count C1E entrances (or exits using invert).  Residency events do not include transition times.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_UFS_TRANSITIONS_RING_GV",
+      EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
+      R"(UNC_P_UFS_TRANSITIONS_RING_GV)",
+      R"(Ring GV with same final and initial frequency)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 }
 
-} // namespace haswellx_uncore_v20
+} // namespace haswellx_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/ivybridge_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/ivybridge_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace ivybridge_core_v21 {
+namespace ivybridge_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from ivybridge_core_v21.json (317 events).
+    Events from ivybridge_core.json (317 events).
 
     Supported SKUs:
         - Arch: x86, Model: IVB id: 58
@@ -199,8 +199,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3994,5 +3994,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace ivybridge_core_v21
+} // namespace ivybridge_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/ivybridge_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/ivybridge_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace ivybridge_uncore_v21 {
+namespace ivybridge_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from ivybridge_uncore_v21.json (34 events).
+    Events from ivybridge_uncore.json (34 events).
 
     Supported SKUs:
         - Arch: x86, Model: IVB id: 58
@@ -427,5 +427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace ivybridge_uncore_v21
+} // namespace ivybridge_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from NehalemEX_core_V2.json (553 events).
+    Events from NehalemEX_core.json (553 events).
 
     Supported SKUs:
         - Arch: x86, Model: NHM-EX id: 46
@@ -5085,8 +5085,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.IO_CSR_MMIO",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x8033}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5098,8 +5098,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_NO_OTHER_CORE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x133}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5111,8 +5111,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x233}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5124,8 +5124,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x433}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5163,8 +5163,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LOCAL_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x4033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5202,8 +5202,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1033}},
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5215,8 +5215,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x833}},
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5228,8 +5228,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x2033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7304,5 +7304,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_core_v16.json (406 events).
+    Events from sandybridge_core.json (406 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -88,7 +88,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x03, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Cases when loads get true Block-on-Store blocking code preventing store forwarding.)",
-      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceeding smaller uncompleted store.  See the table of not supported store forwards in the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
+      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceding smaller uncompleted store.  See the table of not supported store forwards in the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -235,8 +235,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -320,8 +320,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "FP_COMP_OPS_EXE.X87",
       EventDef::Encoding{
           .code = 0x10, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -816,8 +816,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.PENDING",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(L1D miss oustandings duration in cycles.)",
-      R"(L1D miss oustandings duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -856,8 +856,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.FB_FULL",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1025,7 +1025,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x20, .cmask = 1, .msr_values = {0}},
       R"(Performance sensitive flags-merging uops added by Sandy Bridge u-arch.)",
-      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.)",
+      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1037,7 +1037,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x40, .cmask = 0, .msr_values = {0}},
       R"(Cycles with at least one slow LEA uop being allocated.)",
-      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
+      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1345,8 +1345,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1357,8 +1357,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1373,8 +1373,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1409,8 +1409,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_MITE_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1445,8 +1445,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1457,8 +1457,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2405,8 +2405,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_REQUESTS.DEMAND_CODE_RD",
       EventDef::Encoding{
           .code = 0xB0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cacheable and noncachaeble code read requests.)",
-      R"(Cacheable and noncachaeble code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3194,7 +3194,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -3206,7 +3206,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -4136,8 +4136,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.COREWB.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10008}},
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5064,7 +5064,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.ANY_REQUEST.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80408fff}},
-      R"( REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       R"(This event counts any requests that miss the LLC where the data was returned from local DRAM)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5077,8 +5077,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10433}},
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5090,8 +5090,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN_SOCKET.LLC_MISS_LOCAL.ANY_LLC_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x17004001b3}},
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5103,8 +5103,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400004}},
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5116,8 +5116,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_HIT_M.HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1000040002}},
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5129,8 +5129,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400010}},
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5142,8 +5142,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10040}},
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5155,8 +5155,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400040}},
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5168,8 +5168,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5181,8 +5181,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5194,8 +5194,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5207,8 +5207,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5216,5 +5216,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_uncore_v16.json (34 events).
+    Events from sandybridge_uncore.json (34 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -427,5 +427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -38,6 +38,7 @@ TEST(PerCpuThreadSwitchGenerator, SmokeTest) {
 
   g.open(2);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -66,6 +67,7 @@ TEST(PerCpuCountSampleGenerator, SmokeTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -140,6 +142,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Open without pinning the events.
   g.open(false);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -255,6 +258,7 @@ TEST(BPerfCountReader, SmokeTest) {
       std::make_unique<FdWrapper>(cgroup_path));
 
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -311,6 +315,7 @@ TEST(PerCpuCountSampleGenerator, TracePointTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -338,6 +343,7 @@ TEST(PerCpuDummyGenerator, SmokeTest) {
 
   g.open();
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.now();
   g.tstampFromTsc(1000000);
@@ -380,6 +386,8 @@ TEST(CpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   sleep(1);
   g.disable();
   // we should receive a itrace start perf event
@@ -435,6 +443,8 @@ TEST(PerCpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   *phase = 1;
   while (*phase == 1)
     ;


### PR DESCRIPTION
Summary:
This is an intermidate diff to keep ShipIt from OOMing, full summary of changes in D42151461.

Intel has retired download.01.org json events and moved them over to github with several changes.
* Version json files no longer exist
* Json files now included a header and event section.
* List of events in the Event section is equivalent to old files
* mapfiles.csv has three new sections: Core Type, Native Model ID, and Core Role Name

Differential Revision: D42201401

