### PR TITLE
Download and generate Intel events from Github: SKX, SKL

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -153,9 +153,10 @@ bool BPerfEventsGroup::reenable_() {
 
 [[nodiscard]] bool BPerfEventsGroup::enable() {
   int attr_map_fd, err;
-  struct bperf_attr_map_elem entry = {};
-  struct bpf_perf_event_value val = {};
   bool success = false;
+  struct bperf_attr_map_elem entry = {};
+  std::vector<struct bpf_perf_event_value> val;
+  val.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE, {});
 
   if (enabled_) {
     HBT_LOG_WARNING() << "BPerfEventsGroup is already enabled";
@@ -212,10 +213,15 @@ bool BPerfEventsGroup::reenable_() {
       break;
     case BPerfEventType::Cgroup:
       output_fd_ = ::bpf_map_get_fd_by_id(entry.cgroup_output_map_id);
-      err = ::bpf_map_lookup_elem(output_fd_, &id_, &val);
+      err = ::bpf_map_lookup_elem(output_fd_, &id_, val.data());
       if (err) {
-        ::bpf_map_update_elem(output_fd_, &id_, &val, BPF_ANY);
+        err = ::bpf_map_update_elem(output_fd_, &id_, val.data(), BPF_ANY);
+        if (err) {
+          HBT_LOG_ERROR() << "Failed to initlize map elem: " << err;
+          goto out;
+        }
       }
+
       break;
   }
 
@@ -348,14 +354,16 @@ out:
     struct bpf_perf_event_value* output,
     bool skip_offset) {
   auto event_cnt = confs_.size();
-  struct bpf_perf_event_value values[cpu_cnt_ * BPERF_MAX_GROUP_SIZE];
+  std::vector<struct bpf_perf_event_value> values;
+  values.resize((uint64_t)cpu_cnt_ * BPERF_MAX_GROUP_SIZE);
 
   if (!enabled_) {
     return -1;
   }
 
   syncGlobal_();
-  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values); ret) {
+  HBT_LOG_WARNING() << "id_:" << id_;
+  if (int ret = ::bpf_map_lookup_elem(output_fd_, &id_, values.data()); ret) {
     HBT_LOG_ERROR() << "cannot look up key " << id_
                     << " from output map. Return value: " << ret;
     return -1;

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -449,9 +449,10 @@ struct GroupReadValues {
   uint64_t getCount(size_t i) const {
     HBT_DCHECK_LE(t->time_running, t->time_enabled);
     HBT_ARG_CHECK_LT(i, getNumEvents()) << "Index out of range";
-    if (t->time_enabled == 0) {
+    if (t->time_enabled == 0 || t->time_running == 0) {
       return 0;
     }
+
     return static_cast<uint64_t>(
         static_cast<double>(t->count[i]) *
         static_cast<double>(t->time_enabled) /

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -14,9 +14,9 @@ namespace nehalemex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace nehalemex_core
 
-namespace goldmont_core_v13 {
+namespace goldmont_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace goldmont_core_v13
+} // namespace goldmont_core
 
 namespace sandybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -26,21 +26,21 @@ namespace sandybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace sandybridge_uncore
 
-namespace ivybridge_core_v21 {
+namespace ivybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace ivybridge_core_v21
+} // namespace ivybridge_core
 
-namespace ivybridge_uncore_v21 {
+namespace ivybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace ivybridge_uncore_v21
+} // namespace ivybridge_uncore
 
-namespace haswellx_core_v20 {
+namespace haswellx_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace haswellx_core_v20
+} // namespace haswellx_core
 
-namespace haswellx_uncore_v20 {
+namespace haswellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace haswellx_uncore_v20
+} // namespace haswellx_uncore
 
 namespace broadwell_core_v25 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -191,10 +191,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(58, 0x13): // fall-through
     case toCpuKey(58, 0x14): // fall-through
     case toCpuKey(58, 0x15): // fall-through
-      // from ivybridge_core_v21.json
-      ivybridge_core_v21::addEvents(pmu_manager);
-      // from ivybridge_uncore_v21.json
-      ivybridge_uncore_v21::addEvents(pmu_manager);
+      // from ivybridge_core.json
+      ivybridge_core::addEvents(pmu_manager);
+      // from ivybridge_uncore.json
+      ivybridge_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(61, 0x0): // fall-through
@@ -235,10 +235,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(63, 0x13): // fall-through
     case toCpuKey(63, 0x14): // fall-through
     case toCpuKey(63, 0x15): // fall-through
-      // from haswellx_core_v20.json
-      haswellx_core_v20::addEvents(pmu_manager);
-      // from haswellx_uncore_v20.json
-      haswellx_uncore_v20::addEvents(pmu_manager);
+      // from haswellx_core.json
+      haswellx_core::addEvents(pmu_manager);
+      // from haswellx_uncore.json
+      haswellx_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(71, 0x0): // fall-through
@@ -399,8 +399,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(92, 0x13): // fall-through
     case toCpuKey(92, 0x14): // fall-through
     case toCpuKey(92, 0x15): // fall-through
-      // from goldmont_core_v13.json
-      goldmont_core_v13::addEvents(pmu_manager);
+      // from goldmont_core.json
+      goldmont_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(94, 0x0): // fall-through
@@ -441,8 +441,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(95, 0x13): // fall-through
     case toCpuKey(95, 0x14): // fall-through
     case toCpuKey(95, 0x15): // fall-through
-      // from goldmont_core_v13.json
-      goldmont_core_v13::addEvents(pmu_manager);
+      // from goldmont_core.json
+      goldmont_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(126, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -66,13 +66,13 @@ namespace broadwellde_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace broadwellde_uncore
 
-namespace skylake_core_v48 {
+namespace skylake_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace skylake_core_v48
+} // namespace skylake_core
 
-namespace skylake_uncore_v48 {
+namespace skylake_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace skylake_uncore_v48
+} // namespace skylake_uncore
 
 namespace knightslanding_core_v9 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -82,18 +82,17 @@ namespace knightslanding_uncore_v9 {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace knightslanding_uncore_v9
 
-namespace skylakex_core_v1_21 {
+namespace skylakex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace skylakex_core_v1_21
+} // namespace skylakex_core
 
-namespace skylakex_uncore_v1_21 {
+namespace skylakex_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace skylakex_uncore_v1_21
+} // namespace skylakex_uncore
 
-namespace skylakex_uncore_v1_21_experimental {
+namespace skylakex_uncore_experimental {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace skylakex_uncore_v1_21_experimental
-
+} // namespace skylakex_uncore_experimental
 namespace cascadelakex_core_v1_08 {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace cascadelakex_core_v1_08
@@ -279,10 +278,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(78, 0x13): // fall-through
     case toCpuKey(78, 0x14): // fall-through
     case toCpuKey(78, 0x15): // fall-through
-      // from skylake_core_v48.json
-      skylake_core_v48::addEvents(pmu_manager);
-      // from skylake_uncore_v48.json
-      skylake_uncore_v48::addEvents(pmu_manager);
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(79, 0x0): // fall-through
@@ -312,12 +311,12 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(85, 0x2): // fall-through
     case toCpuKey(85, 0x3): // fall-through
     case toCpuKey(85, 0x4): // fall-through
-      // from skylakex_core_v1.21.json
-      skylakex_core_v1_21::addEvents(pmu_manager);
-      // from skylakex_uncore_v1.21.json
-      skylakex_uncore_v1_21::addEvents(pmu_manager);
-      // from skylakex_uncore_v1.21_experimental.json
-      skylakex_uncore_v1_21_experimental::addEvents(pmu_manager);
+      // from skylakex_core.json
+      skylakex_core::addEvents(pmu_manager);
+      // from skylakex_uncore.json
+      skylakex_uncore::addEvents(pmu_manager);
+      // from skylakex_uncore_experimental.json
+      skylakex_uncore_experimental::addEvents(pmu_manager);
       break;
 
     case toCpuKey(85, 0x5): // fall-through
@@ -419,10 +418,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(94, 0x13): // fall-through
     case toCpuKey(94, 0x14): // fall-through
     case toCpuKey(94, 0x15): // fall-through
-      // from skylake_core_v48.json
-      skylake_core_v48::addEvents(pmu_manager);
-      // from skylake_uncore_v48.json
-      skylake_uncore_v48::addEvents(pmu_manager);
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(95, 0x0): // fall-through
@@ -527,10 +526,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(142, 0x13): // fall-through
     case toCpuKey(142, 0x14): // fall-through
     case toCpuKey(142, 0x15): // fall-through
-      // from skylake_core_v48.json
-      skylake_core_v48::addEvents(pmu_manager);
-      // from skylake_uncore_v48.json
-      skylake_uncore_v48::addEvents(pmu_manager);
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(158, 0x0): // fall-through
@@ -549,10 +548,54 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(158, 0x13): // fall-through
     case toCpuKey(158, 0x14): // fall-through
     case toCpuKey(158, 0x15): // fall-through
-      // from skylake_core_v48.json
-      skylake_core_v48::addEvents(pmu_manager);
-      // from skylake_uncore_v48.json
-      skylake_uncore_v48::addEvents(pmu_manager);
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
+      break;
+
+    case toCpuKey(165, 0x0): // fall-through
+    case toCpuKey(165, 0x1): // fall-through
+    case toCpuKey(165, 0x2): // fall-through
+    case toCpuKey(165, 0x3): // fall-through
+    case toCpuKey(165, 0x4): // fall-through
+    case toCpuKey(165, 0x5): // fall-through
+    case toCpuKey(165, 0x6): // fall-through
+    case toCpuKey(165, 0x7): // fall-through
+    case toCpuKey(165, 0x8): // fall-through
+    case toCpuKey(165, 0x9): // fall-through
+    case toCpuKey(165, 0x10): // fall-through
+    case toCpuKey(165, 0x11): // fall-through
+    case toCpuKey(165, 0x12): // fall-through
+    case toCpuKey(165, 0x13): // fall-through
+    case toCpuKey(165, 0x14): // fall-through
+    case toCpuKey(165, 0x15): // fall-through
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
+      break;
+
+    case toCpuKey(166, 0x0): // fall-through
+    case toCpuKey(166, 0x1): // fall-through
+    case toCpuKey(166, 0x2): // fall-through
+    case toCpuKey(166, 0x3): // fall-through
+    case toCpuKey(166, 0x4): // fall-through
+    case toCpuKey(166, 0x5): // fall-through
+    case toCpuKey(166, 0x6): // fall-through
+    case toCpuKey(166, 0x7): // fall-through
+    case toCpuKey(166, 0x8): // fall-through
+    case toCpuKey(166, 0x9): // fall-through
+    case toCpuKey(166, 0x10): // fall-through
+    case toCpuKey(166, 0x11): // fall-through
+    case toCpuKey(166, 0x12): // fall-through
+    case toCpuKey(166, 0x13): // fall-through
+    case toCpuKey(166, 0x14): // fall-through
+    case toCpuKey(166, 0x15): // fall-through
+      // from skylake_core.json
+      skylake_core::addEvents(pmu_manager);
+      // from skylake_uncore.json
+      skylake_uncore::addEvents(pmu_manager);
       break;
 
     default:

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -42,29 +42,29 @@ namespace haswellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace haswellx_uncore
 
-namespace broadwell_core_v25 {
+namespace broadwell_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwell_core_v25
+} // namespace broadwell_core
 
-namespace broadwell_uncore_v25 {
+namespace broadwell_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwell_uncore_v25
+} // namespace broadwell_uncore
 
-namespace broadwellx_core_v14 {
+namespace broadwellx_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellx_core_v14
+} // namespace broadwellx_core
 
-namespace broadwellx_uncore_v14 {
+namespace broadwellx_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellx_uncore_v14
+} // namespace broadwellx_uncore
 
-namespace broadwellde_core_v7 {
+namespace broadwellde_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellde_core_v7
+} // namespace broadwellde_core
 
-namespace broadwellde_uncore_v7 {
+namespace broadwellde_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace broadwellde_uncore_v7
+} // namespace broadwellde_uncore
 
 namespace skylake_core_v48 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -213,10 +213,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(61, 0x13): // fall-through
     case toCpuKey(61, 0x14): // fall-through
     case toCpuKey(61, 0x15): // fall-through
-      // from broadwell_core_v25.json
-      broadwell_core_v25::addEvents(pmu_manager);
-      // from broadwell_uncore_v25.json
-      broadwell_uncore_v25::addEvents(pmu_manager);
+      // from broadwell_core.json
+      broadwell_core::addEvents(pmu_manager);
+      // from broadwell_uncore.json
+      broadwell_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(63, 0x0): // fall-through
@@ -257,10 +257,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(71, 0x13): // fall-through
     case toCpuKey(71, 0x14): // fall-through
     case toCpuKey(71, 0x15): // fall-through
-      // from broadwell_core_v25.json
-      broadwell_core_v25::addEvents(pmu_manager);
-      // from broadwell_uncore_v25.json
-      broadwell_uncore_v25::addEvents(pmu_manager);
+      // from broadwell_core.json
+      broadwell_core::addEvents(pmu_manager);
+      // from broadwell_uncore.json
+      broadwell_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(78, 0x0): // fall-through
@@ -301,10 +301,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(79, 0x13): // fall-through
     case toCpuKey(79, 0x14): // fall-through
     case toCpuKey(79, 0x15): // fall-through
-      // from broadwellx_core_v14.json
-      broadwellx_core_v14::addEvents(pmu_manager);
-      // from broadwellx_uncore_v14.json
-      broadwellx_uncore_v14::addEvents(pmu_manager);
+      // from broadwellx_core.json
+      broadwellx_core::addEvents(pmu_manager);
+      // from broadwellx_uncore.json
+      broadwellx_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(85, 0x0): // fall-through
@@ -355,10 +355,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(86, 0x13): // fall-through
     case toCpuKey(86, 0x14): // fall-through
     case toCpuKey(86, 0x15): // fall-through
-      // from broadwellde_core_v7.json
-      broadwellde_core_v7::addEvents(pmu_manager);
-      // from broadwellde_uncore_v7.json
-      broadwellde_uncore_v7::addEvents(pmu_manager);
+      // from broadwellde_core.json
+      broadwellde_core::addEvents(pmu_manager);
+      // from broadwellde_uncore.json
+      broadwellde_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(87, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
+++ b/hbt/src/perf_event/json_events/generated/intel/JsonEvents.h
@@ -10,21 +10,21 @@
 
 namespace facebook::hbt::perf_event::generated {
 
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 
 namespace goldmont_core_v13 {
 void addEvents(PmuDeviceManager& pmu_manager);
 } // namespace goldmont_core_v13
 
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 void addEvents(PmuDeviceManager& pmu_manager);
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 
 namespace ivybridge_core_v21 {
 void addEvents(PmuDeviceManager& pmu_manager);
@@ -149,10 +149,10 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(42, 0x13): // fall-through
     case toCpuKey(42, 0x14): // fall-through
     case toCpuKey(42, 0x15): // fall-through
-      // from sandybridge_core_v16.json
-      sandybridge_core_v16::addEvents(pmu_manager);
-      // from sandybridge_uncore_v16.json
-      sandybridge_uncore_v16::addEvents(pmu_manager);
+      // from sandybridge_core.json
+      sandybridge_core::addEvents(pmu_manager);
+      // from sandybridge_uncore.json
+      sandybridge_uncore::addEvents(pmu_manager);
       break;
 
     case toCpuKey(46, 0x0): // fall-through
@@ -171,8 +171,8 @@ addEvents(uint32_t cpu_model, uint32_t step, PmuDeviceManager& pmu_manager) {
     case toCpuKey(46, 0x13): // fall-through
     case toCpuKey(46, 0x14): // fall-through
     case toCpuKey(46, 0x15): // fall-through
-      // from NehalemEX_core_V2.json
-      nehalemex_core_v2::addEvents(pmu_manager);
+      // from NehalemEX_core.json
+      nehalemex_core::addEvents(pmu_manager);
       break;
 
     case toCpuKey(58, 0x0): // fall-through

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwell_core_v25 {
+namespace broadwell_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwell_core_v25.json (741 events).
+    Events from broadwell_core.json (741 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW id: 61
@@ -3031,7 +3031,7 @@ Note: Writeback pending FIFO has six entries.)",
       R"(This event counts all actually retired uops. Counting increments by two for micro-fused uops, and by one for macro-fused and other uops. Maximal increment value for one cycle is eight.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
+      EventDef::IntelFeatures{.pebs = 1},
       R"(0)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3703,96 +3703,96 @@ Note: Writeback pending FIFO has six entries.)",
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4)",
       R"(Counts randomly selected loads with latency value being above four.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8)",
       R"(Counts randomly selected loads with latency value being above eight.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16)",
       R"(Counts randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32)",
       R"(Counts randomly selected loads with latency value being above 32.)",
       100007,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64)",
       R"(Counts randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128)",
       R"(Counts randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256)",
       R"(Counts randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512)",
       R"(Counts randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3838,7 +3838,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -3850,7 +3850,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -10256,5 +10256,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       R"(0)"));
 }
 
-} // namespace broadwell_core_v25
+} // namespace broadwell_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwell_uncore_v25 {
+namespace broadwell_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwell_uncore_v25.json (23 events).
+    Events from broadwell_uncore.json (23 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW id: 61
@@ -296,5 +296,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwell_uncore_v25
+} // namespace broadwell_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellde_core_v7 {
+namespace broadwellde_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellde_core_v7.json (340 events).
+    Events from broadwellde_core.json (340 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW-DE id: 86
@@ -4086,7 +4086,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.(Precise Event - PEBS))",
-      R"(This is a precise version (that is, uses PEBS) of the event that counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This is a precise version (that is, uses PEBS) of the event that counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -4099,7 +4099,7 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary. (Precise Event - PEBS))",
-      R"(This is a precise version (that is, uses PEBS) of the event that counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This is a precise version (that is, uses PEBS) of the event that counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -4518,5 +4518,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       ));
 }
 
-} // namespace broadwellde_core_v7
+} // namespace broadwellde_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellde_uncore_v7 {
+namespace broadwellde_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellde_uncore_v7.json (900 events).
+    Events from broadwellde_uncore.json (900 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDW-DE id: 86
@@ -1907,7 +1907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10819,5 +10819,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwellde_uncore_v7
+} // namespace broadwellde_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellx_core_v14 {
+namespace broadwellx_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellx_core_v14.json (371 events).
+    Events from broadwellx_core.json (372 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDX id: 79
@@ -30,7 +30,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -42,7 +43,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -58,7 +60,8 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -71,7 +74,8 @@ Note: On all current platforms this event stops counting during 'throttling (TM)
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -91,7 +95,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -103,7 +108,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -115,7 +121,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -127,7 +134,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -139,7 +147,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -223,7 +232,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -235,7 +245,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -247,7 +258,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -259,7 +271,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -275,7 +288,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -287,7 +301,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -299,7 +314,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -315,7 +331,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -328,7 +345,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -340,7 +358,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -352,7 +371,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -364,7 +384,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -376,7 +397,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -388,7 +410,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -400,7 +423,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -412,7 +436,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -424,7 +449,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -436,7 +462,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -448,7 +475,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -460,7 +488,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -472,7 +501,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -484,7 +514,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -496,7 +527,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -508,7 +540,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -520,7 +553,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -532,7 +566,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -544,7 +579,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -556,7 +592,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -568,7 +605,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -580,7 +618,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -592,7 +631,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -604,7 +644,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -620,7 +661,8 @@ See the table of not supported store forwards in the Optimization Guide.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -629,10 +671,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(This is a fixed-frequency event programmed to general counters. It counts when the core is unhalted at 100 Mhz.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -645,10 +688,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .msr_values = {0}},
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -657,10 +701,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -673,10 +718,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .msr_values = {0x00}},
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
       R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -685,10 +731,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3c, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -697,10 +744,11 @@ See the table of not supported store forwards in the Optimization Guide.)",
           .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -713,7 +761,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -725,7 +774,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -741,7 +791,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -753,7 +804,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -837,7 +889,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -849,7 +902,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -861,7 +915,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -873,7 +928,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -885,7 +941,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -897,7 +954,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -909,7 +967,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -921,7 +980,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -933,7 +993,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -945,7 +1006,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -957,7 +1019,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -969,7 +1032,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -981,7 +1045,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -993,7 +1058,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1005,7 +1071,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1017,7 +1084,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1029,7 +1097,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1041,7 +1110,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1053,7 +1123,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1069,7 +1140,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1081,7 +1153,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1093,7 +1166,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1105,7 +1179,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1117,7 +1192,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1129,7 +1205,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1141,7 +1218,8 @@ Note: In the L1D, a Demand Read contains cacheable or noncacheable demand loads,
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1154,7 +1232,8 @@ Note: In ST-mode, not active thread should drive 0. This is usually caused by se
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1171,7 +1250,8 @@ Note: In ST-mode, not active thread should drive 0. This is usually caused by se
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1280,7 +1360,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1292,7 +1373,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1304,7 +1386,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1316,7 +1399,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1328,7 +1412,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1340,7 +1425,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1352,7 +1438,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1364,7 +1451,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1376,7 +1464,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1392,7 +1481,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1404,7 +1494,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1416,7 +1507,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1428,7 +1520,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1440,7 +1533,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1452,7 +1546,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1464,7 +1559,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1476,7 +1572,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1492,7 +1589,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1504,7 +1602,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1516,7 +1615,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1528,7 +1628,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1540,7 +1641,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1624,7 +1726,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1636,7 +1739,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1648,7 +1752,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1660,7 +1765,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1672,7 +1778,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1684,7 +1791,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1696,7 +1804,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1708,7 +1817,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1720,7 +1830,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1732,7 +1843,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1744,7 +1856,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1756,7 +1869,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1768,7 +1882,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1780,7 +1895,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1792,7 +1908,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1804,7 +1921,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1816,7 +1934,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1828,7 +1947,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1840,7 +1960,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1852,7 +1973,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1864,7 +1986,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1876,7 +1999,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1888,7 +2012,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1900,7 +2025,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1912,7 +2038,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1927,7 +2054,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1939,7 +2067,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1951,7 +2080,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1963,7 +2093,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1975,7 +2106,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1991,7 +2123,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2003,7 +2136,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2015,7 +2149,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2031,7 +2166,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2043,7 +2179,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2055,7 +2192,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2071,7 +2209,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2083,7 +2222,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2095,7 +2235,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2111,7 +2252,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2123,7 +2265,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2135,7 +2278,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2151,7 +2295,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2163,7 +2308,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2175,7 +2321,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2191,7 +2338,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2203,7 +2351,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2215,7 +2364,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2231,7 +2381,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2243,7 +2394,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2255,7 +2407,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2271,7 +2424,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2283,7 +2437,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2295,7 +2450,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2311,7 +2467,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2323,7 +2480,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2335,7 +2493,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2347,7 +2506,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2359,7 +2519,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2371,7 +2532,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2383,7 +2545,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2395,7 +2558,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2407,7 +2571,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2419,7 +2584,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2431,7 +2597,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2443,7 +2610,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2455,7 +2623,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2467,7 +2636,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2479,7 +2649,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2491,7 +2662,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2503,7 +2675,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2515,7 +2688,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2527,7 +2701,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2539,7 +2714,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2551,7 +2727,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2563,7 +2740,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2575,7 +2753,8 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2589,7 +2768,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2601,7 +2781,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2613,7 +2794,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2625,7 +2807,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2637,7 +2820,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2649,7 +2833,21 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS.ALL_REQUESTS",
+      EventDef::Encoding{
+          .code = 0xb0, .umask = 0x80, .cmask = 0, .msr_values = {0}},
+      R"(Any memory transaction that reached the SQ.)",
+      R"(This event counts memory transactions reached the super queue including requests initiated by the core, all L3 prefetches, page walks, and so on.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2661,7 +2859,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2677,7 +2876,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2689,7 +2889,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2701,7 +2902,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2713,7 +2915,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2725,7 +2928,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2737,7 +2941,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2749,7 +2954,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2761,7 +2967,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2773,7 +2980,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2785,7 +2993,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2801,7 +3010,8 @@ Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DS
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2814,7 +3024,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2923,7 +3134,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2935,7 +3147,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2971,7 +3184,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3007,7 +3221,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3018,8 +3233,9 @@ Note: Writeback pending FIFO has six entries.)",
       R"(This event counts all actually retired uops. Counting increments by two for micro-fused uops, and by one for macro-fused and other uops. Maximal increment value for one cycle is eight.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3035,7 +3251,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3044,14 +3261,15 @@ Note: Writeback pending FIFO has six entries.)",
           .code = 0xC2,
           .umask = 0x01,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Number of cycles using always true condition (uops_ret < 16) applied to non PEBS uops retired event.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3063,7 +3281,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3075,7 +3294,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3091,7 +3311,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3106,7 +3327,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3118,7 +3340,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3130,7 +3353,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3142,7 +3366,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3154,7 +3379,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3166,7 +3392,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3178,7 +3405,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3202,7 +3430,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3214,7 +3443,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3226,7 +3456,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3250,7 +3481,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3262,7 +3494,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3274,7 +3507,8 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3286,7 +3520,8 @@ Note: Writeback pending FIFO has six entries.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3298,127 +3533,138 @@ Note: Writeback pending FIFO has six entries.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x03, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational scalar floating-point instructions retired. Applies to SSE* and AVX* scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RSQRT RCP SQRT FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single precision?))",
-      R"(Number of SSE/AVX computational scalar floating-point instructions retired. Applies to SSE* and AVX* scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RSQRT RCP SQRT FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single precision?))",
+          .code = 0xc7, .umask = 0x03, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational scalar floating-point instructions retired; some instructions will count twice as noted below. Each count represents 1 computation operation.   Applies to SSE* and AVX* scalar double and single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational scalar single precision and double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired.  Each count represents 2 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired.  Each count represents 2 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 4 calculations per element.)",
+      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired.  Each count represents 4 computations. Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 4 calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.DOUBLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x15, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational double precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational double precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x15, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational double precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational double precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000006,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xc7, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired.  Each count represents 8 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired.  Each count represents 8 computations. Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 8 calculations per element.)",
+      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SINGLE",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x2A, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational single precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
-      R"(Number of SSE/AVX computational single precision floating-point instructions retired. Applies to SSE* and AVX*scalar, double and single precision floating-point: ADD SUB MUL DIV MIN MAX RCP RSQRT SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+          .code = 0xc7, .umask = 0x2a, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational single precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational single precision floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* scalar and packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000005,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.PACKED",
       EventDef::Encoding{
-          .code = 0xC7, .umask = 0x3C, .cmask = 0, .msr_values = {0x00}},
-      R"(Number of SSE/AVX computational packed floating-point instructions retired. Applies to SSE* and AVX*, packed, double and single precision floating-point: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single-precision?))",
-      R"(Number of SSE/AVX computational packed floating-point instructions retired. Applies to SSE* and AVX*, packed, double and single precision floating-point: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element. (RSQRT for single-precision?))",
+          .code = 0xc7, .umask = 0x3c, .cmask = 0, .msr_values = {0x00}},
+      R"(Number of SSE/AVX computational packed floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* packed double and single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
+      R"(Number of SSE/AVX computational packed floating-point instructions retired; some instructions will count twice as noted below. Applies to SSE* and AVX* packed double and single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform multiple calculations per element.)",
       2000004,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3431,7 +3677,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3443,7 +3690,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3455,7 +3703,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3467,7 +3716,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3479,7 +3729,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3491,7 +3742,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3503,7 +3755,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3515,7 +3768,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3528,7 +3782,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3540,7 +3795,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3552,7 +3808,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3564,7 +3821,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3576,7 +3834,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3588,7 +3847,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3600,7 +3860,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3612,7 +3873,8 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3624,7 +3886,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3636,7 +3899,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3648,7 +3912,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3660,7 +3925,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3672,7 +3938,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3684,102 +3951,103 @@ Note: Writeback pending FIFO has six entries.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4)",
       R"(Counts randomly selected loads with latency value being above four.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8)",
       R"(Counts randomly selected loads with latency value being above eight.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16)",
       R"(Counts randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32)",
       R"(Counts randomly selected loads with latency value being above 32.)",
       100007,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64)",
       R"(Counts randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128)",
       R"(Counts randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256)",
       R"(Counts randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512)",
       R"(Counts randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(BDM100, BDM35)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3792,7 +4060,8 @@ Note: Writeback pending FIFO has six entries.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3805,7 +4074,8 @@ Note: Writeback pending FIFO has six entries.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3825,11 +4095,12 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3837,12 +4108,13 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary.)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3855,7 +4127,8 @@ Note: This event counts AVX-256bit load/store double-pump memory uops as a singl
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3869,7 +4142,8 @@ Note: This event counts AVX-256bit load/store double-pump memory uops as a singl
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3882,7 +4156,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3918,7 +4193,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3930,7 +4206,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3955,7 +4232,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4063,7 +4341,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4075,7 +4354,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4087,7 +4367,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4099,7 +4380,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4111,7 +4393,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4123,7 +4406,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4135,7 +4419,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4147,7 +4432,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4159,7 +4445,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4171,7 +4458,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4183,7 +4471,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4195,7 +4484,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4207,7 +4497,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4219,7 +4510,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4231,7 +4523,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4241,7 +4534,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC08FFF}},
-      R"(Counts all requests miss in the L3 )",
+      R"(Counts all requests miss in the L3)",
       R"(Counts all requests miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4257,7 +4550,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C8FFF}},
-      R"(Counts all requests hit in the L3 )",
+      R"(Counts all requests hit in the L3)",
       R"(Counts all requests hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4269,11 +4562,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x087FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x87FC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4289,7 +4579,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4301,11 +4591,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063BC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63BC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4317,11 +4604,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x06040007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x6040007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4337,7 +4621,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3 )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4353,7 +4637,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4365,11 +4649,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C07F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4381,11 +4662,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000244}},
-      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000244}},
+      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4401,7 +4679,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00244}},
-      R"(Counts all demand & prefetch code reads miss in the L3 )",
+      R"(Counts all demand & prefetch code reads miss in the L3)",
       R"(Counts all demand & prefetch code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4413,11 +4691,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0244}},
-      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0244}},
+      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4429,11 +4704,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000122}},
-      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000122}},
+      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4449,7 +4721,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00122}},
-      R"(Counts all demand & prefetch RFOs miss in the L3 )",
+      R"(Counts all demand & prefetch RFOs miss in the L3)",
       R"(Counts all demand & prefetch RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4465,7 +4737,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4477,11 +4749,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0122}},
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4493,11 +4762,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x087FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x87FC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4513,7 +4779,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4525,11 +4791,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063BC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63BC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4541,11 +4804,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4561,7 +4821,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00091}},
-      R"(Counts all demand & prefetch data reads miss in the L3 )",
+      R"(Counts all demand & prefetch data reads miss in the L3)",
       R"(Counts all demand & prefetch data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4577,7 +4837,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4589,11 +4849,8 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0091}},
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4609,7 +4866,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4625,7 +4882,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4641,7 +4898,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4657,7 +4914,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4673,7 +4930,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4689,7 +4946,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00002}},
-      R"(Counts all demand data writes (RFOs) miss in the L3 )",
+      R"(Counts all demand data writes (RFOs) miss in the L3)",
       R"(Counts all demand data writes (RFOs) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4705,7 +4962,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4721,7 +4978,7 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 )",
+      R"(Counts all demand data writes (RFOs) hit in the L3)",
       R"(Counts all demand data writes (RFOs) hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4730,5 +4987,5 @@ Note: Only two data-sources of L1/FB are applicable for AVX-256bit  even though 
       ));
 }
 
-} // namespace broadwellx_core_v14
+} // namespace broadwellx_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace broadwellx_uncore_v14 {
+namespace broadwellx_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from broadwellx_uncore_v14.json (1284 events).
+    Events from broadwellx_uncore.json (1284 events).
 
     Supported SKUs:
         - Arch: x86, Model: BDX id: 79
@@ -23,7 +23,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_BOUNCE_CONTROL",
       EventDef::Encoding{.code = 0xA, .umask = 0x0, .msr_values = {0x00}},
       R"(Bounce Control)",
-      R"(Bounce Control)",
+      R"(UNC_C_BOUNCE_CONTROL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -35,7 +35,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_CLOCKTICKS",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
       R"(Uncore Clocks)",
-      R"(Uncore Clocks)",
+      R"(UNC_C_CLOCKTICKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -539,7 +539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.AD",
       EventDef::Encoding{.code = 0x5, .umask = 0x1, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; AD)",
-      R"(Number of LLC responses that bounced on the Ring.; AD)",
+      R"(UNC_C_RING_BOUNCES.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -551,7 +551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.AK",
       EventDef::Encoding{.code = 0x5, .umask = 0x2, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; AK)",
-      R"(Number of LLC responses that bounced on the Ring.; AK)",
+      R"(UNC_C_RING_BOUNCES.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -563,7 +563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.BL",
       EventDef::Encoding{.code = 0x5, .umask = 0x4, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; BL)",
-      R"(Number of LLC responses that bounced on the Ring.; BL)",
+      R"(UNC_C_RING_BOUNCES.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -575,7 +575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_BOUNCES.IV",
       EventDef::Encoding{.code = 0x5, .umask = 0x10, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
-      R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
+      R"(UNC_C_RING_BOUNCES.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -635,7 +635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SRC_THRTL",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
       R"(Number of cycles the Cbo is actively throttling traffic onto the Ring in order to limit bounce traffic.)",
-      R"(Number of cycles the Cbo is actively throttling traffic onto the Ring in order to limit bounce traffic.)",
+      R"(UNC_C_RING_SRC_THRTL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1631,7 +1631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
       R"(Onto AD Ring)",
-      R"(Onto AD Ring)",
+      R"(UNC_C_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1643,7 +1643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
       R"(Onto AK Ring)",
-      R"(Onto AK Ring)",
+      R"(UNC_C_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1655,7 +1655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
       R"(Onto BL Ring)",
-      R"(Onto BL Ring)",
+      R"(UNC_C_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1739,7 +1739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0x00}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1823,7 +1823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.AD",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
       R"(AD)",
-      R"(AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1835,7 +1835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.AK",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
       R"(AK)",
-      R"(AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1847,7 +1847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.IV",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
       R"(IV)",
-      R"(IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1859,7 +1859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_RING_SINK_STARVED.BL",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
       R"(BL)",
-      R"(BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1967,7 +1967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.FILT",
       EventDef::Encoding{.code = 0x20, .umask = 0x3, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Address & Opcode Match)",
-      R"(QPI Address/Opcode Match; Address & Opcode Match)",
+      R"(UNC_H_ADDR_OPC_MATCH.FILT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1979,7 +1979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.ADDR",
       EventDef::Encoding{.code = 0x20, .umask = 0x1, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Address)",
-      R"(QPI Address/Opcode Match; Address)",
+      R"(UNC_H_ADDR_OPC_MATCH.ADDR)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1991,7 +1991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.OPC",
       EventDef::Encoding{.code = 0x20, .umask = 0x2, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; Opcode)",
-      R"(QPI Address/Opcode Match; Opcode)",
+      R"(UNC_H_ADDR_OPC_MATCH.OPC)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2003,7 +2003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.AD",
       EventDef::Encoding{.code = 0x20, .umask = 0x4, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; AD Opcodes)",
-      R"(QPI Address/Opcode Match; AD Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2015,7 +2015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.BL",
       EventDef::Encoding{.code = 0x20, .umask = 0x8, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; BL Opcodes)",
-      R"(QPI Address/Opcode Match; BL Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2027,7 +2027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_ADDR_OPC_MATCH.AK",
       EventDef::Encoding{.code = 0x20, .umask = 0x10, .msr_values = {0x00}},
       R"(QPI Address/Opcode Match; AK Opcodes)",
-      R"(QPI Address/Opcode Match; AK Opcodes)",
+      R"(UNC_H_ADDR_OPC_MATCH.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2195,7 +2195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x71, .umask = 0x1, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Counts Number of Hits in HitMe Cache; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_HIT.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2207,7 +2207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.WBMTOI",
       EventDef::Encoding{.code = 0x71, .umask = 0x2, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is WbMtoI)",
-      R"(Counts Number of Hits in HitMe Cache; op is WbMtoI)",
+      R"(UNC_H_HITME_HIT.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2219,7 +2219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x71, .umask = 0x4, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is AckCnfltWbI)",
-      R"(Counts Number of Hits in HitMe Cache; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_HIT.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2231,7 +2231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x71, .umask = 0x8, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is WbMtoE or WbMtoS)",
-      R"(Counts Number of Hits in HitMe Cache; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_HIT.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2243,7 +2243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x71, .umask = 0x10, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_HIT.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2255,7 +2255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x71, .umask = 0x20, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_HIT.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2267,7 +2267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSPFWDS",
       EventDef::Encoding{.code = 0x71, .umask = 0x40, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RsSFwd or RspSFwdWb)",
-      R"(Counts Number of Hits in HitMe Cache; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_HIT.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2279,7 +2279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.RSP",
       EventDef::Encoding{.code = 0x71, .umask = 0x80, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Counts Number of Hits in HitMe Cache; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_HIT.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2291,7 +2291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ALLOCS",
       EventDef::Encoding{.code = 0x71, .umask = 0x70, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Allocations)",
-      R"(Counts Number of Hits in HitMe Cache; Allocations)",
+      R"(UNC_H_HITME_HIT.ALLOCS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2303,7 +2303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.EVICTS",
       EventDef::Encoding{.code = 0x71, .umask = 0x42, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Allocations)",
-      R"(Counts Number of Hits in HitMe Cache; Allocations)",
+      R"(UNC_H_HITME_HIT.EVICTS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2315,7 +2315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.INVALS",
       EventDef::Encoding{.code = 0x71, .umask = 0x26, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; Invalidations)",
-      R"(Counts Number of Hits in HitMe Cache; Invalidations)",
+      R"(UNC_H_HITME_HIT.INVALS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2327,7 +2327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.ALL",
       EventDef::Encoding{.code = 0x71, .umask = 0xFF, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; All Requests)",
-      R"(Counts Number of Hits in HitMe Cache; All Requests)",
+      R"(UNC_H_HITME_HIT.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2339,7 +2339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT.HOM",
       EventDef::Encoding{.code = 0x71, .umask = 0xF, .msr_values = {0x00}},
       R"(Counts Number of Hits in HitMe Cache; HOM Requests)",
-      R"(Counts Number of Hits in HitMe Cache; HOM Requests)",
+      R"(UNC_H_HITME_HIT.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2351,7 +2351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x72, .umask = 0x1, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2363,7 +2363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.WBMTOI",
       EventDef::Encoding{.code = 0x72, .umask = 0x2, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2375,7 +2375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x72, .umask = 0x4, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is AckCnfltWbI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2387,7 +2387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x72, .umask = 0x8, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoE or WbMtoS)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2399,7 +2399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x72, .umask = 0x10, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2411,7 +2411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x72, .umask = 0x20, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2423,7 +2423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDS",
       EventDef::Encoding{.code = 0x72, .umask = 0x40, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RsSFwd or RspSFwdWb)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2435,7 +2435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.RSP",
       EventDef::Encoding{.code = 0x72, .umask = 0x80, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2447,7 +2447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.ALL",
       EventDef::Encoding{.code = 0x72, .umask = 0xFF, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; All Requests)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; All Requests)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2459,7 +2459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_HIT_PV_BITS_SET.HOM",
       EventDef::Encoding{.code = 0x72, .umask = 0xF, .msr_values = {0x00}},
       R"(Accumulates Number of PV bits set on HitMe Cache Hits; HOM Requests)",
-      R"(Accumulates Number of PV bits set on HitMe Cache Hits; HOM Requests)",
+      R"(UNC_H_HITME_HIT_PV_BITS_SET.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2471,7 +2471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.READ_OR_INVITOE",
       EventDef::Encoding{.code = 0x70, .umask = 0x1, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RdCode, RdData, RdDataMigratory, RdInvOwn, RdCur or InvItoE)",
+      R"(UNC_H_HITME_LOOKUP.READ_OR_INVITOE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2483,7 +2483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.WBMTOI",
       EventDef::Encoding{.code = 0x70, .umask = 0x2, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is WbMtoI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is WbMtoI)",
+      R"(UNC_H_HITME_LOOKUP.WBMTOI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2495,7 +2495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ACKCNFLTWBI",
       EventDef::Encoding{.code = 0x70, .umask = 0x4, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is AckCnfltWbI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is AckCnfltWbI)",
+      R"(UNC_H_HITME_LOOKUP.ACKCNFLTWBI)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2507,7 +2507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.WBMTOE_OR_S",
       EventDef::Encoding{.code = 0x70, .umask = 0x8, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is WbMtoE or WbMtoS)",
-      R"(Counts Number of times HitMe Cache is accessed; op is WbMtoE or WbMtoS)",
+      R"(UNC_H_HITME_LOOKUP.WBMTOE_OR_S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2519,7 +2519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDI_REMOTE",
       EventDef::Encoding{.code = 0x70, .umask = 0x10, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a remote request)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a remote request)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDI_REMOTE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2531,7 +2531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDI_LOCAL",
       EventDef::Encoding{.code = 0x70, .umask = 0x20, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a local request)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspIFwd or RspIFwdWb for a local request)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDI_LOCAL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2543,7 +2543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSPFWDS",
       EventDef::Encoding{.code = 0x70, .umask = 0x40, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RsSFwd or RspSFwdWb)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RsSFwd or RspSFwdWb)",
+      R"(UNC_H_HITME_LOOKUP.RSPFWDS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2555,7 +2555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.RSP",
       EventDef::Encoding{.code = 0x70, .umask = 0x80, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
-      R"(Counts Number of times HitMe Cache is accessed; op is RspI, RspIWb, RspS, RspSWb, RspCnflt or RspCnfltWbI)",
+      R"(UNC_H_HITME_LOOKUP.RSP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2567,7 +2567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ALLOCS",
       EventDef::Encoding{.code = 0x70, .umask = 0x70, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; Allocations)",
-      R"(Counts Number of times HitMe Cache is accessed; Allocations)",
+      R"(UNC_H_HITME_LOOKUP.ALLOCS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2579,7 +2579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.INVALS",
       EventDef::Encoding{.code = 0x70, .umask = 0x26, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; Invalidations)",
-      R"(Counts Number of times HitMe Cache is accessed; Invalidations)",
+      R"(UNC_H_HITME_LOOKUP.INVALS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2591,7 +2591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.ALL",
       EventDef::Encoding{.code = 0x70, .umask = 0xFF, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; All Requests)",
-      R"(Counts Number of times HitMe Cache is accessed; All Requests)",
+      R"(UNC_H_HITME_LOOKUP.ALL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2603,7 +2603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_HITME_LOOKUP.HOM",
       EventDef::Encoding{.code = 0x70, .umask = 0xF, .msr_values = {0x00}},
       R"(Counts Number of times HitMe Cache is accessed; HOM Requests)",
-      R"(Counts Number of times HitMe Cache is accessed; HOM Requests)",
+      R"(UNC_H_HITME_LOOKUP.HOM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2699,7 +2699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IMC_RETRY",
       EventDef::Encoding{.code = 0x1E, .umask = 0x0, .msr_values = {0x00}},
       R"(Retry Events)",
-      R"(Retry Events)",
+      R"(UNC_H_IMC_RETRY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4235,7 +4235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IOT_BACKPRESSURE.SAT",
       EventDef::Encoding{.code = 0x61, .umask = 0x1, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_H_IOT_BACKPRESSURE.SAT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4247,7 +4247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_IOT_BACKPRESSURE.HUB",
       EventDef::Encoding{.code = 0x61, .umask = 0x2, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_H_IOT_BACKPRESSURE.HUB)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4811,7 +4811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REQ",
       EventDef::Encoding{.code = 0x14, .umask = 0x1, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Requests)",
-      R"(Misc Events - Set 0; Fastpath Requests)",
+      R"(UNC_I_MISC0.FAST_REQ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4823,7 +4823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REJ",
       EventDef::Encoding{.code = 0x14, .umask = 0x2, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Rejects)",
-      R"(Misc Events - Set 0; Fastpath Rejects)",
+      R"(UNC_I_MISC0.FAST_REJ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4835,7 +4835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_RD_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x4, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_RD_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4847,7 +4847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_WR_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x8, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_WR_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4859,7 +4859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_ATOMIC_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
+      R"(UNC_I_MISC0.2ND_ATOMIC_INSERT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4871,7 +4871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_XFER",
       EventDef::Encoding{.code = 0x14, .umask = 0x20, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
-      R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
+      R"(UNC_I_MISC0.FAST_XFER)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4883,7 +4883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.PF_ACK_HINT",
       EventDef::Encoding{.code = 0x14, .umask = 0x40, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
-      R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
+      R"(UNC_I_MISC0.PF_ACK_HINT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4955,7 +4955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC1.LOST_FWD",
       EventDef::Encoding{.code = 0x15, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 1)",
-      R"(Misc Events - Set 1)",
+      R"(UNC_I_MISC1.LOST_FWD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5014,7 +5014,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x4, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5038,7 +5038,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_OCCUPANCY",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5050,7 +5050,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_CYCLES_FULL",
       EventDef::Encoding{.code = 0x5, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5074,7 +5074,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_OCCUPANCY",
       EventDef::Encoding{.code = 0x8, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5086,7 +5086,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x6, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5110,7 +5110,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_OCCUPANCY",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5123,7 +5123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.MISS",
       EventDef::Encoding{.code = 0x17, .umask = 0x1, .msr_values = {0x00}},
       R"(Snoop Responses; Miss)",
-      R"(Snoop Responses; Miss)",
+      R"(UNC_I_SNOOP_RESP.MISS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5135,7 +5135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_I",
       EventDef::Encoding{.code = 0x17, .umask = 0x2, .msr_values = {0x00}},
       R"(Snoop Responses; Hit I)",
-      R"(Snoop Responses; Hit I)",
+      R"(UNC_I_SNOOP_RESP.HIT_I)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5147,7 +5147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_ES",
       EventDef::Encoding{.code = 0x17, .umask = 0x4, .msr_values = {0x00}},
       R"(Snoop Responses; Hit E or S)",
-      R"(Snoop Responses; Hit E or S)",
+      R"(UNC_I_SNOOP_RESP.HIT_ES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5159,7 +5159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_M",
       EventDef::Encoding{.code = 0x17, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses; Hit M)",
-      R"(Snoop Responses; Hit M)",
+      R"(UNC_I_SNOOP_RESP.HIT_M)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5171,7 +5171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPCODE",
       EventDef::Encoding{.code = 0x17, .umask = 0x10, .msr_values = {0x00}},
       R"(Snoop Responses; SnpCode)",
-      R"(Snoop Responses; SnpCode)",
+      R"(UNC_I_SNOOP_RESP.SNPCODE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5183,7 +5183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPDATA",
       EventDef::Encoding{.code = 0x17, .umask = 0x20, .msr_values = {0x00}},
       R"(Snoop Responses; SnpData)",
-      R"(Snoop Responses; SnpData)",
+      R"(UNC_I_SNOOP_RESP.SNPDATA)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5195,7 +5195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPINV",
       EventDef::Encoding{.code = 0x17, .umask = 0x40, .msr_values = {0x00}},
       R"(Snoop Responses; SnpInv)",
-      R"(Snoop Responses; SnpInv)",
+      R"(UNC_I_SNOOP_RESP.SNPINV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5938,7 +5938,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_UFS_TRANSITIONS_RING_GV",
       EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_RING_GV (Description is auto-generated))",
+      R"(UNC_P_UFS_TRANSITIONS_RING_GV)",
       R"(Ring GV with same final and initial frequency)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5951,7 +5951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_VR_HOT_CYCLES",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
       R"(VR Hot)",
-      R"(VR Hot)",
+      R"(UNC_P_VR_HOT_CYCLES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6191,7 +6191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_BYPASSED",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Rx Flit Buffer Bypassed)",
-      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6371,7 +6371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G0.IDLE",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 0; Idle and Null Flits)",
-      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
+      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6383,7 +6383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x2, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 1; SNP Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6395,7 +6395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6407,7 +6407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6419,7 +6419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x2, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6431,7 +6431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6443,7 +6443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6455,7 +6455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x2, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6467,7 +6467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AD)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6479,7 +6479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AK)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6491,7 +6491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6503,7 +6503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent non-data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6515,7 +6515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x3, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6527,7 +6527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent standard Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6899,7 +6899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Data Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6911,7 +6911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.NON_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Non-Data protocol Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6923,7 +6923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x0, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; SNP Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6935,7 +6935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6947,7 +6947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6959,7 +6959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x0, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6971,7 +6971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6983,7 +6983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6995,7 +6995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x0, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7007,7 +7007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AD)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7019,7 +7019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x1, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AK)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7031,7 +7031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7043,7 +7043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent non-data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7055,7 +7055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x1, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent Bypass Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7067,7 +7067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x1, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent standard Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7474,8 +7474,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_qpi,
       "UNC_Q_RxL_CRC_ERRORS.NORMAL_OP",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
-      R"(CRC Errors Detected; Normal Operations)",
-      R"(Number of CRC errors detected in the QPI Agent.  Each QPI flit incorporates 8 bits of CRC for error detection.  This counts the number of flits where the CRC was able to detect an error.  After an error has been detected, the QPI agent will send a request to the transmitting socket to resend the flit (as well as any flits that came after it).; CRC errors detected during normal operation.)",
+      R"(UNC_Q_RxL_CRC_ERRORS.NORMAL_OP)",
+      R"(UNC_Q_RxL_CRC_ERRORS.NORMAL_OP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7834,8 +7834,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7846,8 +7846,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7858,8 +7858,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7870,8 +7870,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10115,7 +10115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.AD",
       EventDef::Encoding{.code = 0x33, .umask = 0x1, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10127,7 +10127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.BL",
       EventDef::Encoding{.code = 0x33, .umask = 0x4, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10211,7 +10211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_IOT_BACKPRESSURE.SAT",
       EventDef::Encoding{.code = 0xB, .umask = 0x1, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_R3_IOT_BACKPRESSURE.SAT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10223,7 +10223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_IOT_BACKPRESSURE.HUB",
       EventDef::Encoding{.code = 0xB, .umask = 0x2, .msr_values = {0x00}},
       R"(IOT Backpressure)",
-      R"(IOT Backpressure)",
+      R"(UNC_R3_IOT_BACKPRESSURE.HUB)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10367,7 +10367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_BOUNCE_CONTROL",
       EventDef::Encoding{.code = 0xA, .umask = 0x0, .msr_values = {0x00}},
       R"(Bounce Control)",
-      R"(Bounce Control)",
+      R"(UNC_S_BOUNCE_CONTROL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10379,7 +10379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_CLOCKTICKS",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
       R"(Uncore Clocks)",
-      R"(Uncore Clocks)",
+      R"(UNC_S_CLOCKTICKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10619,7 +10619,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.AD_CACHE",
       EventDef::Encoding{.code = 0x5, .umask = 0x1, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.)",
-      R"(Number of LLC responses that bounced on the Ring.)",
+      R"(UNC_S_RING_BOUNCES.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10631,7 +10631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.AK_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x2, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Acknowledgements to core)",
-      R"(Number of LLC responses that bounced on the Ring.; Acknowledgements to core)",
+      R"(UNC_S_RING_BOUNCES.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10643,7 +10643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.BL_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x4, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Data Responses to core)",
-      R"(Number of LLC responses that bounced on the Ring.; Data Responses to core)",
+      R"(UNC_S_RING_BOUNCES.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10655,7 +10655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_S_RING_BOUNCES.IV_CORE",
       EventDef::Encoding{.code = 0x5, .umask = 0x8, .msr_values = {0x00}},
       R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
-      R"(Number of LLC responses that bounced on the Ring.; Snoops of processor's cache.)",
+      R"(UNC_S_RING_BOUNCES.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10906,8 +10906,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AD)",
+      R"(UNC_S_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10918,8 +10918,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AK)",
+      R"(UNC_S_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10930,8 +10930,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.BL)",
+      R"(UNC_S_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11086,8 +11086,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AD_CACHE",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11098,8 +11098,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AK_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11110,8 +11110,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.BL_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11122,8 +11122,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.IV_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11579,7 +11579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.ACT",
       EventDef::Encoding{.code = 0xA1, .umask = 0x1, .msr_values = {0x00}},
       R"(ACT command issued by 2 cycle bypass)",
-      R"(ACT command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.ACT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11591,7 +11591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.CAS",
       EventDef::Encoding{.code = 0xA1, .umask = 0x2, .msr_values = {0x00}},
       R"(CAS command issued by 2 cycle bypass)",
-      R"(CAS command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.CAS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11603,7 +11603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_BYP_CMDS.PRE",
       EventDef::Encoding{.code = 0xA1, .umask = 0x4, .msr_values = {0x00}},
       R"(PRE command issued by 2 cycle bypass)",
-      R"(PRE command issued by 2 cycle bypass)",
+      R"(UNC_M_BYP_CMDS.PRE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11962,8 +11962,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_imc,
       "UNC_M_POWER_PCU_THROTTLING",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12167,7 +12167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.LOW",
       EventDef::Encoding{.code = 0xA0, .umask = 0x1, .msr_values = {0x00}},
       R"(Read CAS issued with LOW priority)",
-      R"(Read CAS issued with LOW priority)",
+      R"(UNC_M_RD_CAS_PRIO.LOW)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12179,7 +12179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.MED",
       EventDef::Encoding{.code = 0xA0, .umask = 0x2, .msr_values = {0x00}},
       R"(Read CAS issued with MEDIUM priority)",
-      R"(Read CAS issued with MEDIUM priority)",
+      R"(UNC_M_RD_CAS_PRIO.MED)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12191,7 +12191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.HIGH",
       EventDef::Encoding{.code = 0xA0, .umask = 0x4, .msr_values = {0x00}},
       R"(Read CAS issued with HIGH priority)",
-      R"(Read CAS issued with HIGH priority)",
+      R"(UNC_M_RD_CAS_PRIO.HIGH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12203,7 +12203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_PRIO.PANIC",
       EventDef::Encoding{.code = 0xA0, .umask = 0x8, .msr_values = {0x00}},
       R"(Read CAS issued with PANIC NON ISOCH priority (starved))",
-      R"(Read CAS issued with PANIC NON ISOCH priority (starved))",
+      R"(UNC_M_RD_CAS_PRIO.PANIC)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12215,7 +12215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 1)",
-      R"(RD_CAS Access to Rank 0; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK0.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12227,7 +12227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 2)",
-      R"(RD_CAS Access to Rank 0; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK0.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12239,7 +12239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB0, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 4)",
-      R"(RD_CAS Access to Rank 0; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK0.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12251,7 +12251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB0, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 8)",
-      R"(RD_CAS Access to Rank 0; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK0.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12263,7 +12263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB0, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; All Banks)",
-      R"(RD_CAS Access to Rank 0; All Banks)",
+      R"(UNC_M_RD_CAS_RANK0.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12275,7 +12275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 0)",
-      R"(RD_CAS Access to Rank 0; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK0.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12287,7 +12287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 3)",
-      R"(RD_CAS Access to Rank 0; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK0.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12299,7 +12299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB0, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 5)",
-      R"(RD_CAS Access to Rank 0; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK0.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12311,7 +12311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB0, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 6)",
-      R"(RD_CAS Access to Rank 0; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK0.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12323,7 +12323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB0, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 7)",
-      R"(RD_CAS Access to Rank 0; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK0.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12335,7 +12335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB0, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 9)",
-      R"(RD_CAS Access to Rank 0; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK0.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12347,7 +12347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB0, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 10)",
-      R"(RD_CAS Access to Rank 0; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK0.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12359,7 +12359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB0, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 11)",
-      R"(RD_CAS Access to Rank 0; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK0.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12371,7 +12371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB0, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 12)",
-      R"(RD_CAS Access to Rank 0; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK0.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12383,7 +12383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB0, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 13)",
-      R"(RD_CAS Access to Rank 0; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK0.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12395,7 +12395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB0, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 14)",
-      R"(RD_CAS Access to Rank 0; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK0.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12407,7 +12407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB0, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 15)",
-      R"(RD_CAS Access to Rank 0; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK0.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12419,7 +12419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12431,7 +12431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12443,7 +12443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12455,7 +12455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK0.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12467,7 +12467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 1)",
-      R"(RD_CAS Access to Rank 1; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK1.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12479,7 +12479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 2)",
-      R"(RD_CAS Access to Rank 1; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK1.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12491,7 +12491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB1, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 4)",
-      R"(RD_CAS Access to Rank 1; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK1.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12503,7 +12503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB1, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 8)",
-      R"(RD_CAS Access to Rank 1; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK1.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12515,7 +12515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB1, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; All Banks)",
-      R"(RD_CAS Access to Rank 1; All Banks)",
+      R"(UNC_M_RD_CAS_RANK1.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12527,7 +12527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 0)",
-      R"(RD_CAS Access to Rank 1; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK1.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12539,7 +12539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 3)",
-      R"(RD_CAS Access to Rank 1; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK1.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12551,7 +12551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB1, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 5)",
-      R"(RD_CAS Access to Rank 1; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK1.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12563,7 +12563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB1, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 6)",
-      R"(RD_CAS Access to Rank 1; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK1.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12575,7 +12575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB1, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 7)",
-      R"(RD_CAS Access to Rank 1; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK1.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12587,7 +12587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB1, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 9)",
-      R"(RD_CAS Access to Rank 1; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK1.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12599,7 +12599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB1, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 10)",
-      R"(RD_CAS Access to Rank 1; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK1.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12611,7 +12611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB1, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 11)",
-      R"(RD_CAS Access to Rank 1; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK1.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12623,7 +12623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB1, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 12)",
-      R"(RD_CAS Access to Rank 1; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK1.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12635,7 +12635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB1, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 13)",
-      R"(RD_CAS Access to Rank 1; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK1.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12647,7 +12647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB1, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 14)",
-      R"(RD_CAS Access to Rank 1; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK1.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12659,7 +12659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB1, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 15)",
-      R"(RD_CAS Access to Rank 1; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK1.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12671,7 +12671,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12683,7 +12683,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12695,7 +12695,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12707,7 +12707,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK1.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12719,7 +12719,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK2.BANK0",
       EventDef::Encoding{.code = 0xB2, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 2; Bank 0)",
-      R"(RD_CAS Access to Rank 2; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK2.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12731,7 +12731,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 1)",
-      R"(RD_CAS Access to Rank 4; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK4.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12743,7 +12743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 2)",
-      R"(RD_CAS Access to Rank 4; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK4.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12755,7 +12755,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xB4, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 4)",
-      R"(RD_CAS Access to Rank 4; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK4.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12767,7 +12767,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xB4, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 8)",
-      R"(RD_CAS Access to Rank 4; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK4.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12779,7 +12779,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xB4, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; All Banks)",
-      R"(RD_CAS Access to Rank 4; All Banks)",
+      R"(UNC_M_RD_CAS_RANK4.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12791,7 +12791,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 0)",
-      R"(RD_CAS Access to Rank 4; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK4.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12803,7 +12803,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 3)",
-      R"(RD_CAS Access to Rank 4; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK4.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12815,7 +12815,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xB4, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 5)",
-      R"(RD_CAS Access to Rank 4; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK4.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12827,7 +12827,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xB4, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 6)",
-      R"(RD_CAS Access to Rank 4; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK4.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12839,7 +12839,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xB4, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 7)",
-      R"(RD_CAS Access to Rank 4; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK4.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12851,7 +12851,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xB4, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 9)",
-      R"(RD_CAS Access to Rank 4; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK4.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12863,7 +12863,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xB4, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 10)",
-      R"(RD_CAS Access to Rank 4; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK4.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12875,7 +12875,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xB4, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 11)",
-      R"(RD_CAS Access to Rank 4; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK4.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12887,7 +12887,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xB4, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 12)",
-      R"(RD_CAS Access to Rank 4; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK4.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12899,7 +12899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xB4, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 13)",
-      R"(RD_CAS Access to Rank 4; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK4.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12911,7 +12911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xB4, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 14)",
-      R"(RD_CAS Access to Rank 4; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK4.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12923,7 +12923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xB4, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 15)",
-      R"(RD_CAS Access to Rank 4; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK4.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12935,7 +12935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12947,7 +12947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12959,7 +12959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12971,7 +12971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK4.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12983,7 +12983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 1)",
-      R"(RD_CAS Access to Rank 5; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK5.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12995,7 +12995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 2)",
-      R"(RD_CAS Access to Rank 5; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK5.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13007,7 +13007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xB5, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 4)",
-      R"(RD_CAS Access to Rank 5; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK5.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13019,7 +13019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xB5, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 8)",
-      R"(RD_CAS Access to Rank 5; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK5.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13031,7 +13031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xB5, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; All Banks)",
-      R"(RD_CAS Access to Rank 5; All Banks)",
+      R"(UNC_M_RD_CAS_RANK5.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13043,7 +13043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 0)",
-      R"(RD_CAS Access to Rank 5; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK5.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13055,7 +13055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 3)",
-      R"(RD_CAS Access to Rank 5; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK5.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13067,7 +13067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xB5, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 5)",
-      R"(RD_CAS Access to Rank 5; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK5.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13079,7 +13079,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xB5, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 6)",
-      R"(RD_CAS Access to Rank 5; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK5.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13091,7 +13091,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xB5, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 7)",
-      R"(RD_CAS Access to Rank 5; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK5.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13103,7 +13103,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xB5, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 9)",
-      R"(RD_CAS Access to Rank 5; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK5.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13115,7 +13115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xB5, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 10)",
-      R"(RD_CAS Access to Rank 5; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK5.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13127,7 +13127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xB5, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 11)",
-      R"(RD_CAS Access to Rank 5; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK5.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13139,7 +13139,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xB5, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 12)",
-      R"(RD_CAS Access to Rank 5; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK5.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13151,7 +13151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xB5, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 13)",
-      R"(RD_CAS Access to Rank 5; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK5.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13163,7 +13163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xB5, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 14)",
-      R"(RD_CAS Access to Rank 5; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK5.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13175,7 +13175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xB5, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 15)",
-      R"(RD_CAS Access to Rank 5; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK5.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13187,7 +13187,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13199,7 +13199,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13211,7 +13211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13223,7 +13223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK5.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13235,7 +13235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 1)",
-      R"(RD_CAS Access to Rank 6; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK6.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13247,7 +13247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 2)",
-      R"(RD_CAS Access to Rank 6; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK6.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13259,7 +13259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xB6, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 4)",
-      R"(RD_CAS Access to Rank 6; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK6.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13271,7 +13271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xB6, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 8)",
-      R"(RD_CAS Access to Rank 6; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK6.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13283,7 +13283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xB6, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; All Banks)",
-      R"(RD_CAS Access to Rank 6; All Banks)",
+      R"(UNC_M_RD_CAS_RANK6.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13295,7 +13295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 0)",
-      R"(RD_CAS Access to Rank 6; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK6.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13307,7 +13307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 3)",
-      R"(RD_CAS Access to Rank 6; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK6.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13319,7 +13319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xB6, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 5)",
-      R"(RD_CAS Access to Rank 6; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK6.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13331,7 +13331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xB6, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 6)",
-      R"(RD_CAS Access to Rank 6; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK6.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13343,7 +13343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xB6, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 7)",
-      R"(RD_CAS Access to Rank 6; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK6.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13355,7 +13355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xB6, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 9)",
-      R"(RD_CAS Access to Rank 6; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK6.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13367,7 +13367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xB6, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 10)",
-      R"(RD_CAS Access to Rank 6; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK6.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13379,7 +13379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xB6, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 11)",
-      R"(RD_CAS Access to Rank 6; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK6.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13391,7 +13391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xB6, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 12)",
-      R"(RD_CAS Access to Rank 6; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK6.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13403,7 +13403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xB6, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 13)",
-      R"(RD_CAS Access to Rank 6; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK6.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13415,7 +13415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xB6, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 14)",
-      R"(RD_CAS Access to Rank 6; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK6.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13427,7 +13427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xB6, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 15)",
-      R"(RD_CAS Access to Rank 6; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK6.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13439,7 +13439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13451,7 +13451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13463,7 +13463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13475,7 +13475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK6.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13487,7 +13487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 1)",
-      R"(RD_CAS Access to Rank 7; Bank 1)",
+      R"(UNC_M_RD_CAS_RANK7.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13499,7 +13499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 2)",
-      R"(RD_CAS Access to Rank 7; Bank 2)",
+      R"(UNC_M_RD_CAS_RANK7.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13511,7 +13511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xB7, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 4)",
-      R"(RD_CAS Access to Rank 7; Bank 4)",
+      R"(UNC_M_RD_CAS_RANK7.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13523,7 +13523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xB7, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 8)",
-      R"(RD_CAS Access to Rank 7; Bank 8)",
+      R"(UNC_M_RD_CAS_RANK7.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13535,7 +13535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xB7, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; All Banks)",
-      R"(RD_CAS Access to Rank 7; All Banks)",
+      R"(UNC_M_RD_CAS_RANK7.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13547,7 +13547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 0)",
-      R"(RD_CAS Access to Rank 7; Bank 0)",
+      R"(UNC_M_RD_CAS_RANK7.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13559,7 +13559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 3)",
-      R"(RD_CAS Access to Rank 7; Bank 3)",
+      R"(UNC_M_RD_CAS_RANK7.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13571,7 +13571,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xB7, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 5)",
-      R"(RD_CAS Access to Rank 7; Bank 5)",
+      R"(UNC_M_RD_CAS_RANK7.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13583,7 +13583,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xB7, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 6)",
-      R"(RD_CAS Access to Rank 7; Bank 6)",
+      R"(UNC_M_RD_CAS_RANK7.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13595,7 +13595,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xB7, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 7)",
-      R"(RD_CAS Access to Rank 7; Bank 7)",
+      R"(UNC_M_RD_CAS_RANK7.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13607,7 +13607,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xB7, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 9)",
-      R"(RD_CAS Access to Rank 7; Bank 9)",
+      R"(UNC_M_RD_CAS_RANK7.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13619,7 +13619,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xB7, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 10)",
-      R"(RD_CAS Access to Rank 7; Bank 10)",
+      R"(UNC_M_RD_CAS_RANK7.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13631,7 +13631,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xB7, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 11)",
-      R"(RD_CAS Access to Rank 7; Bank 11)",
+      R"(UNC_M_RD_CAS_RANK7.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13643,7 +13643,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xB7, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 12)",
-      R"(RD_CAS Access to Rank 7; Bank 12)",
+      R"(UNC_M_RD_CAS_RANK7.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13655,7 +13655,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xB7, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 13)",
-      R"(RD_CAS Access to Rank 7; Bank 13)",
+      R"(UNC_M_RD_CAS_RANK7.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13667,7 +13667,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xB7, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 14)",
-      R"(RD_CAS Access to Rank 7; Bank 14)",
+      R"(UNC_M_RD_CAS_RANK7.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13679,7 +13679,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xB7, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 15)",
-      R"(RD_CAS Access to Rank 7; Bank 15)",
+      R"(UNC_M_RD_CAS_RANK7.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13691,7 +13691,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13703,7 +13703,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13715,7 +13715,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13727,7 +13727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_RD_CAS_RANK7.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13763,7 +13763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_MXB_WR_OCCUPANCY",
       EventDef::Encoding{.code = 0x91, .umask = 0x0, .msr_values = {0x00}},
       R"(VMSE MXB write buffer occupancy)",
-      R"(VMSE MXB write buffer occupancy)",
+      R"(UNC_M_VMSE_MXB_WR_OCCUPANCY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13775,7 +13775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_WR_PUSH.WMM",
       EventDef::Encoding{.code = 0x90, .umask = 0x1, .msr_values = {0x00}},
       R"(VMSE WR PUSH issued; VMSE write PUSH issued in WMM)",
-      R"(VMSE WR PUSH issued; VMSE write PUSH issued in WMM)",
+      R"(UNC_M_VMSE_WR_PUSH.WMM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13787,7 +13787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_VMSE_WR_PUSH.RMM",
       EventDef::Encoding{.code = 0x90, .umask = 0x2, .msr_values = {0x00}},
       R"(VMSE WR PUSH issued; VMSE write PUSH issued in RMM)",
-      R"(VMSE WR PUSH issued; VMSE write PUSH issued in RMM)",
+      R"(UNC_M_VMSE_WR_PUSH.RMM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13799,7 +13799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.LOW_THRESH",
       EventDef::Encoding{.code = 0xC0, .umask = 0x1, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold; Transition from WMM to RMM because of starve counter)",
-      R"(Transition from WMM to RMM because of low threshold; Transition from WMM to RMM because of starve counter)",
+      R"(UNC_M_WMM_TO_RMM.LOW_THRESH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13811,7 +13811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.STARVE",
       EventDef::Encoding{.code = 0xC0, .umask = 0x2, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold)",
-      R"(Transition from WMM to RMM because of low threshold)",
+      R"(UNC_M_WMM_TO_RMM.STARVE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13823,7 +13823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WMM_TO_RMM.VMSE_RETRY",
       EventDef::Encoding{.code = 0xC0, .umask = 0x4, .msr_values = {0x00}},
       R"(Transition from WMM to RMM because of low threshold)",
-      R"(Transition from WMM to RMM because of low threshold)",
+      R"(UNC_M_WMM_TO_RMM.VMSE_RETRY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13883,7 +13883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WRONG_MM",
       EventDef::Encoding{.code = 0xC1, .umask = 0x0, .msr_values = {0x00}},
       R"(Not getting the requested Major Mode)",
-      R"(Not getting the requested Major Mode)",
+      R"(UNC_M_WRONG_MM)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13895,7 +13895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 1)",
-      R"(WR_CAS Access to Rank 0; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK0.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13907,7 +13907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 2)",
-      R"(WR_CAS Access to Rank 0; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK0.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13919,7 +13919,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB8, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 4)",
-      R"(WR_CAS Access to Rank 0; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK0.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13931,7 +13931,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB8, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 8)",
-      R"(WR_CAS Access to Rank 0; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK0.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13943,7 +13943,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB8, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; All Banks)",
-      R"(WR_CAS Access to Rank 0; All Banks)",
+      R"(UNC_M_WR_CAS_RANK0.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13955,7 +13955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 0)",
-      R"(WR_CAS Access to Rank 0; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK0.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13967,7 +13967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 3)",
-      R"(WR_CAS Access to Rank 0; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK0.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13979,7 +13979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB8, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 5)",
-      R"(WR_CAS Access to Rank 0; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK0.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13991,7 +13991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB8, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 6)",
-      R"(WR_CAS Access to Rank 0; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK0.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14003,7 +14003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB8, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 7)",
-      R"(WR_CAS Access to Rank 0; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK0.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14015,7 +14015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB8, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 9)",
-      R"(WR_CAS Access to Rank 0; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK0.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14027,7 +14027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB8, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 10)",
-      R"(WR_CAS Access to Rank 0; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK0.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14039,7 +14039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB8, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 11)",
-      R"(WR_CAS Access to Rank 0; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK0.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14051,7 +14051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB8, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 12)",
-      R"(WR_CAS Access to Rank 0; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK0.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14063,7 +14063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB8, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 13)",
-      R"(WR_CAS Access to Rank 0; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK0.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14075,7 +14075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB8, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 14)",
-      R"(WR_CAS Access to Rank 0; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK0.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14087,7 +14087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB8, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 15)",
-      R"(WR_CAS Access to Rank 0; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK0.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14099,7 +14099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14111,7 +14111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14123,7 +14123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14135,7 +14135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK0.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14147,7 +14147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 1)",
-      R"(WR_CAS Access to Rank 1; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK1.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14159,7 +14159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 2)",
-      R"(WR_CAS Access to Rank 1; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK1.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14171,7 +14171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB9, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 4)",
-      R"(WR_CAS Access to Rank 1; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK1.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14183,7 +14183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB9, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 8)",
-      R"(WR_CAS Access to Rank 1; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK1.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14195,7 +14195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB9, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; All Banks)",
-      R"(WR_CAS Access to Rank 1; All Banks)",
+      R"(UNC_M_WR_CAS_RANK1.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14207,7 +14207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 0)",
-      R"(WR_CAS Access to Rank 1; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK1.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14219,7 +14219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 3)",
-      R"(WR_CAS Access to Rank 1; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK1.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14231,7 +14231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB9, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 5)",
-      R"(WR_CAS Access to Rank 1; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK1.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14243,7 +14243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB9, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 6)",
-      R"(WR_CAS Access to Rank 1; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK1.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14255,7 +14255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB9, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 7)",
-      R"(WR_CAS Access to Rank 1; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK1.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14267,7 +14267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB9, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 9)",
-      R"(WR_CAS Access to Rank 1; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK1.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14279,7 +14279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB9, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 10)",
-      R"(WR_CAS Access to Rank 1; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK1.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14291,7 +14291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB9, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 11)",
-      R"(WR_CAS Access to Rank 1; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK1.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14303,7 +14303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB9, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 12)",
-      R"(WR_CAS Access to Rank 1; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK1.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14315,7 +14315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB9, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 13)",
-      R"(WR_CAS Access to Rank 1; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK1.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14327,7 +14327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB9, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 14)",
-      R"(WR_CAS Access to Rank 1; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK1.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14339,7 +14339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB9, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 15)",
-      R"(WR_CAS Access to Rank 1; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK1.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14351,7 +14351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14363,7 +14363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14375,7 +14375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14387,7 +14387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK1.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14399,7 +14399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 1)",
-      R"(WR_CAS Access to Rank 4; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK4.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14411,7 +14411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 2)",
-      R"(WR_CAS Access to Rank 4; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK4.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14423,7 +14423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xBC, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 4)",
-      R"(WR_CAS Access to Rank 4; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK4.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14435,7 +14435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xBC, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 8)",
-      R"(WR_CAS Access to Rank 4; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK4.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14447,7 +14447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xBC, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; All Banks)",
-      R"(WR_CAS Access to Rank 4; All Banks)",
+      R"(UNC_M_WR_CAS_RANK4.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14459,7 +14459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 0)",
-      R"(WR_CAS Access to Rank 4; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK4.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14471,7 +14471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 3)",
-      R"(WR_CAS Access to Rank 4; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK4.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14483,7 +14483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xBC, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 5)",
-      R"(WR_CAS Access to Rank 4; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK4.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14495,7 +14495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xBC, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 6)",
-      R"(WR_CAS Access to Rank 4; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK4.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14507,7 +14507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xBC, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 7)",
-      R"(WR_CAS Access to Rank 4; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK4.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14519,7 +14519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xBC, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 9)",
-      R"(WR_CAS Access to Rank 4; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK4.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14531,7 +14531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xBC, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 10)",
-      R"(WR_CAS Access to Rank 4; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK4.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14543,7 +14543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xBC, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 11)",
-      R"(WR_CAS Access to Rank 4; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK4.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14555,7 +14555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xBC, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 12)",
-      R"(WR_CAS Access to Rank 4; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK4.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14567,7 +14567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xBC, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 13)",
-      R"(WR_CAS Access to Rank 4; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK4.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14579,7 +14579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xBC, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 14)",
-      R"(WR_CAS Access to Rank 4; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK4.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14591,7 +14591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xBC, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 15)",
-      R"(WR_CAS Access to Rank 4; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK4.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14603,7 +14603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14615,7 +14615,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14627,7 +14627,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14639,7 +14639,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK4.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14651,7 +14651,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 1)",
-      R"(WR_CAS Access to Rank 5; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK5.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14663,7 +14663,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 2)",
-      R"(WR_CAS Access to Rank 5; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK5.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14675,7 +14675,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xBD, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 4)",
-      R"(WR_CAS Access to Rank 5; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK5.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14687,7 +14687,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xBD, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 8)",
-      R"(WR_CAS Access to Rank 5; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK5.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14699,7 +14699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xBD, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; All Banks)",
-      R"(WR_CAS Access to Rank 5; All Banks)",
+      R"(UNC_M_WR_CAS_RANK5.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14711,7 +14711,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 0)",
-      R"(WR_CAS Access to Rank 5; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK5.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14723,7 +14723,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 3)",
-      R"(WR_CAS Access to Rank 5; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK5.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14735,7 +14735,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xBD, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 5)",
-      R"(WR_CAS Access to Rank 5; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK5.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14747,7 +14747,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xBD, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 6)",
-      R"(WR_CAS Access to Rank 5; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK5.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14759,7 +14759,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xBD, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 7)",
-      R"(WR_CAS Access to Rank 5; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK5.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14771,7 +14771,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xBD, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 9)",
-      R"(WR_CAS Access to Rank 5; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK5.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14783,7 +14783,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xBD, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 10)",
-      R"(WR_CAS Access to Rank 5; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK5.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14795,7 +14795,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xBD, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 11)",
-      R"(WR_CAS Access to Rank 5; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK5.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14807,7 +14807,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xBD, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 12)",
-      R"(WR_CAS Access to Rank 5; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK5.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14819,7 +14819,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xBD, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 13)",
-      R"(WR_CAS Access to Rank 5; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK5.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14831,7 +14831,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xBD, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 14)",
-      R"(WR_CAS Access to Rank 5; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK5.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14843,7 +14843,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xBD, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 15)",
-      R"(WR_CAS Access to Rank 5; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK5.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14855,7 +14855,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14867,7 +14867,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14879,7 +14879,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14891,7 +14891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK5.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14903,7 +14903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 1)",
-      R"(WR_CAS Access to Rank 6; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK6.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14915,7 +14915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 2)",
-      R"(WR_CAS Access to Rank 6; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK6.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14927,7 +14927,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xBE, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 4)",
-      R"(WR_CAS Access to Rank 6; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK6.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14939,7 +14939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xBE, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 8)",
-      R"(WR_CAS Access to Rank 6; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK6.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14951,7 +14951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xBE, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; All Banks)",
-      R"(WR_CAS Access to Rank 6; All Banks)",
+      R"(UNC_M_WR_CAS_RANK6.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14963,7 +14963,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 0)",
-      R"(WR_CAS Access to Rank 6; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK6.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14975,7 +14975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 3)",
-      R"(WR_CAS Access to Rank 6; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK6.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14987,7 +14987,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xBE, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 5)",
-      R"(WR_CAS Access to Rank 6; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK6.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14999,7 +14999,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xBE, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 6)",
-      R"(WR_CAS Access to Rank 6; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK6.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15011,7 +15011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xBE, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 7)",
-      R"(WR_CAS Access to Rank 6; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK6.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15023,7 +15023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xBE, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 9)",
-      R"(WR_CAS Access to Rank 6; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK6.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15035,7 +15035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xBE, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 10)",
-      R"(WR_CAS Access to Rank 6; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK6.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15047,7 +15047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xBE, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 11)",
-      R"(WR_CAS Access to Rank 6; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK6.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15059,7 +15059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xBE, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 12)",
-      R"(WR_CAS Access to Rank 6; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK6.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15071,7 +15071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xBE, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 13)",
-      R"(WR_CAS Access to Rank 6; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK6.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15083,7 +15083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xBE, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 14)",
-      R"(WR_CAS Access to Rank 6; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK6.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15095,7 +15095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xBE, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 15)",
-      R"(WR_CAS Access to Rank 6; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK6.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15107,7 +15107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15119,7 +15119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15131,7 +15131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15143,7 +15143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK6.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15155,7 +15155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 1)",
-      R"(WR_CAS Access to Rank 7; Bank 1)",
+      R"(UNC_M_WR_CAS_RANK7.BANK1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15167,7 +15167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 2)",
-      R"(WR_CAS Access to Rank 7; Bank 2)",
+      R"(UNC_M_WR_CAS_RANK7.BANK2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15179,7 +15179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xBF, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 4)",
-      R"(WR_CAS Access to Rank 7; Bank 4)",
+      R"(UNC_M_WR_CAS_RANK7.BANK4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15191,7 +15191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xBF, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 8)",
-      R"(WR_CAS Access to Rank 7; Bank 8)",
+      R"(UNC_M_WR_CAS_RANK7.BANK8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15203,7 +15203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xBF, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; All Banks)",
-      R"(WR_CAS Access to Rank 7; All Banks)",
+      R"(UNC_M_WR_CAS_RANK7.ALLBANKS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15215,7 +15215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 0)",
-      R"(WR_CAS Access to Rank 7; Bank 0)",
+      R"(UNC_M_WR_CAS_RANK7.BANK0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15227,7 +15227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 3)",
-      R"(WR_CAS Access to Rank 7; Bank 3)",
+      R"(UNC_M_WR_CAS_RANK7.BANK3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15239,7 +15239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xBF, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 5)",
-      R"(WR_CAS Access to Rank 7; Bank 5)",
+      R"(UNC_M_WR_CAS_RANK7.BANK5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15251,7 +15251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xBF, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 6)",
-      R"(WR_CAS Access to Rank 7; Bank 6)",
+      R"(UNC_M_WR_CAS_RANK7.BANK6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15263,7 +15263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xBF, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 7)",
-      R"(WR_CAS Access to Rank 7; Bank 7)",
+      R"(UNC_M_WR_CAS_RANK7.BANK7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15275,7 +15275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xBF, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 9)",
-      R"(WR_CAS Access to Rank 7; Bank 9)",
+      R"(UNC_M_WR_CAS_RANK7.BANK9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15287,7 +15287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xBF, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 10)",
-      R"(WR_CAS Access to Rank 7; Bank 10)",
+      R"(UNC_M_WR_CAS_RANK7.BANK10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15299,7 +15299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xBF, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 11)",
-      R"(WR_CAS Access to Rank 7; Bank 11)",
+      R"(UNC_M_WR_CAS_RANK7.BANK11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15311,7 +15311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xBF, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 12)",
-      R"(WR_CAS Access to Rank 7; Bank 12)",
+      R"(UNC_M_WR_CAS_RANK7.BANK12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15323,7 +15323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xBF, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 13)",
-      R"(WR_CAS Access to Rank 7; Bank 13)",
+      R"(UNC_M_WR_CAS_RANK7.BANK13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15335,7 +15335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xBF, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 14)",
-      R"(WR_CAS Access to Rank 7; Bank 14)",
+      R"(UNC_M_WR_CAS_RANK7.BANK14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15347,7 +15347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xBF, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 15)",
-      R"(WR_CAS Access to Rank 7; Bank 15)",
+      R"(UNC_M_WR_CAS_RANK7.BANK15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15359,7 +15359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15371,7 +15371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15383,7 +15383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15395,7 +15395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(UNC_M_WR_CAS_RANK7.BANKG3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15427,5 +15427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace broadwellx_uncore_v14
+} // namespace broadwellx_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/goldmont_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/goldmont_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace goldmont_core_v13 {
+namespace goldmont_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from goldmont_core_v13.json (169 events).
+    Events from goldmont_core.json (169 events).
 
     Supported SKUs:
         - Arch: x86, Model: GLM id: 92
@@ -2295,5 +2295,5 @@ This event counts differently than Intel processors based on Silvermont microarc
       R"(0)"));
 }
 
-} // namespace goldmont_core_v13
+} // namespace goldmont_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/haswellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/haswellx_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace haswellx_core_v20 {
+namespace haswellx_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from haswellx_core_v20.json (385 events).
+    Events from haswellx_core.json (385 events).
 
     Supported SKUs:
         - Arch: x86, Model: HSX id: 63
@@ -40,23 +40,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_ANY",
-      EventDef::Encoding{
-          .code = 0x00,
-          .umask = 0x02,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -68,7 +53,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -80,7 +66,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -92,7 +79,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -104,7 +92,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -116,7 +105,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -128,7 +118,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -140,7 +131,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -152,7 +144,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -164,7 +157,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -176,19 +170,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_LOAD_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Demand load Miss in all translation lookaside buffer (TLB) levels causes a page walk that completes of any page size.)",
-      R"(Completed page walks in any TLB of any page size due to demand load misses.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -200,7 +183,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -212,7 +196,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -224,19 +209,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_LOAD_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x08, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Load operations that miss the first DTLB level but hit the second and do not cause page walks)",
-      R"(Number of cache load STLB hits. No page walk.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -248,7 +222,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -260,23 +235,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "INT_MISC.RECOVERY_CYCLES_ANY",
-      EventDef::Encoding{
-          .code = 0x0D,
-          .umask = 0x03,
-          .any = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke))",
-      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -288,7 +248,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.FLAGS_MERGE",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Number of flags-merge uops being allocated. Such uops considered perf sensitive; added by GSR u-arch.)",
+      R"(Number of flags-merge uops allocated. Such uops add delay.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.SLOW_LEA",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Number of slow LEA uops being allocated. A uop is generally considered SlowLea if it has 3 sources (e.g. 2 sources + immediate) regardless if as a result of LEA instruction or not.)",
+      R"(Number of slow LEA or similar uops allocated. Such uop has 3 sources (for example, 2 sources + immediate) regardless of whether it is a result of LEA instruction or not.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_ISSUED.SINGLE_MUL",
+      EventDef::Encoding{
+          .code = 0x0E, .umask = 0x40, .cmask = 0, .msr_values = {0}},
+      R"(Number of Multiply packed/scalar single precision uops allocated)",
+      R"(Number of multiply packed/scalar single precision uops allocated.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -304,7 +304,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -321,43 +322,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.FLAGS_MERGE",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of flags-merge uops being allocated. Such uops considered perf sensitive; added by GSR u-arch.)",
-      R"(Number of flags-merge uops allocated. Such uops add delay.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.SLOW_LEA",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of slow LEA uops being allocated. A uop is generally considered SlowLea if it has 3 sources (e.g. 2 sources + immediate) regardless if as a result of LEA instruction or not.)",
-      R"(Number of slow LEA or similar uops allocated. Such uop has 3 sources (for example, 2 sources + immediate) regardless of whether it is a result of LEA instruction or not.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_ISSUED.SINGLE_MUL",
-      EventDef::Encoding{
-          .code = 0x0E, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(Number of Multiply packed/scalar single precision uops allocated)",
-      R"(Number of multiply packed/scalar single precision uops allocated.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -369,7 +335,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -381,67 +348,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.RFO_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x22, .cmask = 0, .msr_values = {0}},
-      R"(RFO requests that miss L2 cache)",
-      R"(Counts the number of store RFO requests that miss the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.CODE_RD_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x24, .cmask = 0, .msr_values = {0}},
-      R"(L2 cache misses when fetching instructions)",
-      R"(Number of instruction fetches that missed the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.ALL_DEMAND_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x27, .cmask = 0, .msr_values = {0}},
-      R"(Demand requests that miss L2 cache)",
-      R"(Demand requests that miss L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.L2_PF_MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(L2 prefetch requests that miss L2 cache)",
-      R"(Counts all L2 HW prefetcher requests that missed L2.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.MISS",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0x3F, .cmask = 0, .msr_values = {0}},
-      R"(All requests that miss L2 cache)",
-      R"(All requests that missed L2.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -453,31 +360,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "L2_RQSTS.RFO_HIT",
+      "L2_RQSTS.L2_PF_MISS",
       EventDef::Encoding{
-          .code = 0x24, .umask = 0xc2, .cmask = 0, .msr_values = {0}},
-      R"(RFO requests that hit L2 cache)",
-      R"(Counts the number of store RFO requests that hit the L2 cache.)",
+          .code = 0x24, .umask = 0x30, .cmask = 0, .msr_values = {0}},
+      R"(L2 prefetch requests that miss L2 cache)",
+      R"(Counts all L2 HW prefetcher requests that missed L2.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.CODE_RD_HIT",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xc4, .cmask = 0, .msr_values = {0}},
-      R"(L2 cache hits when fetching instructions, code reads.)",
-      R"(Number of instruction fetches that hit the L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -489,19 +385,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "L2_RQSTS.ALL_DEMAND_DATA_RD",
       EventDef::Encoding{
-          .code = 0x24, .umask = 0xE1, .cmask = 0, .msr_values = {0}},
+          .code = 0x24, .umask = 0xe1, .cmask = 0, .msr_values = {0}},
       R"(Demand Data Read requests)",
       R"(Counts any demand and L1 HW prefetch data load requests to L2.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -513,7 +410,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -525,19 +423,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.ALL_DEMAND_REFERENCES",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xe7, .cmask = 0, .msr_values = {0}},
-      R"(Demand requests to L2 cache)",
-      R"(Demand requests to L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -549,19 +436,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L2_RQSTS.REFERENCES",
-      EventDef::Encoding{
-          .code = 0x24, .umask = 0xFF, .cmask = 0, .msr_values = {0}},
-      R"(All L2 requests)",
-      R"(All requests to L2 cache.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -573,7 +449,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -585,7 +462,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -597,35 +475,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_P",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(Thread cycles when thread is not in halt state)",
-      R"(Counts the number of thread cycles while the thread is not in a halt state. The thread enters the halt state when it is running the HLT instruction. The core frequency may change from time to time due to power or thermal throttling.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.THREAD_P_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x00,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -634,54 +485,11 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
       R"(Increments at the frequency of XCLK (100 MHz) when not halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.REF_XCLK",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
-      R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the thread is unhalted. (counts at 100 MHz rate))",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.REF_XCLK_ANY",
-      EventDef::Encoding{
-          .code = 0x3C,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0x00}},
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
-      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -690,62 +498,24 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x3c, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
       R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
+      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE",
-      EventDef::Encoding{
-          .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
-      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "L1D_PEND_MISS.PENDING",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(L1D miss oustandings duration in cycles)",
+      R"(L1D miss outstanding duration in cycles)",
       R"(Increments the number of outstanding L1D misses every cycle. Set Cmask = 1 and Edge =1 to count occurrences.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L1D_PEND_MISS.PENDING_CYCLES",
-      EventDef::Encoding{
-          .code = 0x48, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles with L1D load Misses outstanding.)",
-      R"(Cycles with L1D load Misses outstanding.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "L1D_PEND_MISS.PENDING_CYCLES_ANY",
-      EventDef::Encoding{
-          .code = 0x48,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 1,
-          .msr_values = {0x00}},
-      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
-      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -757,19 +527,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "L1D_PEND_MISS.FB_FULL",
+      "L1D_PEND_MISS.PENDING_CYCLES",
       EventDef::Encoding{
-          .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+          .code = 0x48, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles with L1D load Misses outstanding.)",
+      R"(Cycles with L1D load Misses outstanding.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -781,7 +553,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -793,7 +566,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -805,7 +579,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -817,19 +592,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_STORE_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Store misses in all DTLB levels that cause completed page walks)",
-      R"(Completed page walks due to store miss in any TLB levels of any page size (4K/2M/4M/1G).)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -841,7 +605,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -853,7 +618,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -865,19 +631,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "DTLB_STORE_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x49, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks)",
-      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -889,7 +644,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -901,7 +657,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -913,7 +670,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -925,7 +683,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -937,7 +696,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -949,7 +709,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -961,7 +722,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -973,7 +735,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -985,7 +748,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -997,7 +761,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1009,7 +774,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1021,7 +787,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1033,7 +800,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1045,7 +813,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1057,7 +826,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1069,7 +839,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       1000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1081,7 +852,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPL_CYCLES.RING123",
+      EventDef::Encoding{
+          .code = 0x5C, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Unhalted core cycles when thread is in rings 1, 2, or 3)",
+      R"(Unhalted core cycles when the thread is not in ring 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1097,19 +882,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CPL_CYCLES.RING123",
-      EventDef::Encoding{
-          .code = 0x5C, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Unhalted core cycles when thread is in rings 1, 2, or 3)",
-      R"(Unhalted core cycles when the thread is not in ring 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1121,7 +895,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1133,7 +908,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1145,7 +921,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1157,7 +934,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1169,7 +947,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1181,24 +960,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "RS_EVENTS.EMPTY_END",
-      EventDef::Encoding{
-          .code = 0x5E,
-          .umask = 0x01,
-          .edge = true,
-          .inv = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
-      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1210,31 +973,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_DATA_RD",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
-      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.DEMAND_DATA_RD_GE_6",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x01, .cmask = 6, .msr_values = {0x00}},
-      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
-      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD78, HSD62, HSD61)"));
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1246,7 +985,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1258,19 +997,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO",
-      EventDef::Encoding{
-          .code = 0x60, .umask = 0x04, .cmask = 1, .msr_values = {0}},
-      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
-      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1282,7 +1009,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_DATA_RD",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
+      R"(Cycles when offcore outstanding Demand Data Read transactions are present in SuperQueue (SQ), queue to uncore.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1294,7 +1033,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD62, HSD61)"));
+      R"(HSD62, HSD61, HSM63)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x04, .cmask = 1, .msr_values = {0}},
+      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
+      R"(Offcore outstanding demand rfo reads transactions in SuperQueue (SQ), queue to uncore, every cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD62, HSD61, HSM63)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1306,7 +1057,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1318,7 +1070,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1342,19 +1095,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MITE_CYCLES",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x04, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1366,7 +1108,73 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_DSB_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by DSB. Set Cmask = 1 to count cycles. Add Edge=1 to count # of delivery.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_MITE_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by MITE. Set Cmask = 1 to count cycles.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_UOPS",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(This event counts uops delivered by the Front-end with the assistance of the microcode sequencer.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_CYCLES",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy)",
+      R"(This event counts cycles during which the microcode sequencer assisted the Front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MITE_CYCLES",
+      EventDef::Encoding{
+          .code = 0x79, .umask = 0x04, .cmask = 1, .msr_values = {0}},
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) from MITE path.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1378,31 +1186,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_DSB_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by DSB. Set Cmask = 1 to count cycles. Add Edge=1 to count # of delivery.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "IDQ.MS_DSB_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1413,12 +1211,13 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1430,7 +1229,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1442,19 +1242,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_MITE_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(Increment each cycle # of uops delivered to IDQ when MS_busy by MITE. Set Cmask = 1 to count cycles.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1466,7 +1255,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1478,47 +1268,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_UOPS",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(This event counts uops delivered by the Front-end with the assistance of the microcode sequencer.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_CYCLES",
-      EventDef::Encoding{
-          .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy)",
-      R"(This event counts cycles during which the microcode sequencer assisted the Front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "IDQ.MS_SWITCHES",
-      EventDef::Encoding{
-          .code = 0x79,
-          .umask = 0x30,
-          .edge = true,
-          .cmask = 1,
-          .msr_values = {0}},
-      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
-      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1530,7 +1281,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1542,7 +1294,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1554,7 +1307,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1566,19 +1320,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ICACHE.IFDATA_STALL",
-      EventDef::Encoding{
-          .code = 0x80, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
-      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1590,7 +1333,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1602,7 +1346,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1614,7 +1359,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1626,19 +1372,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ITLB_MISSES.WALK_COMPLETED",
-      EventDef::Encoding{
-          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
-      R"(Misses in all ITLB levels that cause completed page walks)",
-      R"(Completed page walks in ITLB of any page size.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1650,7 +1385,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1662,7 +1398,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1674,19 +1411,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "ITLB_MISSES.STLB_HIT",
-      EventDef::Encoding{
-          .code = 0x85, .umask = 0x60, .cmask = 0, .msr_values = {0}},
-      R"(Operations that miss the first ITLB level but hit the second and do not cause any page walks)",
-      R"(ITLB misses that hit STLB. No page walk.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1698,7 +1424,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1710,7 +1437,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1722,7 +1450,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1734,7 +1463,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1746,7 +1476,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1758,7 +1489,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1770,7 +1502,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1782,7 +1515,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1794,7 +1528,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1806,7 +1541,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1818,7 +1554,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1830,7 +1567,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1842,7 +1580,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1854,7 +1593,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1866,7 +1606,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1878,7 +1619,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1890,7 +1632,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1902,7 +1645,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1914,19 +1658,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_MISP_EXEC.TAKEN_INDIRECT_NEAR_CALL",
-      EventDef::Encoding{
-          .code = 0x89, .umask = 0xA0, .cmask = 0, .msr_values = {0}},
-      R"(Taken speculative and retired mispredicted indirect calls.)",
-      R"(Taken speculative and retired mispredicted indirect calls.)",
-      200003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1938,7 +1671,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1950,7 +1684,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1962,7 +1697,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2050,35 +1786,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_0_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x01,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 0.)",
-      R"(Cycles per core when uops are exectuted in port 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_0",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 0.)",
-      R"(Cycles per thread when uops are executed in port 0.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2090,35 +1799,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_1_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x02,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 1.)",
-      R"(Cycles per core when uops are exectuted in port 1.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_1",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 1.)",
-      R"(Cycles per thread when uops are executed in port 1.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2130,35 +1812,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_2_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x04,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 2.)",
-      R"(Cycles per core when uops are dispatched to port 2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_2",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 2.)",
-      R"(Cycles per thread when uops are executed in port 2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2170,35 +1825,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_3_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x08,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 3.)",
-      R"(Cycles per core when uops are dispatched to port 3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_3",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 3.)",
-      R"(Cycles per thread when uops are executed in port 3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2210,35 +1838,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_4_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x10,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 4.)",
-      R"(Cycles per core when uops are exectuted in port 4.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_4",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 4.)",
-      R"(Cycles per thread when uops are executed in port 4.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2250,35 +1851,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_5_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x20,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 5.)",
-      R"(Cycles per core when uops are exectuted in port 5.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_5",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 5.)",
-      R"(Cycles per thread when uops are executed in port 5.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2290,35 +1864,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_6_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x40,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are executed in port 6.)",
-      R"(Cycles per core when uops are exectuted in port 6.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_6",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 6.)",
-      R"(Cycles per thread when uops are executed in port 6.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2330,35 +1877,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED_PORT.PORT_7_CORE",
-      EventDef::Encoding{
-          .code = 0xA1,
-          .umask = 0x80,
-          .any = true,
-          .cmask = 0,
-          .msr_values = {0}},
-      R"(Cycles per core when uops are dispatched to port 7.)",
-      R"(Cycles per core when uops are dispatched to port 7.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_DISPATCHED_PORT.PORT_7",
-      EventDef::Encoding{
-          .code = 0xA1, .umask = 0x80, .cmask = 0, .msr_values = {0}},
-      R"(Cycles per thread when uops are executed in port 7.)",
-      R"(Cycles per thread when uops are executed in port 7.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2382,7 +1902,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2394,7 +1915,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2406,67 +1928,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CYCLE_ACTIVITY.CYCLES_L2_PENDING",
       EventDef::Encoding{
-          .code = 0xA3, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+          .code = 0xa3, .umask = 0x01, .cmask = 1, .msr_values = {0}},
       R"(Cycles with pending L2 cache miss loads.)",
       R"(Cycles with pending L2 miss loads. Set Cmask=2 to count cycle.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.CYCLES_LDM_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x02, .cmask = 2, .msr_values = {0}},
-      R"(Cycles with pending memory loads.)",
-      R"(Cycles with pending memory loads. Set Cmask=2 to count cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.CYCLES_NO_EXECUTE",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x04, .cmask = 4, .msr_values = {0}},
-      R"(This event increments by 1 for every cycle where there was no execute for this thread.)",
-      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.STALLS_L2_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x05, .cmask = 5, .msr_values = {0}},
-      R"(Execution stalls due to L2 cache misses.)",
-      R"(Number of loads missed L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "CYCLE_ACTIVITY.STALLS_LDM_PENDING",
-      EventDef::Encoding{
-          .code = 0xA3, .umask = 0x06, .cmask = 6, .msr_values = {0}},
-      R"(Execution stalls due to memory subsystem.)",
-      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline and there were memory instructions pending (waiting for data).)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      R"(HSD78, HSM63, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2478,7 +1953,59 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.CYCLES_LDM_PENDING",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x02, .cmask = 2, .msr_values = {0}},
+      R"(Cycles with pending memory loads.)",
+      R"(Cycles with pending memory loads. Set Cmask=2 to count cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.CYCLES_NO_EXECUTE",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x04, .cmask = 4, .msr_values = {0}},
+      R"(This event increments by 1 for every cycle where there was no execute for this thread.)",
+      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.STALLS_L2_PENDING",
+      EventDef::Encoding{
+          .code = 0xa3, .umask = 0x05, .cmask = 5, .msr_values = {0}},
+      R"(Execution stalls due to L2 cache misses.)",
+      R"(Number of loads missed L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSM63, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CYCLE_ACTIVITY.STALLS_LDM_PENDING",
+      EventDef::Encoding{
+          .code = 0xA3, .umask = 0x06, .cmask = 6, .msr_values = {0}},
+      R"(Execution stalls due to memory subsystem.)",
+      R"(This event counts cycles during which no instructions were executed in the execution stage of the pipeline and there were memory instructions pending (waiting for data).)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2490,7 +2017,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2502,31 +2030,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "LSD.CYCLES_ACTIVE",
-      EventDef::Encoding{
-          .code = 0xA8, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
-      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "LSD.CYCLES_4_UOPS",
-      EventDef::Encoding{
-          .code = 0xA8, .umask = 0x01, .cmask = 4, .msr_values = {0}},
-      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
-      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2538,7 +2043,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2550,31 +2056,33 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_REQUESTS.DEMAND_DATA_RD",
       EventDef::Encoding{
-          .code = 0xB0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+          .code = 0xb0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Demand Data Read requests sent to uncore)",
       R"(Demand data read requests sent to uncore.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(HSD78)"));
+      R"(HSD78, HSM80)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_REQUESTS.DEMAND_CODE_RD",
       EventDef::Encoding{
           .code = 0xB0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cacheable and noncachaeble code read requests)",
+      R"(Cacheable and noncacheable code read requests)",
       R"(Demand code read requests sent to uncore.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2586,7 +2094,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2598,7 +2107,20 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of uops executed on the core.)",
+      R"(Counts total number of uops to be executed per-core each cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2618,148 +2140,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 1, .msr_values = {0}},
-      R"(Cycles where at least 1 uop was executed per-thread)",
-      R"(This events counts the cycles where at least one uop was executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 2, .msr_values = {0}},
-      R"(Cycles where at least 2 uops were executed per-thread)",
-      R"(This events counts the cycles where at least two uop were executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 3, .msr_values = {0}},
-      R"(Cycles where at least 3 uops were executed per-thread)",
-      R"(This events counts the cycles where at least three uop were executed. It is counted per thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CYCLES_GE_4_UOPS_EXEC",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x01, .cmask = 4, .msr_values = {0}},
-      R"(Cycles where at least 4 uops were executed per-thread.)",
-      R"(Cycles where at least 4 uops were executed per-thread.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD144, HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE",
-      EventDef::Encoding{
-          .code = 0xB1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of uops executed on the core.)",
-      R"(Counts total number of uops to be executed per-core each cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_1",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_2",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 2, .msr_values = {0x00}},
-      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_3",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 3, .msr_values = {0x00}},
-      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_GE_4",
-      EventDef::Encoding{
-          .code = 0xb1, .umask = 0x02, .cmask = 4, .msr_values = {0x00}},
-      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
-      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_EXECUTED.CORE_CYCLES_NONE",
-      EventDef::Encoding{
-          .code = 0xb1,
-          .umask = 0x02,
-          .inv = true,
-          .cmask = 0,
-          .msr_values = {0x00}},
-      R"(Cycles with no micro-ops executed from any thread on physical core.)",
-      R"(Cycles with no micro-ops executed from any thread on physical core.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(HSD30, HSM31)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
       "OFFCORE_REQUESTS_BUFFER.SQ_FULL",
       EventDef::Encoding{
           .code = 0xb2, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Offcore requests buffer cannot take more entries for this thread core.)",
       R"(Offcore requests buffer cannot take more entries for this thread core.)",
       2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "OFFCORE_RESPONSE",
-      EventDef::Encoding{
-          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
-      100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
       std::nullopt // Errata
@@ -2775,7 +2161,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.ITLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x21, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L1+FB)",
+      R"(Number of ITLB page walker loads that hit in the L1+FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_DTLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x41, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_ITLB_L1",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x81, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2787,7 +2213,47 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.ITLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x22, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L2)",
+      R"(Number of ITLB page walker loads that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_DTLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x42, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "PAGE_WALKER_LOADS.EPT_ITLB_L2",
+      EventDef::Encoding{
+          .code = 0xBC, .umask = 0x82, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2803,11 +2269,11 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.DTLB_MEMORY",
+      "PAGE_WALKER_LOADS.ITLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x18, .cmask = 0, .msr_values = {0}},
-      R"(Number of DTLB page walker hits in Memory)",
-      R"(Number of DTLB page walker loads from memory.)",
+          .code = 0xBC, .umask = 0x24, .cmask = 0, .msr_values = {0}},
+      R"(Number of ITLB page walker hits in the L3 + XSNP)",
+      R"(Number of ITLB page walker loads that hit in the L3.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2815,35 +2281,37 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L1",
+      "PAGE_WALKER_LOADS.EPT_DTLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x21, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L1+FB)",
-      R"(Number of ITLB page walker loads that hit in the L1+FB.)",
+          .code = 0xBC, .umask = 0x44, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
+      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L2",
+      "PAGE_WALKER_LOADS.EPT_ITLB_L3",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x22, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L2)",
-      R"(Number of ITLB page walker loads that hit in the L2.)",
+          .code = 0xBC, .umask = 0x84, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
+      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.ITLB_L3",
+      "PAGE_WALKER_LOADS.DTLB_MEMORY",
       EventDef::Encoding{
-          .code = 0xBC, .umask = 0x24, .cmask = 0, .msr_values = {0}},
-      R"(Number of ITLB page walker hits in the L3 + XSNP)",
-      R"(Number of ITLB page walker loads that hit in the L3.)",
+          .code = 0xBC, .umask = 0x18, .cmask = 0, .msr_values = {0}},
+      R"(Number of DTLB page walker hits in Memory)",
+      R"(Number of DTLB page walker loads from memory.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2863,42 +2331,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L1",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x41, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L1 and FB.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L2",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x42, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_DTLB_L3",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x44, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
-      R"(Counts the number of Extended Page Table walks from the DTLB that hit in the L3.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
       "PAGE_WALKER_LOADS.EPT_DTLB_MEMORY",
       EventDef::Encoding{
           .code = 0xBC, .umask = 0x48, .cmask = 0, .msr_values = {0}},
@@ -2907,43 +2339,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L1",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x81, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L1 and FB.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L2",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x82, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "PAGE_WALKER_LOADS.EPT_ITLB_L3",
-      EventDef::Encoding{
-          .code = 0xBC, .umask = 0x84, .cmask = 0, .msr_values = {0}},
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      R"(Counts the number of Extended Page Table walks from the ITLB that hit in the L2.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2955,7 +2352,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2967,7 +2365,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2979,7 +2378,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2995,6 +2395,19 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "INST_RETIRED.X87",
+      EventDef::Encoding{
+          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(FP operations retired. X87 FP operations that have no exceptions: Counts also flows that have several X87 or flows that use X87 uops in the exception handling.)",
+      R"(This is a non-precise version (that is, does not use PEBS) of the event that counts FP operations retired. For X87 FP operations that have no exceptions counting also includes flows that have several X87, or flows that use X87 uops in the exception handling.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "INST_RETIRED.PREC_DIST",
       EventDef::Encoding{
           .code = 0xC0, .umask = 0x01, .cmask = 0, .msr_values = {0}},
@@ -3004,18 +2417,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
       R"(HSD140)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "INST_RETIRED.X87",
-      EventDef::Encoding{
-          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(FP operations retired. X87 FP operations that have no exceptions: Counts also flows that have several X87 or flows that use X87 uops in the exception handling.)",
-      R"(This is a non-precise version (that is, does not use PEBS) of the event that counts FP operations retired. For X87 FP operations that have no exceptions counting also includes flows that have several X87, or flows that use X87 uops in the exception handling.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3051,7 +2452,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3062,8 +2464,22 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Counts the number of micro-ops retired. Use Cmask=1 and invert to count active cycles or stalled cycles.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_RETIRED.RETIRE_SLOTS",
+      EventDef::Encoding{
+          .code = 0xC2, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Retirement slots used.)",
+      R"(This event counts the number of retirement slots used each cycle.  There are potentially 4 slots that can be used each cycle - meaning, 4 uops or 4 instructions could retire each cycle.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3079,7 +2495,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3088,14 +2505,15 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0xC2,
           .umask = 0x01,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Cycles with less than 10 actually retired uops.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3112,19 +2530,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "UOPS_RETIRED.RETIRE_SLOTS",
-      EventDef::Encoding{
-          .code = 0xC2, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Retirement slots used.)",
-      R"(This event counts the number of retirement slots used each cycle.  There are potentially 4 slots that can be used each cycle - meaning, 4 uops or 4 instructions could retire each cycle.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3136,23 +2543,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "MACHINE_CLEARS.COUNT",
-      EventDef::Encoding{
-          .code = 0xC3,
-          .umask = 0x01,
-          .edge = true,
-          .cmask = 1,
-          .msr_values = {0x00}},
-      R"(Number of machine clears (nukes) of any type.)",
-      R"(Number of machine clears (nukes) of any type.)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3164,7 +2556,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3176,7 +2569,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3188,19 +2582,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_INST_RETIRED.ALL_BRANCHES",
-      EventDef::Encoding{
-          .code = 0xC4, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(All (macro) branch instructions retired.)",
-      R"(Branch instructions at retirement.)",
-      400009,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3212,7 +2595,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3224,31 +2608,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BR_INST_RETIRED.NEAR_CALL_R3",
+      "BR_INST_RETIRED.ALL_BRANCHES",
       EventDef::Encoding{
-          .code = 0xC4, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
-      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
-      100003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_INST_RETIRED.ALL_BRANCHES_PEBS",
-      EventDef::Encoding{
-          .code = 0xC4, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+          .code = 0xC4, .umask = 0x00, .cmask = 0, .msr_values = {0}},
       R"(All (macro) branch instructions retired.)",
-      R"(All (macro) branch instructions retired.)",
+      R"(Branch instructions at retirement.)",
       400009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3260,7 +2634,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3272,7 +2647,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3284,7 +2660,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3296,19 +2673,34 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BR_MISP_RETIRED.ALL_BRANCHES",
+      "BR_INST_RETIRED.ALL_BRANCHES_PEBS",
       EventDef::Encoding{
-          .code = 0xC5, .umask = 0x00, .cmask = 0, .msr_values = {0}},
-      R"(All mispredicted macro branch instructions retired.)",
-      R"(Mispredicted branch instructions at retirement.)",
+          .code = 0xC4, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(All (macro) branch instructions retired.)",
+      R"(All (macro) branch instructions retired.)",
       400009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      EventDef::IntelFeatures{.pebs = 2},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_INST_RETIRED.NEAR_CALL_R3",
+      EventDef::Encoding{
+          .code = 0xC4, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
+      R"(Direct and indirect macro near call instructions retired (captured in ring 3).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3320,7 +2712,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_RETIRED.ALL_BRANCHES",
+      EventDef::Encoding{
+          .code = 0xC5, .umask = 0x00, .cmask = 0, .msr_values = {0}},
+      R"(All mispredicted macro branch instructions retired.)",
+      R"(Mispredicted branch instructions at retirement.)",
+      400009,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3332,31 +2738,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "BR_MISP_RETIRED.NEAR_TAKEN",
-      EventDef::Encoding{
-          .code = 0xC5, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(number of near branch instructions retired that were mispredicted and taken.)",
-      R"(Number of near branch instructions retired that were taken but mispredicted.)",
-      400009,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::cpu,
-      "AVX_INSTS.ALL",
-      EventDef::Encoding{
-          .code = 0xC6, .umask = 0x07, .cmask = 0, .msr_values = {0}},
-      R"(Approximate counts of AVX & AVX2 256-bit instructions, including non-arithmetic instructions, loads, and stores.  May count non-AVX instructions that employ 256-bit operations, including (but not necessarily limited to) rep string instructions that use 256-bit loads and stores for optimized performance, XSAVE* and XRSTOR*, and operations that transition the x87 FPU data registers between x87 and MMX.)",
-      R"(Note that a whole rep string only counts AVX_INST.ALL once.)",
-      2000003,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3368,7 +2751,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3380,7 +2764,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3392,7 +2777,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3404,7 +2790,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3416,7 +2803,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3428,7 +2816,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3452,7 +2841,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3464,7 +2854,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3476,7 +2867,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3488,7 +2880,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3500,7 +2893,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3512,7 +2906,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3524,7 +2919,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3548,7 +2944,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3560,7 +2957,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3572,7 +2970,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3584,7 +2983,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3596,7 +2996,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3608,7 +3009,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3620,102 +3022,103 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_4",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x4}},
       R"(Randomly selected loads with latency value being above 4.)",
       R"(Randomly selected loads with latency value being above 4.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_8",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x8}},
       R"(Randomly selected loads with latency value being above 8.)",
       R"(Randomly selected loads with latency value being above 8.)",
       50021,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_16",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x10}},
       R"(Randomly selected loads with latency value being above 16.)",
       R"(Randomly selected loads with latency value being above 16.)",
       20011,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_32",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x20}},
       R"(Randomly selected loads with latency value being above 32.)",
       R"(Randomly selected loads with latency value being above 32.)",
       100003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_64",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x40}},
       R"(Randomly selected loads with latency value being above 64.)",
       R"(Randomly selected loads with latency value being above 64.)",
       2003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_128",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x80}},
       R"(Randomly selected loads with latency value being above 128.)",
       R"(Randomly selected loads with latency value being above 128.)",
       1009,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_256",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x100}},
       R"(Randomly selected loads with latency value being above 256.)",
       R"(Randomly selected loads with latency value being above 256.)",
       503,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEM_TRANS_RETIRED.LOAD_LATENCY_GT_512",
       EventDef::Encoding{
-          .code = 0xCD, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
+          .code = 0xcd, .umask = 0x01, .cmask = 0, .msr_values = {0x200}},
       R"(Randomly selected loads with latency value being above 512.)",
       R"(Randomly selected loads with latency value being above 512.)",
       101,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.data_la = true, .pebs = 2},
       R"(HSD76, HSD25, HSM26)"));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3785,8 +3188,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "MEM_UOPS_RETIRED.ALL_LOADS",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x81, .cmask = 0, .msr_values = {0}},
-      R"(All retired load uops.)",
-      R"(All retired load uops.)",
+      R"(Retired load uops.)",
+      R"(Counts all retired load uops. This event accounts for SW prefetch uops of PREFETCHNTA or PREFETCHT0/1/2 or PREFETCHW.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
@@ -3797,8 +3200,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "MEM_UOPS_RETIRED.ALL_STORES",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x82, .cmask = 0, .msr_values = {0}},
-      R"(All retired store uops.)",
-      R"(All retired store uops.)",
+      R"(Retired store uops.)",
+      R"(Counts all retired store uops.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
@@ -3987,15 +3390,16 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
-      "BACLEARS.ANY",
+      "CPU_CLK_UNHALTED.THREAD_P",
       EventDef::Encoding{
-          .code = 0xe6, .umask = 0x1f, .cmask = 0, .msr_values = {0}},
-      R"(Counts the total number when the front end is resteered, mainly when the BPU cannot provide a correct prediction and this is corrected by other branch handling mechanisms at the front end.)",
-      R"(Number of front end re-steers due to BPU misprediction.)",
-      100003,
+          .code = 0x3C, .umask = 0x00, .cmask = 0, .msr_values = {0}},
+      R"(Thread cycles when thread is not in halt state)",
+      R"(Counts the number of thread cycles while the thread is not in a halt state. The thread enters the halt state when it is running the HLT instruction. The core frequency may change from time to time due to power or thermal throttling.)",
+      2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4007,7 +3411,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4019,7 +3424,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4031,7 +3437,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4043,7 +3450,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4055,7 +3463,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4067,7 +3476,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4079,7 +3489,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4091,7 +3502,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4103,7 +3515,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4115,7 +3528,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4127,7 +3541,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4139,7 +3554,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4151,7 +3567,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4163,7 +3580,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -4175,17 +3593,854 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_EXEC.TAKEN_INDIRECT_NEAR_CALL",
+      EventDef::Encoding{
+          .code = 0x89, .umask = 0xA0, .cmask = 0, .msr_values = {0}},
+      R"(Taken speculative and retired mispredicted indirect calls.)",
+      R"(Taken speculative and retired mispredicted indirect calls.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_0_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 0.)",
+      R"(Cycles per core when uops are executed in port 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_1_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x02,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 1.)",
+      R"(Cycles per core when uops are executed in port 1.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_2_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x04,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 2.)",
+      R"(Cycles per core when uops are dispatched to port 2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_3_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x08,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 3.)",
+      R"(Cycles per core when uops are dispatched to port 3.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_4_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x10,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 4.)",
+      R"(Cycles per core when uops are executed in port 4.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_5_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x20,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 5.)",
+      R"(Cycles per core when uops are executed in port 5.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_6_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x40,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are executed in port 6.)",
+      R"(Cycles per core when uops are executed in port 6.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED_PORT.PORT_7_CORE",
+      EventDef::Encoding{
+          .code = 0xA1,
+          .umask = 0x80,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Cycles per core when uops are dispatched to port 7.)",
+      R"(Cycles per core when uops are dispatched to port 7.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_RETIRED.NEAR_TAKEN",
+      EventDef::Encoding{
+          .code = 0xC5, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(number of near branch instructions retired that were mispredicted and taken.)",
+      R"(Number of near branch instructions retired that were taken but mispredicted.)",
+      400009,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_LOAD_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Demand load Miss in all translation lookaside buffer (TLB) levels causes a page walk that completes of any page size.)",
+      R"(Completed page walks in any TLB of any page size due to demand load misses.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_LOAD_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x08, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Load operations that miss the first DTLB level but hit the second and do not cause page walks)",
+      R"(Number of cache load STLB hits. No page walk.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.RFO_HIT",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xc2, .cmask = 0, .msr_values = {0}},
+      R"(RFO requests that hit L2 cache)",
+      R"(Counts the number of store RFO requests that hit the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.RFO_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x22, .cmask = 0, .msr_values = {0}},
+      R"(RFO requests that miss L2 cache)",
+      R"(Counts the number of store RFO requests that miss the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.CODE_RD_HIT",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xc4, .cmask = 0, .msr_values = {0}},
+      R"(L2 cache hits when fetching instructions, code reads.)",
+      R"(Number of instruction fetches that hit the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.CODE_RD_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x24, .cmask = 0, .msr_values = {0}},
+      R"(L2 cache misses when fetching instructions)",
+      R"(Number of instruction fetches that missed the L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.ALL_DEMAND_MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x27, .cmask = 0, .msr_values = {0}},
+      R"(Demand requests that miss L2 cache)",
+      R"(Demand requests that miss L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.ALL_DEMAND_REFERENCES",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xe7, .cmask = 0, .msr_values = {0}},
+      R"(Demand requests to L2 cache)",
+      R"(Demand requests to L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.MISS",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0x3f, .cmask = 0, .msr_values = {0}},
+      R"(All requests that miss L2 cache)",
+      R"(All requests that missed L2.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L2_RQSTS.REFERENCES",
+      EventDef::Encoding{
+          .code = 0x24, .umask = 0xff, .cmask = 0, .msr_values = {0}},
+      R"(All L2 requests)",
+      R"(All requests to L2 cache.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_STORE_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Store misses in all DTLB levels that cause completed page walks)",
+      R"(Completed page walks due to store miss in any TLB levels of any page size (4K/2M/4M/1G).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "DTLB_STORE_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x49, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks)",
+      R"(Store operations that miss the first TLB level but hit the second and do not cause page walks.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ITLB_MISSES.WALK_COMPLETED",
+      EventDef::Encoding{
+          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
+      R"(Misses in all ITLB levels that cause completed page walks)",
+      R"(Completed page walks in ITLB of any page size.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ITLB_MISSES.STLB_HIT",
+      EventDef::Encoding{
+          .code = 0x85, .umask = 0x60, .cmask = 0, .msr_values = {0}},
+      R"(Operations that miss the first ITLB level but hit the second and do not cause any page walks)",
+      R"(ITLB misses that hit STLB. No page walk.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles where at least 1 uop was executed per-thread)",
+      R"(This events counts the cycles where at least one uop was executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 2, .msr_values = {0}},
+      R"(Cycles where at least 2 uops were executed per-thread)",
+      R"(This events counts the cycles where at least two uop were executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 3, .msr_values = {0}},
+      R"(Cycles where at least 3 uops were executed per-thread)",
+      R"(This events counts the cycles where at least three uop were executed. It is counted per thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CYCLES_GE_4_UOPS_EXEC",
+      EventDef::Encoding{
+          .code = 0xB1, .umask = 0x01, .cmask = 4, .msr_values = {0}},
+      R"(Cycles where at least 4 uops were executed per-thread.)",
+      R"(Cycles where at least 4 uops were executed per-thread.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD144, HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BACLEARS.ANY",
+      EventDef::Encoding{
+          .code = 0xe6, .umask = 0x1f, .cmask = 0, .msr_values = {0}},
+      R"(Counts the total number when the front end is resteered, mainly when the BPU cannot provide a correct prediction and this is corrected by other branch handling mechanisms at the front end.)",
+      R"(Number of front end re-steers due to BPU misprediction.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_RESPONSE",
+      EventDef::Encoding{
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "MACHINE_CLEARS.COUNT",
+      EventDef::Encoding{
+          .code = 0xC3,
+          .umask = 0x01,
+          .edge = true,
+          .cmask = 1,
+          .msr_values = {0x00}},
+      R"(Number of machine clears (nukes) of any type.)",
+      R"(Number of machine clears (nukes) of any type.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "LSD.CYCLES_ACTIVE",
+      EventDef::Encoding{
+          .code = 0xA8, .umask = 0x01, .cmask = 1, .msr_values = {0}},
+      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
+      R"(Cycles Uops delivered by the LSD, but didn't come from the decoder.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "LSD.CYCLES_4_UOPS",
+      EventDef::Encoding{
+          .code = 0xA8, .umask = 0x01, .cmask = 4, .msr_values = {0}},
+      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
+      R"(Cycles 4 Uops delivered by the LSD, but didn't come from the decoder.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "RS_EVENTS.EMPTY_END",
+      EventDef::Encoding{
+          .code = 0x5E,
+          .umask = 0x01,
+          .edge = true,
+          .inv = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
+      R"(Counts end of periods where the Reservation Station (RS) was empty. Could be useful to precisely locate Frontend Latency Bound issues.)",
+      200003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "IDQ.MS_SWITCHES",
+      EventDef::Encoding{
+          .code = 0x79,
+          .umask = 0x30,
+          .edge = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
+      R"(Number of switches from DSB (Decode Stream Buffer) or MITE (legacy decode pipeline) to the Microcode Sequencer.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_0",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 0.)",
+      R"(Cycles per thread when uops are executed in port 0.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_1",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 1.)",
+      R"(Cycles per thread when uops are executed in port 1.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_2",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 2.)",
+      R"(Cycles per thread when uops are executed in port 2.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_3",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x08, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 3.)",
+      R"(Cycles per thread when uops are executed in port 3.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_4",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 4.)",
+      R"(Cycles per thread when uops are executed in port 4.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_5",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x20, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 5.)",
+      R"(Cycles per thread when uops are executed in port 5.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_6",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x40, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 6.)",
+      R"(Cycles per thread when uops are executed in port 6.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_DISPATCHED_PORT.PORT_7",
+      EventDef::Encoding{
+          .code = 0xA1, .umask = 0x80, .cmask = 0, .msr_values = {0}},
+      R"(Cycles per thread when uops are executed in port 7.)",
+      R"(Cycles per thread when uops are executed in port 7.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.THREAD_ANY",
+      EventDef::Encoding{
+          .code = 0x00,
+          .umask = 0x02,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.THREAD_P_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x00,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      R"(Core cycles when at least one thread on the physical core is not in halt state.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0}},
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "INT_MISC.RECOVERY_CYCLES_ANY",
+      EventDef::Encoding{
+          .code = 0x0D,
+          .umask = 0x03,
+          .any = true,
+          .cmask = 1,
+          .msr_values = {0}},
+      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke))",
+      R"(Core cycles the allocator was stalled due to recovery from earlier clear event for any thread running on the physical core (e.g. misprediction or memory nuke).)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_1",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
+      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 1 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_2",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 2, .msr_values = {0x00}},
+      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 2 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_3",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 3, .msr_values = {0x00}},
+      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 3 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_GE_4",
+      EventDef::Encoding{
+          .code = 0xb1, .umask = 0x02, .cmask = 4, .msr_values = {0x00}},
+      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
+      R"(Cycles at least 4 micro-op is executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_EXECUTED.CORE_CYCLES_NONE",
+      EventDef::Encoding{
+          .code = 0xb1,
+          .umask = 0x02,
+          .inv = true,
+          .cmask = 0,
+          .msr_values = {0x00}},
+      R"(Cycles with no micro-ops executed from any thread on physical core.)",
+      R"(Cycles with no micro-ops executed from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD30, HSM31)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "OFFCORE_REQUESTS_OUTSTANDING.DEMAND_DATA_RD_GE_6",
+      EventDef::Encoding{
+          .code = 0x60, .umask = 0x01, .cmask = 6, .msr_values = {0x00}},
+      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
+      R"(Cycles with at least 6 offcore outstanding Demand Data Read transactions in uncore queue.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      R"(HSD78, HSD62, HSD61, HSM63, HSM80)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L1D_PEND_MISS.PENDING_CYCLES_ANY",
+      EventDef::Encoding{
+          .code = 0x48,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 1,
+          .msr_values = {0x00}},
+      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
+      R"(Cycles with L1D load Misses outstanding from any thread on physical core.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "L1D_PEND_MISS.FB_FULL",
+      EventDef::Encoding{
+          .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
+      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "AVX_INSTS.ALL",
+      EventDef::Encoding{
+          .code = 0xC6, .umask = 0x07, .cmask = 0, .msr_values = {0}},
+      R"(Approximate counts of AVX & AVX2 256-bit instructions, including non-arithmetic instructions, loads, and stores.  May count non-AVX instructions that employ 256-bit operations, including (but not necessarily limited to) rep string instructions that use 256-bit loads and stores for optimized performance, XSAVE* and XRSTOR*, and operations that transition the x87 FPU data registers between x87 and MMX.)",
+      R"(Note that a whole rep string only counts AVX_INST.ALL once.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "ICACHE.IFDATA_STALL",
+      EventDef::Encoding{
+          .code = 0x80, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
+      R"(Cycles where a code fetch is stalled due to L1 instruction-cache miss.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.REF_XCLK",
+      EventDef::Encoding{
+          .code = 0x3C, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
+      R"(Reference cycles when the thread is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the thread is unhalted. (counts at 100 MHz rate))",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.REF_XCLK_ANY",
+      EventDef::Encoding{
+          .code = 0x3C,
+          .umask = 0x01,
+          .any = true,
+          .cmask = 0,
+          .msr_values = {0x00}},
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate))",
+      R"(Reference cycles when the at least one thread on the physical core is unhalted (counts at 100 MHz rate).)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE",
+      EventDef::Encoding{
+          .code = 0x3C, .umask = 0x02, .cmask = 0, .msr_values = {0x00}},
+      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
+      R"(Count XClk pulses when this thread is unhalted and the other thread is halted.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0001}},
-      R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0001}},
+      R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts demand data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4201,7 +4456,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0001}},
-      R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts demand data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4217,7 +4472,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00001}},
-      R"(Counts demand data reads miss in the L3 )",
+      R"(Counts demand data reads miss in the L3)",
       R"(Counts demand data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4229,11 +4484,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400001}},
-      R"(Counts demand data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400001}},
+      R"(Counts demand data reads miss the L3 and the data is returned from local dram)",
       R"(Counts demand data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4245,11 +4497,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0002}},
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4265,7 +4514,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0002}},
-      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand data writes (RFOs) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4281,7 +4530,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00002}},
-      R"(Counts all demand data writes (RFOs) miss in the L3 )",
+      R"(Counts all demand data writes (RFOs) miss in the L3)",
       R"(Counts all demand data writes (RFOs) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4293,11 +4542,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400002}},
+      R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4313,7 +4559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00002}},
-      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand data writes (RFOs) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4325,11 +4571,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0004}},
-      R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0004}},
+      R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4345,7 +4588,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0004}},
-      R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand code reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4361,7 +4604,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00004}},
-      R"(Counts all demand code reads miss in the L3 )",
+      R"(Counts all demand code reads miss in the L3)",
       R"(Counts all demand code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4373,11 +4616,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400004}},
-      R"(Counts all demand code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400004}},
+      R"(Counts all demand code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4393,7 +4633,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0010}},
-      R"(Counts prefetch (that bring data to L2) data reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to L2) data reads hit in the L3)",
       R"(Counts prefetch (that bring data to L2) data reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4409,7 +4649,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00010}},
-      R"(Counts prefetch (that bring data to L2) data reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to L2) data reads miss in the L3)",
       R"(Counts prefetch (that bring data to L2) data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4425,7 +4665,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0020}},
-      R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to L2) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4441,7 +4681,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00020}},
-      R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to L2) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4457,7 +4697,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0040}},
-      R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4473,7 +4713,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00040}},
-      R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4489,7 +4729,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0080}},
-      R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) data reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4505,7 +4745,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00080}},
-      R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4521,7 +4761,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4537,7 +4777,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00100}},
-      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3 )",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       R"(Counts all prefetch (that bring data to LLC only) RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4553,7 +4793,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C0200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4569,7 +4809,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00200}},
-      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3 )",
+      R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       R"(Counts prefetch (that bring data to LLC only) code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4581,11 +4821,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0091}},
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4601,7 +4838,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0091}},
-      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch data reads hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4617,7 +4854,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00091}},
-      R"(Counts all demand & prefetch data reads miss in the L3 )",
+      R"(Counts all demand & prefetch data reads miss in the L3)",
       R"(Counts all demand & prefetch data reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4629,11 +4866,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4645,11 +4879,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063F800091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63F800091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       R"(Counts all demand & prefetch data reads miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4665,7 +4896,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4677,11 +4908,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00091}},
-      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00091}},
+      R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all demand & prefetch data reads miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4693,11 +4921,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0122}},
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4713,7 +4938,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C0122}},
-      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all demand & prefetch RFOs hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4729,7 +4954,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00122}},
-      R"(Counts all demand & prefetch RFOs miss in the L3 )",
+      R"(Counts all demand & prefetch RFOs miss in the L3)",
       R"(Counts all demand & prefetch RFOs miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4741,11 +4966,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400122}},
-      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400122}},
+      R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch RFOs miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4757,11 +4979,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0244}},
-      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0244}},
+      R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all demand & prefetch code reads hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4777,7 +4996,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC00244}},
-      R"(Counts all demand & prefetch code reads miss in the L3 )",
+      R"(Counts all demand & prefetch code reads miss in the L3)",
       R"(Counts all demand & prefetch code reads miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4789,11 +5008,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_CODE_RD.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0600400244}},
-      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x600400244}},
+      R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       R"(Counts all demand & prefetch code reads miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4805,11 +5021,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C07F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoops to sibling cores hit in either E/S state and the line is not forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4825,7 +5038,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10003C07F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       R"(Counts all data/code/rfo reads (demand & prefetch) hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4841,7 +5054,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3 )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4853,11 +5066,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.LOCAL_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x06004007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x6004007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from local dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4869,11 +5079,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_DRAM",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063F8007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63F8007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the data is returned from remote dram)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4889,7 +5096,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache )",
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and the modified data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4901,11 +5108,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_READS.LLC_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC007F7}},
-      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC007F7}},
+      R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       R"(Counts all data/code/rfo reads (demand & prefetch) miss the L3 and clean or shared data is transferred from remote cache)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4921,7 +5125,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3F803C8FFF}},
-      R"(Counts all requests hit in the L3 )",
+      R"(Counts all requests hit in the L3)",
       R"(Counts all requests hit in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4937,7 +5141,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FBFC08FFF}},
-      R"(Counts all requests miss in the L3 )",
+      R"(Counts all requests miss in the L3)",
       R"(Counts all requests miss in the L3)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4946,5 +5150,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace haswellx_core_v20
+} // namespace haswellx_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/haswellx_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/haswellx_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace haswellx_uncore_v20 {
+namespace haswellx_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from haswellx_uncore_v20.json (1278 events).
+    Events from haswellx_uncore.json (1278 events).
 
     Supported SKUs:
         - Arch: x86, Model: HSX id: 63
@@ -83,7 +83,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_LLC_LOOKUP.WRITE",
       EventDef::Encoding{.code = 0x34, .umask = 0x5, .msr_values = {0x00}},
       R"(Cache Lookups; Write Requests)",
-      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CBoGlCtrl[22:18] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cachable and UC.)",
+      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CBoGlCtrl[22:18] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cacheable and UC.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -706,8 +706,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.AD",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(AD)",
-      R"(AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
+      R"(UNC_C_RING_SINK_STARVED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -718,8 +718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.AK",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(AK)",
-      R"(AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
+      R"(UNC_C_RING_SINK_STARVED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -730,8 +730,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.IV",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(IV)",
-      R"(IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
+      R"(UNC_C_RING_SINK_STARVED.IV)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -742,8 +742,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cbox,
       "UNC_C_RING_SINK_STARVED.BL",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(BL)",
-      R"(BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
+      R"(UNC_C_RING_SINK_STARVED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1319,7 +1319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x1, .msr_values = {0x00}},
       R"(TOR Inserts; Opcode Match)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match an opcode (matched by Cn_MSR_PMON_BOX_FILTER.opc))",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match an opcode (matched by Cn_MSR_PMON_BOX_FILTER.opc))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1331,7 +1331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.EVICTION",
       EventDef::Encoding{.code = 0x35, .umask = 0x4, .msr_values = {0x00}},
       R"(TOR Inserts; Evictions)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Eviction transactions inserted into the TOR.  Evictions can be quick, such as when the line is in the F, S, or E states and no core valid bits are set.  They can also be longer if either CV bits are set (so the cores need to be snooped) and/or if there is a HitM (in which case it is necessary to write the request out to memory).)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Eviction transactions inserted into the TOR.  Evictions can be quick, such as when the line is in the F, S, or E states and no core valid bits are set.  They can also be longer if either CV bits are set (so the cores need to be snooped) and/or if there is a HitM (in which case it is necessary to write the request out to memory).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1343,7 +1343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x8, .msr_values = {0x00}},
       R"(TOR Inserts; All)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR.    This includes requests that reside in the TOR for a short time, such as LLC Hits that do not need to snoop cores or requests that get rejected and have to be retried through one of the ingress queues.  The TOR is more commonly a bottleneck in skews with smaller core counts, where the ratio of RTIDs to TOR entries is larger.  Note that there are reserved TOR entries for various request types, so it is possible that a given request type be blocked with an occupancy that is less than 20.  Also note that generally requests will not be able to arbitrate into the TOR pipeline if there are no available TOR slots.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR.    This includes requests that reside in the TOR for a short time, such as LLC Hits that do not need to snoop cores or requests that get rejected and have to be retried through one of the ingress queues.  The TOR is more commonly a bottleneck in skews with smaller core counts, where the ratio of RTIDs to TOR entries is larger.  Note that there are reserved TOR entries for various request types, so it is possible that a given request type be blocked with an occupancy that is less than 20.  Also note that generally requests will not be able to arbitrate into the TOR pipeline if there are no available TOR slots.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1355,7 +1355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.WB",
       EventDef::Encoding{.code = 0x35, .umask = 0x10, .msr_values = {0x00}},
       R"(TOR Inserts; Writebacks)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Write transactions inserted into the TOR.   This does not include RFO, but actual operations that contain data being sent from the core.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Write transactions inserted into the TOR.   This does not include RFO, but actual operations that contain data being sent from the core.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1367,7 +1367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x3, .msr_values = {0x00}},
       R"(TOR Inserts; Miss Opcode Match)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1379,7 +1379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x41, .msr_values = {0x00}},
       R"(TOR Inserts; NID and Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match a NID and an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Transactions inserted into the TOR that match a NID and an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1391,7 +1391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_EVICTION",
       EventDef::Encoding{.code = 0x35, .umask = 0x44, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Evictions)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched eviction transactions inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched eviction transactions inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1403,7 +1403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x48, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched (matches an RTID destination) transactions inserted into the TOR.  The NID is programmed in Cn_MSR_PMON_BOX_FILTER.nid.  In conjunction with STATE = I, it is possible to monitor misses to specific NIDs in the system.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched (matches an RTID destination) transactions inserted into the TOR.  The NID is programmed in Cn_MSR_PMON_BOX_FILTER.nid.  In conjunction with STATE = I, it is possible to monitor misses to specific NIDs in the system.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1415,7 +1415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_WB",
       EventDef::Encoding{.code = 0x35, .umask = 0x50, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Writebacks)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched write transactions inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; NID matched write transactions inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1427,7 +1427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_MISS_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x43, .msr_values = {0x00}},
       R"(TOR Inserts; NID and Opcode Matched Miss)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match a NID and an opcode.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that match a NID and an opcode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1439,7 +1439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.NID_MISS_ALL",
       EventDef::Encoding{.code = 0x35, .umask = 0x4A, .msr_values = {0x00}},
       R"(TOR Inserts; NID Matched Miss All)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched miss requests that were inserted into the TOR.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All NID matched miss requests that were inserted into the TOR.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1451,7 +1451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_LOCAL",
       EventDef::Encoding{.code = 0x35, .umask = 0x2A, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Local Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1463,7 +1463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_REMOTE",
       EventDef::Encoding{.code = 0x35, .umask = 0x8A, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Remote Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1475,7 +1475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.LOCAL",
       EventDef::Encoding{.code = 0x35, .umask = 0x28, .msr_values = {0x00}},
       R"(TOR Inserts; Local Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1487,7 +1487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.REMOTE",
       EventDef::Encoding{.code = 0x35, .umask = 0x88, .msr_values = {0x00}},
       R"(TOR Inserts; Remote Memory)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1499,7 +1499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x23, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Local Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisifed by an opcode, inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisfied by an opcode, inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1511,7 +1511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x83, .msr_values = {0x00}},
       R"(TOR Inserts; Misses to Remote Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; Miss transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1523,7 +1523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
       R"(TOR Inserts; Local Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by locally HOMed memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent. There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1535,7 +1535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_INSERTS.REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x35, .umask = 0x81, .msr_values = {0x00}},
       R"(TOR Inserts; Remote Memory - Opcode Matched)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisifed by an opcode,  inserted into the TOR that are satisifed by remote caches or remote memory.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match  qualifications specified by the subevent.  There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc  to DRD (0x182).; All transactions, satisfied by an opcode,  inserted into the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1715,7 +1715,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.MISS_LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x23, .msr_values = {0x00}},
       R"(TOR Occupancy; Misses to Local Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisifed by an opcode, in the TOR that are satisifed by locally HOMed memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisfied by an opcode, in the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1727,7 +1727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.MISS_REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x83, .msr_values = {0x00}},
       R"(TOR Occupancy; Misses to Remote Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisifed by an opcode, in the TOR that are satisifed by remote caches or remote memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding Miss transactions, satisfied by an opcode, in the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1739,7 +1739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.LOCAL_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
       R"(TOR Occupancy; Local Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisifed by an opcode,  in the TOR that are satisifed by locally HOMed memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisfied by an opcode,  in the TOR that are satisfied by locally HOMed memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1751,7 +1751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TOR_OCCUPANCY.REMOTE_OPCODE",
       EventDef::Encoding{.code = 0x36, .umask = 0x81, .msr_values = {0x00}},
       R"(TOR Occupancy; Remote Memory - Opcode Matched)",
-      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisifed by an opcode,  in the TOR that are satisifed by remote caches or remote memory.)",
+      R"(For each cycle, this event accumulates the number of valid entries in the TOR that match qualifications specified by the subevent.   There are a number of subevent 'filters' but only a subset of the subevent combinations are valid.  Subevents that require an opcode or NID match require the Cn_MSR_PMON_BOX_FILTER.{opc, nid} field to be set.  If, for example, one wanted to count DRD Local Misses, one should select MISS_OPC_MATCH and set Cn_MSR_PMON_BOX_FILTER.opc to DRD (0x182); Number of outstanding  transactions, satisfied by an opcode,  in the TOR that are satisfied by remote caches or remote memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1895,7 +1895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_C_TxR_INSERTS.BL_CORE",
       EventDef::Encoding{.code = 0x2, .umask = 0x40, .msr_values = {0x00}},
       R"(Egress Allocations; BL - Corebo)",
-      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Cbo Egress.  The Egress is used to queue up requests destined for the ring.; Ring transactions from the Corebo destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1944,30 +1944,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Injection Starvation; Onto AD Ring (to core))",
       R"(Counts injection starvation.  This starvation is triggered when the Egress cannot send a transaction onto the ring for a long period of time.; cycles that the core AD egress spent in starvation)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_cbox,
-      "UNC_C_RxR_OCCUPANCY.IRQ_REJ",
-      EventDef::Encoding{.code = 0x11, .umask = 0x2, .msr_values = {0x00}},
-      R"(Ingress Occupancy; IRQ Rejected)",
-      R"(Counts number of entries in the specified Ingress queue in each cycle.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_cbox,
-      "UNC_C_LLC_VICTIMS.I_STATE",
-      EventDef::Encoding{.code = 0x37, .umask = 0x4, .msr_values = {0x00}},
-      R"(Lines Victimized; Lines in S State)",
-      R"(Counts the number of lines that were victimized on a fill.  This can be filtered by the state that the line was in.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2183,7 +2159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_DIRECTORY_LAT_OPT",
       EventDef::Encoding{.code = 0x41, .umask = 0x0, .msr_values = {0x00}},
       R"(Directory Lat Opt Return)",
-      R"(Directory Latency Optimization Data Return Path Taken. When directory mode is enabled and the directory retuned for a read is Dir=I, then data can be returned using a faster path if certain conditions are met (credits, free pipeline, etc).)",
+      R"(Directory Latency Optimization Data Return Path Taken. When directory mode is enabled and the directory returned for a read is Dir=I, then data can be returned using a faster path if certain conditions are met (credits, free pipeline, etc).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3683,7 +3659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_SNOOP_RESP.RSPSFWD",
       EventDef::Encoding{.code = 0x21, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses Received; RspSFwd)",
-      R"(Counts the total number of RspI snoop responses received.  Whenever a snoops are issued, one or more snoop responses will be returned depending on the topology of the system.   In systems larger than 2s, when multiple snoops are returned this will count all the snoops that are received.  For example, if 3 snoops were issued and returned RspI, RspS, and RspSFwd; then each of these sub-events would increment by 1.; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currentl copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
+      R"(Counts the total number of RspI snoop responses received.  Whenever a snoops are issued, one or more snoop responses will be returned depending on the topology of the system.   In systems larger than 2s, when multiple snoops are returned this will count all the snoops that are received.  For example, if 3 snoops were issued and returned RspI, RspS, and RspSFwd; then each of these sub-events would increment by 1.; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currently copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3767,7 +3743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_H_SNP_RESP_RECV_LOCAL.RSPSFWD",
       EventDef::Encoding{.code = 0x60, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses Received Local; RspSFwd)",
-      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currentl copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
+      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd.  This is returned when a remote caching agent forwards data but holds on to its currently copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4627,42 +4603,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.LOCAL",
-      EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; Local Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from the local socket.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.REMOTE",
-      EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; Remote Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from remote sockets.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ha,
-      "UNC_H_TRACKER_CYCLES_NE.ALL",
-      EventDef::Encoding{.code = 0x3, .umask = 0x3, .msr_values = {0x00}},
-      R"(Tracker Cycles Not Empty; All Requests)",
-      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; Requests coming from both local and remote sockets.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_irp,
       "UNC_I_CACHE_TOTAL_OCCUPANCY.ANY",
       EventDef::Encoding{.code = 0x12, .umask = 0x1, .msr_values = {0x00}},
@@ -4799,7 +4739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REQ",
       EventDef::Encoding{.code = 0x14, .umask = 0x1, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Requests)",
-      R"(Misc Events - Set 0; Fastpath Requests)",
+      R"(Counts Timeouts - Set 0 : Fastpath Requests)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4811,7 +4751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_REJ",
       EventDef::Encoding{.code = 0x14, .umask = 0x2, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Rejects)",
-      R"(Misc Events - Set 0; Fastpath Rejects)",
+      R"(Counts Timeouts - Set 0 : Fastpath Rejects)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4823,7 +4763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_RD_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x4, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Read Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Read Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4835,7 +4775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_WR_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x8, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Write Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Write Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4847,7 +4787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.2ND_ATOMIC_INSERT",
       EventDef::Encoding{.code = 0x14, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
-      R"(Misc Events - Set 0; Cache Inserts of Atomic Transactions as Secondary)",
+      R"(Counts Timeouts - Set 0 : Cache Inserts of Atomic Transactions as Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4859,7 +4799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.FAST_XFER",
       EventDef::Encoding{.code = 0x14, .umask = 0x20, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
-      R"(Misc Events - Set 0; Fastpath Transfers From Primary to Secondary)",
+      R"(Counts Timeouts - Set 0 : Fastpath Transfers From Primary to Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4871,7 +4811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC0.PF_ACK_HINT",
       EventDef::Encoding{.code = 0x14, .umask = 0x40, .msr_values = {0x00}},
       R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
-      R"(Misc Events - Set 0; Prefetch Ack Hints From Primary to Secondary)",
+      R"(Counts Timeouts - Set 0 : Prefetch Ack Hints From Primary to Secondary)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4931,7 +4871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_MISC1.LOST_FWD",
       EventDef::Encoding{.code = 0x15, .umask = 0x10, .msr_values = {0x00}},
       R"(Misc Events - Set 1)",
-      R"(Misc Events - Set 1)",
+      R"(Misc Events - Set 1 : Lost Forward : Snoop pulled away ownership before a write was committed)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4990,7 +4930,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x4, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5014,7 +4954,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_DRS_OCCUPANCY",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_DRS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_DRS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5026,7 +4966,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_CYCLES_FULL",
       EventDef::Encoding{.code = 0x5, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5050,7 +4990,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCB_OCCUPANCY",
       EventDef::Encoding{.code = 0x8, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCB_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCB_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5062,7 +5002,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_CYCLES_FULL",
       EventDef::Encoding{.code = 0x6, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_CYCLES_FULL)",
       R"(Counts the number of cycles when the BL Ingress is full.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5086,7 +5026,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_irp,
       "UNC_I_RxR_BL_NCS_OCCUPANCY",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_I_RxR_BL_NCS_OCCUPANCY (Description is auto-generated))",
+      R"(UNC_I_RxR_BL_NCS_OCCUPANCY)",
       R"(Accumulates the occupancy of the BL Ingress in each cycles.  This queue is where the IRP receives data from R2PCIe (the ring).  It is used for data returns from read requets as well as outbound MMIO writes.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -5099,7 +5039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.MISS",
       EventDef::Encoding{.code = 0x17, .umask = 0x1, .msr_values = {0x00}},
       R"(Snoop Responses; Miss)",
-      R"(Snoop Responses; Miss)",
+      R"(Snoop Responses : Miss)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5111,7 +5051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_I",
       EventDef::Encoding{.code = 0x17, .umask = 0x2, .msr_values = {0x00}},
       R"(Snoop Responses; Hit I)",
-      R"(Snoop Responses; Hit I)",
+      R"(Snoop Responses : Hit I)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5123,7 +5063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_ES",
       EventDef::Encoding{.code = 0x17, .umask = 0x4, .msr_values = {0x00}},
       R"(Snoop Responses; Hit E or S)",
-      R"(Snoop Responses; Hit E or S)",
+      R"(Snoop Responses : Hit E or S)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5135,7 +5075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.HIT_M",
       EventDef::Encoding{.code = 0x17, .umask = 0x8, .msr_values = {0x00}},
       R"(Snoop Responses; Hit M)",
-      R"(Snoop Responses; Hit M)",
+      R"(Snoop Responses : Hit M)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5147,7 +5087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPCODE",
       EventDef::Encoding{.code = 0x17, .umask = 0x10, .msr_values = {0x00}},
       R"(Snoop Responses; SnpCode)",
-      R"(Snoop Responses; SnpCode)",
+      R"(Snoop Responses : SnpCode)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5159,7 +5099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPDATA",
       EventDef::Encoding{.code = 0x17, .umask = 0x20, .msr_values = {0x00}},
       R"(Snoop Responses; SnpData)",
-      R"(Snoop Responses; SnpData)",
+      R"(Snoop Responses : SnpData)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5171,7 +5111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_SNOOP_RESP.SNPINV",
       EventDef::Encoding{.code = 0x17, .umask = 0x40, .msr_values = {0x00}},
       R"(Snoop Responses; SnpInv)",
-      R"(Snoop Responses; SnpInv)",
+      R"(Snoop Responses : SnpInv)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5316,18 +5256,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0xD, .umask = 0x0, .msr_values = {0x00}},
       R"(Outbound Request Queue Occupancy)",
       R"(Accumultes the number of outstanding outbound requests from the IRP to the switch (towards the devices).  This can be used in conjuection with the allocations event in order to calculate average latency of outbound requests.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_MISC0.PF_TIMEOUT",
-      EventDef::Encoding{.code = 0x14, .umask = 0x80, .msr_values = {0x00}},
-      R"(Misc Events - Set 0; Prefetch TimeOut)",
-      R"(Indicates the fetch for a previous prefetch wasn't accepted by the prefetch.   This happens in the case of a prefetch TimeOut)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5963,7 +5891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C0",
       EventDef::Encoding{.code = 0x80, .umask = 0x40, .msr_values = {0x00}},
       R"(Number of cores in C-State; C0 and C1)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5975,7 +5903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C3",
       EventDef::Encoding{.code = 0x80, .umask = 0x80, .msr_values = {0x00}},
       R"(Number of cores in C-State; C3)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5987,7 +5915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_POWER_STATE_OCCUPANCY.CORES_C6",
       EventDef::Encoding{.code = 0x80, .umask = 0xC0, .msr_values = {0x00}},
       R"(Number of cores in C-State; C6 and C7)",
-      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with thresholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6011,7 +5939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_PROCHOT_INTERNAL_CYCLES",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Internal Prochot)",
-      R"(Counts the number of cycles that we are in Interal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
+      R"(Counts the number of cycles that we are in Internal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6034,7 +5962,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_UFS_TRANSITIONS_NO_CHANGE",
       EventDef::Encoding{.code = 0x79, .umask = 0x00, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_NO_CHANGE (Description is auto-generated))",
+      R"(UNC_P_UFS_TRANSITIONS_NO_CHANGE)",
       R"(Ring GV with same final and initial frequency)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -6047,31 +5975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_VR_HOT_CYCLES",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
       R"(VR Hot)",
-      R"(VR Hot)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_pcu,
-      "UNC_P_PKG_RESIDENCY_C1E_CYCLES",
-      EventDef::Encoding{.code = 0x4E, .umask = 0x0, .msr_values = {0x00}},
-      R"(Package C State Residency - C1E)",
-      R"(Counts the number of cycles when the package was in C1E.  This event can be used in conjunction with edge detect to count C1E entrances (or exits using invert).  Residency events do not include transition times.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_pcu,
-      "UNC_P_UFS_TRANSITIONS_RING_GV",
-      EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_UFS_TRANSITIONS_RING_GV (Description is auto-generated))",
-      R"(Ring GV with same final and initial frequency)",
+      R"(VR Hot : Number of cycles that a CPU SVID VR is hot.  Does not cover DRAM VRs)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6107,7 +6011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.SUCCESS_RBT_HIT",
       EventDef::Encoding{.code = 0x13, .umask = 0x1, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Success)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn was successful.  There were sufficient credits, the RBT valid bit was set and there was an RBT tag match.  The message was marked to spawn direct2core.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn was successful.  There were sufficient credits, the RBT valid bit was set and there was an RBT tag match.  The message was marked to spawn direct2core.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6119,7 +6023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS",
       EventDef::Encoding{.code = 0x13, .umask = 0x2, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress Credits)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits.  Had there been enough credits, the spawn would have worked as the RBT bit was set and the RBT tag matched.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits.  Had there been enough credits, the spawn would have worked as the RBT bit was set and the RBT tag matched.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6131,7 +6035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_RBT_HIT",
       EventDef::Encoding{.code = 0x13, .umask = 0x4, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the route-back table (RBT) specified that the transaction should not trigger a direct2core tranaction.  This is common for IO transactions.  There were enough Egress credits and the RBT tag matched but the valid bit was not set.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the route-back table (RBT) specified that the transaction should not trigger a direct2core transaction.  This is common for IO transactions.  There were enough Egress credits and the RBT tag matched but the valid bit was not set.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6143,7 +6047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_RBT",
       EventDef::Encoding{.code = 0x13, .umask = 0x8, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits AND the RBT bit was not set, but the RBT tag matched.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because there were not enough Egress credits AND the RBT bit was not set, but the RBT tag matched.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6155,7 +6059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x10, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Miss)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match although the valid bit was set and there were enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match although the valid bit was set and there were enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6167,7 +6071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x20, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Miss)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and there weren't enough Egress credits.   The valid bit was set.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and there weren't enough Egress credits.   The valid bit was set.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6179,7 +6083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_RBT_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x40, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - RBT Miss and Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and the valid bit was not set although there were enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match and the valid bit was not set although there were enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6191,7 +6095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_DIRECT2CORE.FAILURE_CREDITS_RBT_MISS",
       EventDef::Encoding{.code = 0x13, .umask = 0x80, .msr_values = {0x00}},
       R"(Direct 2 Core Spawning; Spawn Failure - Egress and RBT Miss, Invalid)",
-      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exlusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match, the valid bit was not set and there weren't enough Egress credits.)",
+      R"(Counts the number of DRS packets that we attempted to do direct2core on.  There are 4 mutually exclusive filters.  Filter [0] can be used to get successful spawns, while [1:3] provide the different failure cases.  Note that this does not count packets that are not candidates for Direct2Core.  The only candidates for Direct2Core are DRS packets destined for Cbos.; The spawn failed because the RBT tag did not match, the valid bit was not set and there weren't enough Egress credits.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6239,7 +6143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_BYPASSED",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Rx Flit Buffer Bypassed)",
-      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts the number of times that an incoming flit was able to bypass the flit buffer and pass directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of flits transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6587,7 +6491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G0.IDLE",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 0; Idle and Null Flits)",
-      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generall not considered part of the QPI bandwidth.)",
+      R"(Counts the number of flits received from the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of flits received over QPI that do not hold protocol payload.  When QPI is not in a power saving state, it continuously transmits flits across the link.  When there are no protocol flits to send, it will send IDLE and NULL flits  across.  These flits sometimes do carry a payload, such as credit returns, but are generally not considered part of the QPI bandwidth.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6599,7 +6503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x2, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 1; SNP Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits received over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are received on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6611,7 +6515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request received over QPI on the home channel.  This basically counts the number of remote memory requests received over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6623,7 +6527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x2, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits received over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6635,7 +6539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x2, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Received - Group 1; HOM Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits received over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6647,7 +6551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6659,7 +6563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x2, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6671,7 +6575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x2, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Received - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits received over the NCB channel which transmits non-coherent data.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6683,7 +6587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AD)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6695,7 +6599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Data Response Rx Flits - AK)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits received over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6707,7 +6611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6719,7 +6623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x3, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent non-data Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6731,7 +6635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x3, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6743,7 +6647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_RxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x3, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Received - Group 2; Non-Coherent standard Rx Flits)",
-      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits received from the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits received over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7307,7 +7211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Data Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of data flits transmitted over QPI.  Each flit contains 64b of data.  This includes both DRS and NCB data flits (coherent and non-coherent).  This can be used to calculate the data bandwidth of the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This does not include the header flits that go in data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7319,7 +7223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G0.NON_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 0; Non-Data protocol Tx Flits)",
-      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  It includes filters for Idle, protocol, and Data Flits.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time (for L0) or 4B instead of 8B for L0p.; Number of non-NULL non-data flits transmitted across QPI.  This basically tracks the protocol overhead on the QPI link.  One can get a good picture of the QPI-link characteristics by evaluating the protocol flits, data flits, and idle/null flits.  This includes the header flits for data packets.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7331,7 +7235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.SNP",
       EventDef::Encoding{.code = 0x0, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; SNP Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of snoop request flits transmitted over QPI.  These requests are contained in the snoop channel.  This does not include snoop responses, which are transmitted on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7343,7 +7247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_REQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of data request transmitted over QPI on the home channel.  This basically counts the number of remote memory requests transmitted over QPI.  In conjunction with the local read count in the Home Agent, one can calculate the number of LLC Misses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7355,7 +7259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM_NONREQ",
       EventDef::Encoding{.code = 0x0, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Non-Request Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of non-request flits transmitted over QPI on the home channel.  These are most commonly snoop responses, and this event can be used as a proxy for that.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7367,7 +7271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.HOM",
       EventDef::Encoding{.code = 0x0, .umask = 0x6, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; HOM Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the number of flits transmitted over QPI on the home channel.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7379,7 +7283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_DATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Data Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of data flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the data flits (not the header).)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7391,7 +7295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS_NONDATA",
       EventDef::Encoding{.code = 0x0, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Header Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of protocol flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.  This does not count data flits transmitted over the NCB channel which transmits non-coherent data.  This includes only the header flits (not the data).  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7403,7 +7307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G1.DRS",
       EventDef::Encoding{.code = 0x0, .umask = 0x18, .msr_values = {0x00}},
       R"(Flits Transferred - Group 1; DRS Flits (both Header and Data))",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for SNP, HOM, and DRS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over QPI on the DRS (Data Response) channel.  DRS flits are used to transmit data with coherency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7415,7 +7319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AD)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets to the local socket which use the AK ring.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7427,7 +7331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NDR_AK",
       EventDef::Encoding{.code = 0x1, .umask = 0x2, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Data Response Tx Flits - AK)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Counts the total number of flits transmitted over the NDR (Non-Data Response) channel.  This channel is used to send a variety of protocol flits including grants and completions.  This is only for NDR packets destined for Route-thru to a remote socket.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7439,7 +7343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_DATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x4, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not te NCB headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass data flits.  These flits are generally used to transmit non-coherent data across QPI.  This does not include a count of the DRS (coherent) data flits.  This only counts the data flits, not the NCB headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7451,7 +7355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB_NONDATA",
       EventDef::Encoding{.code = 0x1, .umask = 0x8, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent non-data Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass non-data flits.  These packets are generally used to transmit non-coherent data across QPI, and the flits counted here are for headers and other non-data flits.  This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7463,7 +7367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCB",
       EventDef::Encoding{.code = 0x1, .umask = 0xC, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent Bypass Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of Non-Coherent Bypass flits.  These packets are generally used to transmit non-coherent data across QPI.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7475,7 +7379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxL_FLITS_G2.NCS",
       EventDef::Encoding{.code = 0x1, .umask = 0x10, .msr_values = {0x00}},
       R"(Flits Transferred - Group 2; Non-Coherent standard Tx Flits)",
-      R"(Counts the number of flits trasmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transfering a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
+      R"(Counts the number of flits transmitted across the QPI Link.  This is one of three groups that allow us to track flits.  It includes filters for NDR, NCB, and NCS message classes.  Each flit is made up of 80 bits of information (in addition to some ECC data).  In full-width (L0) mode, flits are made up of four fits, each of which contains 20 bits of data (along with some additional ECC data).   In half-width (L0p) mode, the fits are only 10 bits, and therefore it takes twice as many fits to transmit a flit.  When one talks about QPI speed (for example, 8.0 GT/s), the transfers here refer to fits.  Therefore, in L0, the system will transfer 1 flit at the rate of 1/4th the QPI speed.  One can calculate the bandwidth of the link by taking: flits*80b/time.  Note that this is not the same as data bandwidth.  For example, when we are transferring a 64B cacheline across QPI, we will break it into 9 flits -- 1 with header information and 8 with 64 bits of actual data and an additional 16 bits of other information.  To calculate data bandwidth, one should therefore do: data flits * 8B / time.; Number of NCS (non-coherent standard) flits transmitted over QPI.    This includes extended headers.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7631,7 +7535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxR_AD_SNP_CREDIT_OCCUPANCY.VN0",
       EventDef::Encoding{.code = 0x23, .umask = 0x1, .msr_values = {0x00}},
       R"(R3QPI Egress Credit Occupancy - AD SNP; for VN0)",
-      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO fro Snoop messages on AD.)",
+      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO for Snoop messages on AD.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7643,7 +7547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_Q_TxR_AD_SNP_CREDIT_OCCUPANCY.VN1",
       EventDef::Encoding{.code = 0x23, .umask = 0x2, .msr_values = {0x00}},
       R"(R3QPI Egress Credit Occupancy - AD SNP; for VN1)",
-      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO fro Snoop messages on AD.)",
+      R"(Occupancy event that tracks the number of link layer credits into the R3 (for transactions across the BGF) available in each cycle.  Flow Control FIFO for Snoop messages on AD.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7882,8 +7786,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7894,8 +7798,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.PRQ_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.PRQ_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7906,8 +7810,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI0",
       EventDef::Encoding{.code = 0x2D, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7918,8 +7822,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_r2pcie,
       "UNC_R2_IIO_CREDIT.ISOCH_QPI1",
       EventDef::Encoding{.code = 0x2D, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
-      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1 (Description is auto-generated))",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
+      R"(UNC_R2_IIO_CREDIT.ISOCH_QPI1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10247,7 +10151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.AD",
       EventDef::Encoding{.code = 0x33, .umask = 0x1, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10259,7 +10163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_R3_VNA_CREDITS_ACQUIRED.BL",
       EventDef::Encoding{.code = 0x33, .umask = 0x4, .msr_values = {0x00}},
       R"(VNA credit Acquisitions; HOM Message Class)",
-      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transfered).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transfered in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
+      R"(Number of QPI VNA Credit acquisitions.  This event can be used in conjunction with the VNA In-Use Accumulator to calculate the average lifetime of a credit holder.  VNA credits are used by all message classes in order to communicate across QPI.  If a packet is unable to acquire credits, it will then attempt to use credts from the VN0 pool.  Note that a single packet may require multiple flit buffers (i.e. when data is being transferred).  Therefore, this event will increment by the number of credits acquired in each cycle.  Filtering based on message class is not provided.  One can count the number of packets transferred in a given message class using an qfclk event.; Filter for the Home (HOM) message class.  HOM is generally used to send requests, request responses, and snoop responses.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10666,8 +10570,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AD_CACHE",
       EventDef::Encoding{.code = 0x6, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AD_CACHE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
+      R"(UNC_S_RING_SINK_STARVED.AD_CACHE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10678,8 +10582,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.AK_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.AK_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.AK_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10690,8 +10594,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.BL_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.BL_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.BL_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10702,8 +10606,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_RING_SINK_STARVED.IV_CORE",
       EventDef::Encoding{.code = 0x6, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
-      R"(UNC_S_RING_SINK_STARVED.IV_CORE (Description is auto-generated))",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
+      R"(UNC_S_RING_SINK_STARVED.IV_CORE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11062,8 +10966,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AD",
       EventDef::Encoding{.code = 0x4, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AD (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AD)",
+      R"(UNC_S_TxR_ADS_USED.AD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11074,8 +10978,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.AK",
       EventDef::Encoding{.code = 0x4, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.AK (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.AK)",
+      R"(UNC_S_TxR_ADS_USED.AK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11086,8 +10990,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_sbox,
       "UNC_S_TxR_ADS_USED.BL",
       EventDef::Encoding{.code = 0x4, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
-      R"(UNC_S_TxR_ADS_USED.BL (Description is auto-generated))",
+      R"(UNC_S_TxR_ADS_USED.BL)",
+      R"(UNC_S_TxR_ADS_USED.BL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11467,18 +11371,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_ubox,
-      "UNC_U_CLOCKTICKS",
-      EventDef::Encoding{.code = 0x00, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_U_CLOCKTICKS (Description is auto-generated))",
-      R"(UNC_U_CLOCKTICKS (Description is auto-generated))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_imc,
       "UNC_M_ACT_COUNT.RD",
       EventDef::Encoding{.code = 0x1, .umask = 0x1, .msr_values = {0x00}},
@@ -11711,7 +11603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_ECC_CORRECTABLE_ERRORS",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(ECC Correctable Errors)",
-      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit erros in lockstep mode.)",
+      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit errors in lockstep mode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11902,8 +11794,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_imc,
       "UNC_M_POWER_PCU_THROTTLING",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12155,7 +12047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 1)",
-      R"(RD_CAS Access to Rank 0; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12167,7 +12059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 2)",
-      R"(RD_CAS Access to Rank 0; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12179,7 +12071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB0, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 4)",
-      R"(RD_CAS Access to Rank 0; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12191,7 +12083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB0, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 8)",
-      R"(RD_CAS Access to Rank 0; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12203,7 +12095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB0, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; All Banks)",
-      R"(RD_CAS Access to Rank 0; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12215,7 +12107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 0)",
-      R"(RD_CAS Access to Rank 0; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12227,7 +12119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 3)",
-      R"(RD_CAS Access to Rank 0; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12239,7 +12131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB0, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 5)",
-      R"(RD_CAS Access to Rank 0; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12251,7 +12143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB0, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 6)",
-      R"(RD_CAS Access to Rank 0; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12263,7 +12155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB0, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 7)",
-      R"(RD_CAS Access to Rank 0; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12275,7 +12167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB0, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 9)",
-      R"(RD_CAS Access to Rank 0; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12287,7 +12179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB0, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 10)",
-      R"(RD_CAS Access to Rank 0; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12299,7 +12191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB0, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 11)",
-      R"(RD_CAS Access to Rank 0; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12311,7 +12203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB0, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 12)",
-      R"(RD_CAS Access to Rank 0; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12323,7 +12215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB0, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 13)",
-      R"(RD_CAS Access to Rank 0; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12335,7 +12227,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB0, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 14)",
-      R"(RD_CAS Access to Rank 0; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12347,7 +12239,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB0, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank 15)",
-      R"(RD_CAS Access to Rank 0; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12359,7 +12251,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB0, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12371,7 +12263,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB0, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12383,7 +12275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB0, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12395,7 +12287,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB0, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12407,7 +12299,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 1)",
-      R"(RD_CAS Access to Rank 1; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12419,7 +12311,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 2)",
-      R"(RD_CAS Access to Rank 1; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12431,7 +12323,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB1, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 4)",
-      R"(RD_CAS Access to Rank 1; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12443,7 +12335,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB1, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 8)",
-      R"(RD_CAS Access to Rank 1; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12455,7 +12347,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB1, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; All Banks)",
-      R"(RD_CAS Access to Rank 1; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12467,7 +12359,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 0)",
-      R"(RD_CAS Access to Rank 1; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12479,7 +12371,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 3)",
-      R"(RD_CAS Access to Rank 1; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12491,7 +12383,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB1, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 5)",
-      R"(RD_CAS Access to Rank 1; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12503,7 +12395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB1, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 6)",
-      R"(RD_CAS Access to Rank 1; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12515,7 +12407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB1, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 7)",
-      R"(RD_CAS Access to Rank 1; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12527,7 +12419,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB1, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 9)",
-      R"(RD_CAS Access to Rank 1; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12539,7 +12431,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB1, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 10)",
-      R"(RD_CAS Access to Rank 1; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12551,7 +12443,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB1, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 11)",
-      R"(RD_CAS Access to Rank 1; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12563,7 +12455,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB1, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 12)",
-      R"(RD_CAS Access to Rank 1; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12575,7 +12467,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB1, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 13)",
-      R"(RD_CAS Access to Rank 1; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12587,7 +12479,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB1, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 14)",
-      R"(RD_CAS Access to Rank 1; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12599,7 +12491,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB1, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank 15)",
-      R"(RD_CAS Access to Rank 1; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12611,7 +12503,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB1, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12623,7 +12515,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB1, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12635,7 +12527,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB1, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12647,7 +12539,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB1, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12659,7 +12551,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK2.BANK0",
       EventDef::Encoding{.code = 0xB2, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 2; Bank 0)",
-      R"(RD_CAS Access to Rank 2; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12671,7 +12563,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 1)",
-      R"(RD_CAS Access to Rank 4; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12683,7 +12575,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 2)",
-      R"(RD_CAS Access to Rank 4; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12695,7 +12587,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xB4, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 4)",
-      R"(RD_CAS Access to Rank 4; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12707,7 +12599,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xB4, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 8)",
-      R"(RD_CAS Access to Rank 4; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12719,7 +12611,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xB4, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; All Banks)",
-      R"(RD_CAS Access to Rank 4; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12731,7 +12623,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 0)",
-      R"(RD_CAS Access to Rank 4; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12743,7 +12635,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 3)",
-      R"(RD_CAS Access to Rank 4; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12755,7 +12647,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xB4, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 5)",
-      R"(RD_CAS Access to Rank 4; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12767,7 +12659,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xB4, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 6)",
-      R"(RD_CAS Access to Rank 4; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12779,7 +12671,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xB4, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 7)",
-      R"(RD_CAS Access to Rank 4; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12791,7 +12683,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xB4, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 9)",
-      R"(RD_CAS Access to Rank 4; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12803,7 +12695,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xB4, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 10)",
-      R"(RD_CAS Access to Rank 4; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12815,7 +12707,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xB4, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 11)",
-      R"(RD_CAS Access to Rank 4; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12827,7 +12719,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xB4, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 12)",
-      R"(RD_CAS Access to Rank 4; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12839,7 +12731,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xB4, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 13)",
-      R"(RD_CAS Access to Rank 4; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12851,7 +12743,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xB4, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 14)",
-      R"(RD_CAS Access to Rank 4; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12863,7 +12755,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xB4, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank 15)",
-      R"(RD_CAS Access to Rank 4; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12875,7 +12767,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xB4, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12887,7 +12779,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xB4, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12899,7 +12791,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xB4, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12911,7 +12803,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xB4, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12923,7 +12815,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 1)",
-      R"(RD_CAS Access to Rank 5; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12935,7 +12827,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 2)",
-      R"(RD_CAS Access to Rank 5; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12947,7 +12839,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xB5, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 4)",
-      R"(RD_CAS Access to Rank 5; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12959,7 +12851,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xB5, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 8)",
-      R"(RD_CAS Access to Rank 5; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12971,7 +12863,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xB5, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; All Banks)",
-      R"(RD_CAS Access to Rank 5; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12983,7 +12875,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 0)",
-      R"(RD_CAS Access to Rank 5; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -12995,7 +12887,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 3)",
-      R"(RD_CAS Access to Rank 5; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13007,7 +12899,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xB5, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 5)",
-      R"(RD_CAS Access to Rank 5; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13019,7 +12911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xB5, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 6)",
-      R"(RD_CAS Access to Rank 5; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13031,7 +12923,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xB5, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 7)",
-      R"(RD_CAS Access to Rank 5; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13043,7 +12935,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xB5, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 9)",
-      R"(RD_CAS Access to Rank 5; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13055,7 +12947,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xB5, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 10)",
-      R"(RD_CAS Access to Rank 5; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13067,7 +12959,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xB5, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 11)",
-      R"(RD_CAS Access to Rank 5; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13079,7 +12971,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xB5, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 12)",
-      R"(RD_CAS Access to Rank 5; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13091,7 +12983,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xB5, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 13)",
-      R"(RD_CAS Access to Rank 5; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13103,7 +12995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xB5, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 14)",
-      R"(RD_CAS Access to Rank 5; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13115,7 +13007,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xB5, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank 15)",
-      R"(RD_CAS Access to Rank 5; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13127,7 +13019,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xB5, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13139,7 +13031,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xB5, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13151,7 +13043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xB5, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13163,7 +13055,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xB5, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13175,7 +13067,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 1)",
-      R"(RD_CAS Access to Rank 6; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13187,7 +13079,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 2)",
-      R"(RD_CAS Access to Rank 6; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13199,7 +13091,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xB6, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 4)",
-      R"(RD_CAS Access to Rank 6; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13211,7 +13103,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xB6, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 8)",
-      R"(RD_CAS Access to Rank 6; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13223,7 +13115,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xB6, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; All Banks)",
-      R"(RD_CAS Access to Rank 6; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13235,7 +13127,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 0)",
-      R"(RD_CAS Access to Rank 6; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13247,7 +13139,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 3)",
-      R"(RD_CAS Access to Rank 6; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13259,7 +13151,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xB6, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 5)",
-      R"(RD_CAS Access to Rank 6; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13271,7 +13163,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xB6, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 6)",
-      R"(RD_CAS Access to Rank 6; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13283,7 +13175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xB6, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 7)",
-      R"(RD_CAS Access to Rank 6; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13295,7 +13187,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xB6, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 9)",
-      R"(RD_CAS Access to Rank 6; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13307,7 +13199,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xB6, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 10)",
-      R"(RD_CAS Access to Rank 6; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13319,7 +13211,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xB6, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 11)",
-      R"(RD_CAS Access to Rank 6; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13331,7 +13223,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xB6, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 12)",
-      R"(RD_CAS Access to Rank 6; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13343,7 +13235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xB6, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 13)",
-      R"(RD_CAS Access to Rank 6; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13355,7 +13247,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xB6, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 14)",
-      R"(RD_CAS Access to Rank 6; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13367,7 +13259,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xB6, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank 15)",
-      R"(RD_CAS Access to Rank 6; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13379,7 +13271,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xB6, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13391,7 +13283,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xB6, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13403,7 +13295,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xB6, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13415,7 +13307,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xB6, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13427,7 +13319,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x1, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 1)",
-      R"(RD_CAS Access to Rank 7; Bank 1)",
+      R"(RD_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13439,7 +13331,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x2, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 2)",
-      R"(RD_CAS Access to Rank 7; Bank 2)",
+      R"(RD_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13451,7 +13343,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xB7, .umask = 0x4, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 4)",
-      R"(RD_CAS Access to Rank 7; Bank 4)",
+      R"(RD_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13463,7 +13355,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xB7, .umask = 0x8, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 8)",
-      R"(RD_CAS Access to Rank 7; Bank 8)",
+      R"(RD_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13475,7 +13367,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xB7, .umask = 0x10, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; All Banks)",
-      R"(RD_CAS Access to Rank 7; All Banks)",
+      R"(RD_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13487,7 +13379,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x0, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 0)",
-      R"(RD_CAS Access to Rank 7; Bank 0)",
+      R"(RD_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13499,7 +13391,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x3, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 3)",
-      R"(RD_CAS Access to Rank 7; Bank 3)",
+      R"(RD_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13511,7 +13403,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xB7, .umask = 0x5, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 5)",
-      R"(RD_CAS Access to Rank 7; Bank 5)",
+      R"(RD_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13523,7 +13415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xB7, .umask = 0x6, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 6)",
-      R"(RD_CAS Access to Rank 7; Bank 6)",
+      R"(RD_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13535,7 +13427,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xB7, .umask = 0x7, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 7)",
-      R"(RD_CAS Access to Rank 7; Bank 7)",
+      R"(RD_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13547,7 +13439,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xB7, .umask = 0x9, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 9)",
-      R"(RD_CAS Access to Rank 7; Bank 9)",
+      R"(RD_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13559,7 +13451,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xB7, .umask = 0xA, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 10)",
-      R"(RD_CAS Access to Rank 7; Bank 10)",
+      R"(RD_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13571,7 +13463,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xB7, .umask = 0xB, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 11)",
-      R"(RD_CAS Access to Rank 7; Bank 11)",
+      R"(RD_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13583,7 +13475,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xB7, .umask = 0xC, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 12)",
-      R"(RD_CAS Access to Rank 7; Bank 12)",
+      R"(RD_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13595,7 +13487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xB7, .umask = 0xD, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 13)",
-      R"(RD_CAS Access to Rank 7; Bank 13)",
+      R"(RD_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13607,7 +13499,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xB7, .umask = 0xE, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 14)",
-      R"(RD_CAS Access to Rank 7; Bank 14)",
+      R"(RD_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13619,7 +13511,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xB7, .umask = 0xF, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank 15)",
-      R"(RD_CAS Access to Rank 7; Bank 15)",
+      R"(RD_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13631,7 +13523,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xB7, .umask = 0x11, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(RD_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13643,7 +13535,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xB7, .umask = 0x12, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(RD_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13655,7 +13547,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xB7, .umask = 0x13, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(RD_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13667,7 +13559,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_RD_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xB7, .umask = 0x14, .msr_values = {0x00}},
       R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(RD_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(RD_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13835,7 +13727,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 1)",
-      R"(WR_CAS Access to Rank 0; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13847,7 +13739,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 2)",
-      R"(WR_CAS Access to Rank 0; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13859,7 +13751,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK4",
       EventDef::Encoding{.code = 0xB8, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 4)",
-      R"(WR_CAS Access to Rank 0; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13871,7 +13763,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK8",
       EventDef::Encoding{.code = 0xB8, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 8)",
-      R"(WR_CAS Access to Rank 0; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13883,7 +13775,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.ALLBANKS",
       EventDef::Encoding{.code = 0xB8, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; All Banks)",
-      R"(WR_CAS Access to Rank 0; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13895,7 +13787,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 0)",
-      R"(WR_CAS Access to Rank 0; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13907,7 +13799,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 3)",
-      R"(WR_CAS Access to Rank 0; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13919,7 +13811,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK5",
       EventDef::Encoding{.code = 0xB8, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 5)",
-      R"(WR_CAS Access to Rank 0; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13931,7 +13823,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK6",
       EventDef::Encoding{.code = 0xB8, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 6)",
-      R"(WR_CAS Access to Rank 0; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13943,7 +13835,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK7",
       EventDef::Encoding{.code = 0xB8, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 7)",
-      R"(WR_CAS Access to Rank 0; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13955,7 +13847,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK9",
       EventDef::Encoding{.code = 0xB8, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 9)",
-      R"(WR_CAS Access to Rank 0; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13967,7 +13859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK10",
       EventDef::Encoding{.code = 0xB8, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 10)",
-      R"(WR_CAS Access to Rank 0; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13979,7 +13871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK11",
       EventDef::Encoding{.code = 0xB8, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 11)",
-      R"(WR_CAS Access to Rank 0; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -13991,7 +13883,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK12",
       EventDef::Encoding{.code = 0xB8, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 12)",
-      R"(WR_CAS Access to Rank 0; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14003,7 +13895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK13",
       EventDef::Encoding{.code = 0xB8, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 13)",
-      R"(WR_CAS Access to Rank 0; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14015,7 +13907,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK14",
       EventDef::Encoding{.code = 0xB8, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 14)",
-      R"(WR_CAS Access to Rank 0; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14027,7 +13919,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANK15",
       EventDef::Encoding{.code = 0xB8, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank 15)",
-      R"(WR_CAS Access to Rank 0; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14039,7 +13931,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG0",
       EventDef::Encoding{.code = 0xB8, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 0; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14051,7 +13943,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG1",
       EventDef::Encoding{.code = 0xB8, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 0; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14063,7 +13955,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG2",
       EventDef::Encoding{.code = 0xB8, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 0; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14075,7 +13967,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK0.BANKG3",
       EventDef::Encoding{.code = 0xB8, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 0; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14087,7 +13979,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 1)",
-      R"(WR_CAS Access to Rank 1; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14099,7 +13991,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 2)",
-      R"(WR_CAS Access to Rank 1; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14111,7 +14003,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK4",
       EventDef::Encoding{.code = 0xB9, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 4)",
-      R"(WR_CAS Access to Rank 1; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14123,7 +14015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK8",
       EventDef::Encoding{.code = 0xB9, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 8)",
-      R"(WR_CAS Access to Rank 1; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14135,7 +14027,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.ALLBANKS",
       EventDef::Encoding{.code = 0xB9, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; All Banks)",
-      R"(WR_CAS Access to Rank 1; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14147,7 +14039,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 0)",
-      R"(WR_CAS Access to Rank 1; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14159,7 +14051,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 3)",
-      R"(WR_CAS Access to Rank 1; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14171,7 +14063,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK5",
       EventDef::Encoding{.code = 0xB9, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 5)",
-      R"(WR_CAS Access to Rank 1; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14183,7 +14075,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK6",
       EventDef::Encoding{.code = 0xB9, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 6)",
-      R"(WR_CAS Access to Rank 1; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14195,7 +14087,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK7",
       EventDef::Encoding{.code = 0xB9, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 7)",
-      R"(WR_CAS Access to Rank 1; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14207,7 +14099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK9",
       EventDef::Encoding{.code = 0xB9, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 9)",
-      R"(WR_CAS Access to Rank 1; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14219,7 +14111,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK10",
       EventDef::Encoding{.code = 0xB9, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 10)",
-      R"(WR_CAS Access to Rank 1; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14231,7 +14123,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK11",
       EventDef::Encoding{.code = 0xB9, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 11)",
-      R"(WR_CAS Access to Rank 1; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14243,7 +14135,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK12",
       EventDef::Encoding{.code = 0xB9, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 12)",
-      R"(WR_CAS Access to Rank 1; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14255,7 +14147,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK13",
       EventDef::Encoding{.code = 0xB9, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 13)",
-      R"(WR_CAS Access to Rank 1; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14267,7 +14159,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK14",
       EventDef::Encoding{.code = 0xB9, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 14)",
-      R"(WR_CAS Access to Rank 1; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14279,7 +14171,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANK15",
       EventDef::Encoding{.code = 0xB9, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank 15)",
-      R"(WR_CAS Access to Rank 1; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14291,7 +14183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG0",
       EventDef::Encoding{.code = 0xB9, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 1; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14303,7 +14195,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG1",
       EventDef::Encoding{.code = 0xB9, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 1; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14315,7 +14207,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG2",
       EventDef::Encoding{.code = 0xB9, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 1; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14327,7 +14219,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK1.BANKG3",
       EventDef::Encoding{.code = 0xB9, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 1; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14339,7 +14231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 1)",
-      R"(WR_CAS Access to Rank 4; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14351,7 +14243,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 2)",
-      R"(WR_CAS Access to Rank 4; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14363,7 +14255,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK4",
       EventDef::Encoding{.code = 0xBC, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 4)",
-      R"(WR_CAS Access to Rank 4; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14375,7 +14267,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK8",
       EventDef::Encoding{.code = 0xBC, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 8)",
-      R"(WR_CAS Access to Rank 4; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14387,7 +14279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.ALLBANKS",
       EventDef::Encoding{.code = 0xBC, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; All Banks)",
-      R"(WR_CAS Access to Rank 4; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14399,7 +14291,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 0)",
-      R"(WR_CAS Access to Rank 4; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14411,7 +14303,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 3)",
-      R"(WR_CAS Access to Rank 4; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14423,7 +14315,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK5",
       EventDef::Encoding{.code = 0xBC, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 5)",
-      R"(WR_CAS Access to Rank 4; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14435,7 +14327,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK6",
       EventDef::Encoding{.code = 0xBC, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 6)",
-      R"(WR_CAS Access to Rank 4; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14447,7 +14339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK7",
       EventDef::Encoding{.code = 0xBC, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 7)",
-      R"(WR_CAS Access to Rank 4; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14459,7 +14351,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK9",
       EventDef::Encoding{.code = 0xBC, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 9)",
-      R"(WR_CAS Access to Rank 4; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14471,7 +14363,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK10",
       EventDef::Encoding{.code = 0xBC, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 10)",
-      R"(WR_CAS Access to Rank 4; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14483,7 +14375,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK11",
       EventDef::Encoding{.code = 0xBC, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 11)",
-      R"(WR_CAS Access to Rank 4; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14495,7 +14387,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK12",
       EventDef::Encoding{.code = 0xBC, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 12)",
-      R"(WR_CAS Access to Rank 4; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14507,7 +14399,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK13",
       EventDef::Encoding{.code = 0xBC, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 13)",
-      R"(WR_CAS Access to Rank 4; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14519,7 +14411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK14",
       EventDef::Encoding{.code = 0xBC, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 14)",
-      R"(WR_CAS Access to Rank 4; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14531,7 +14423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANK15",
       EventDef::Encoding{.code = 0xBC, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank 15)",
-      R"(WR_CAS Access to Rank 4; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14543,7 +14435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG0",
       EventDef::Encoding{.code = 0xBC, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 4; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14555,7 +14447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG1",
       EventDef::Encoding{.code = 0xBC, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 4; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14567,7 +14459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG2",
       EventDef::Encoding{.code = 0xBC, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 4; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14579,7 +14471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK4.BANKG3",
       EventDef::Encoding{.code = 0xBC, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 4; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14591,7 +14483,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 1)",
-      R"(WR_CAS Access to Rank 5; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14603,7 +14495,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 2)",
-      R"(WR_CAS Access to Rank 5; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14615,7 +14507,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK4",
       EventDef::Encoding{.code = 0xBD, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 4)",
-      R"(WR_CAS Access to Rank 5; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14627,7 +14519,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK8",
       EventDef::Encoding{.code = 0xBD, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 8)",
-      R"(WR_CAS Access to Rank 5; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14639,7 +14531,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.ALLBANKS",
       EventDef::Encoding{.code = 0xBD, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; All Banks)",
-      R"(WR_CAS Access to Rank 5; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14651,7 +14543,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 0)",
-      R"(WR_CAS Access to Rank 5; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14663,7 +14555,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 3)",
-      R"(WR_CAS Access to Rank 5; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14675,7 +14567,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK5",
       EventDef::Encoding{.code = 0xBD, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 5)",
-      R"(WR_CAS Access to Rank 5; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14687,7 +14579,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK6",
       EventDef::Encoding{.code = 0xBD, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 6)",
-      R"(WR_CAS Access to Rank 5; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14699,7 +14591,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK7",
       EventDef::Encoding{.code = 0xBD, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 7)",
-      R"(WR_CAS Access to Rank 5; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14711,7 +14603,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK9",
       EventDef::Encoding{.code = 0xBD, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 9)",
-      R"(WR_CAS Access to Rank 5; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14723,7 +14615,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK10",
       EventDef::Encoding{.code = 0xBD, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 10)",
-      R"(WR_CAS Access to Rank 5; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14735,7 +14627,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK11",
       EventDef::Encoding{.code = 0xBD, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 11)",
-      R"(WR_CAS Access to Rank 5; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14747,7 +14639,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK12",
       EventDef::Encoding{.code = 0xBD, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 12)",
-      R"(WR_CAS Access to Rank 5; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14759,7 +14651,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK13",
       EventDef::Encoding{.code = 0xBD, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 13)",
-      R"(WR_CAS Access to Rank 5; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14771,7 +14663,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK14",
       EventDef::Encoding{.code = 0xBD, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 14)",
-      R"(WR_CAS Access to Rank 5; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14783,7 +14675,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANK15",
       EventDef::Encoding{.code = 0xBD, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank 15)",
-      R"(WR_CAS Access to Rank 5; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14795,7 +14687,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG0",
       EventDef::Encoding{.code = 0xBD, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 5; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14807,7 +14699,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG1",
       EventDef::Encoding{.code = 0xBD, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 5; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14819,7 +14711,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG2",
       EventDef::Encoding{.code = 0xBD, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 5; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14831,7 +14723,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK5.BANKG3",
       EventDef::Encoding{.code = 0xBD, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 5; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14843,7 +14735,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 1)",
-      R"(WR_CAS Access to Rank 6; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14855,7 +14747,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 2)",
-      R"(WR_CAS Access to Rank 6; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14867,7 +14759,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK4",
       EventDef::Encoding{.code = 0xBE, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 4)",
-      R"(WR_CAS Access to Rank 6; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14879,7 +14771,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK8",
       EventDef::Encoding{.code = 0xBE, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 8)",
-      R"(WR_CAS Access to Rank 6; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14891,7 +14783,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.ALLBANKS",
       EventDef::Encoding{.code = 0xBE, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; All Banks)",
-      R"(WR_CAS Access to Rank 6; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14903,7 +14795,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 0)",
-      R"(WR_CAS Access to Rank 6; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14915,7 +14807,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 3)",
-      R"(WR_CAS Access to Rank 6; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14927,7 +14819,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK5",
       EventDef::Encoding{.code = 0xBE, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 5)",
-      R"(WR_CAS Access to Rank 6; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14939,7 +14831,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK6",
       EventDef::Encoding{.code = 0xBE, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 6)",
-      R"(WR_CAS Access to Rank 6; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14951,7 +14843,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK7",
       EventDef::Encoding{.code = 0xBE, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 7)",
-      R"(WR_CAS Access to Rank 6; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14963,7 +14855,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK9",
       EventDef::Encoding{.code = 0xBE, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 9)",
-      R"(WR_CAS Access to Rank 6; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14975,7 +14867,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK10",
       EventDef::Encoding{.code = 0xBE, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 10)",
-      R"(WR_CAS Access to Rank 6; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14987,7 +14879,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK11",
       EventDef::Encoding{.code = 0xBE, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 11)",
-      R"(WR_CAS Access to Rank 6; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14999,7 +14891,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK12",
       EventDef::Encoding{.code = 0xBE, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 12)",
-      R"(WR_CAS Access to Rank 6; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15011,7 +14903,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK13",
       EventDef::Encoding{.code = 0xBE, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 13)",
-      R"(WR_CAS Access to Rank 6; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15023,7 +14915,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK14",
       EventDef::Encoding{.code = 0xBE, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 14)",
-      R"(WR_CAS Access to Rank 6; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15035,7 +14927,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANK15",
       EventDef::Encoding{.code = 0xBE, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank 15)",
-      R"(WR_CAS Access to Rank 6; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15047,7 +14939,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG0",
       EventDef::Encoding{.code = 0xBE, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 6; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15059,7 +14951,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG1",
       EventDef::Encoding{.code = 0xBE, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 6; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15071,7 +14963,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG2",
       EventDef::Encoding{.code = 0xBE, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 6; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15083,7 +14975,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK6.BANKG3",
       EventDef::Encoding{.code = 0xBE, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 6; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15095,7 +14987,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x1, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 1)",
-      R"(WR_CAS Access to Rank 7; Bank 1)",
+      R"(WR_CAS Access to Rank 0 : Bank 1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15107,7 +14999,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x2, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 2)",
-      R"(WR_CAS Access to Rank 7; Bank 2)",
+      R"(WR_CAS Access to Rank 0 : Bank 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15119,7 +15011,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK4",
       EventDef::Encoding{.code = 0xBF, .umask = 0x4, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 4)",
-      R"(WR_CAS Access to Rank 7; Bank 4)",
+      R"(WR_CAS Access to Rank 0 : Bank 4)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15131,7 +15023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK8",
       EventDef::Encoding{.code = 0xBF, .umask = 0x8, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 8)",
-      R"(WR_CAS Access to Rank 7; Bank 8)",
+      R"(WR_CAS Access to Rank 0 : Bank 8)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15143,7 +15035,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.ALLBANKS",
       EventDef::Encoding{.code = 0xBF, .umask = 0x10, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; All Banks)",
-      R"(WR_CAS Access to Rank 7; All Banks)",
+      R"(WR_CAS Access to Rank 0 : All Banks)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15155,7 +15047,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x0, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 0)",
-      R"(WR_CAS Access to Rank 7; Bank 0)",
+      R"(WR_CAS Access to Rank 0 : Bank 0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15167,7 +15059,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x3, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 3)",
-      R"(WR_CAS Access to Rank 7; Bank 3)",
+      R"(WR_CAS Access to Rank 0 : Bank 3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15179,7 +15071,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK5",
       EventDef::Encoding{.code = 0xBF, .umask = 0x5, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 5)",
-      R"(WR_CAS Access to Rank 7; Bank 5)",
+      R"(WR_CAS Access to Rank 0 : Bank 5)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15191,7 +15083,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK6",
       EventDef::Encoding{.code = 0xBF, .umask = 0x6, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 6)",
-      R"(WR_CAS Access to Rank 7; Bank 6)",
+      R"(WR_CAS Access to Rank 0 : Bank 6)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15203,7 +15095,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK7",
       EventDef::Encoding{.code = 0xBF, .umask = 0x7, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 7)",
-      R"(WR_CAS Access to Rank 7; Bank 7)",
+      R"(WR_CAS Access to Rank 0 : Bank 7)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15215,7 +15107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK9",
       EventDef::Encoding{.code = 0xBF, .umask = 0x9, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 9)",
-      R"(WR_CAS Access to Rank 7; Bank 9)",
+      R"(WR_CAS Access to Rank 0 : Bank 9)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15227,7 +15119,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK10",
       EventDef::Encoding{.code = 0xBF, .umask = 0xA, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 10)",
-      R"(WR_CAS Access to Rank 7; Bank 10)",
+      R"(WR_CAS Access to Rank 0 : Bank 10)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15239,7 +15131,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK11",
       EventDef::Encoding{.code = 0xBF, .umask = 0xB, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 11)",
-      R"(WR_CAS Access to Rank 7; Bank 11)",
+      R"(WR_CAS Access to Rank 0 : Bank 11)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15251,7 +15143,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK12",
       EventDef::Encoding{.code = 0xBF, .umask = 0xC, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 12)",
-      R"(WR_CAS Access to Rank 7; Bank 12)",
+      R"(WR_CAS Access to Rank 0 : Bank 12)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15263,7 +15155,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK13",
       EventDef::Encoding{.code = 0xBF, .umask = 0xD, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 13)",
-      R"(WR_CAS Access to Rank 7; Bank 13)",
+      R"(WR_CAS Access to Rank 0 : Bank 13)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15275,7 +15167,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK14",
       EventDef::Encoding{.code = 0xBF, .umask = 0xE, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 14)",
-      R"(WR_CAS Access to Rank 7; Bank 14)",
+      R"(WR_CAS Access to Rank 0 : Bank 14)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15287,7 +15179,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANK15",
       EventDef::Encoding{.code = 0xBF, .umask = 0xF, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank 15)",
-      R"(WR_CAS Access to Rank 7; Bank 15)",
+      R"(WR_CAS Access to Rank 0 : Bank 15)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15299,7 +15191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG0",
       EventDef::Encoding{.code = 0xBF, .umask = 0x11, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
-      R"(WR_CAS Access to Rank 7; Bank Group 0 (Banks 0-3))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 0 (Banks 0-3))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15311,7 +15203,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG1",
       EventDef::Encoding{.code = 0xBF, .umask = 0x12, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
-      R"(WR_CAS Access to Rank 7; Bank Group 1 (Banks 4-7))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 1 (Banks 4-7))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15323,7 +15215,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG2",
       EventDef::Encoding{.code = 0xBF, .umask = 0x13, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
-      R"(WR_CAS Access to Rank 7; Bank Group 2 (Banks 8-11))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 2 (Banks 8-11))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15335,7 +15227,79 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_WR_CAS_RANK7.BANKG3",
       EventDef::Encoding{.code = 0xBF, .umask = 0x14, .msr_values = {0x00}},
       R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
-      R"(WR_CAS Access to Rank 7; Bank Group 3 (Banks 12-15))",
+      R"(WR_CAS Access to Rank 0 : Bank Group 3 (Banks 12-15))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ubox,
+      "UNC_U_CLOCKTICKS",
+      EventDef::Encoding{.code = 0x00, .umask = 0x0, .msr_values = {0x00}},
+      R"(UNC_U_CLOCKTICKS)",
+      R"(UNC_U_CLOCKTICKS)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_cbox,
+      "UNC_C_RxR_OCCUPANCY.IRQ_REJ",
+      EventDef::Encoding{.code = 0x11, .umask = 0x2, .msr_values = {0x00}},
+      R"(Ingress Occupancy; IRQ Rejected)",
+      R"(Counts number of entries in the specified Ingress queue in each cycle.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.LOCAL",
+      EventDef::Encoding{.code = 0x3, .umask = 0x1, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; Local Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from the local socket.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.REMOTE",
+      EventDef::Encoding{.code = 0x3, .umask = 0x2, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; Remote Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; This filter includes only requests coming from remote sockets.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_ha,
+      "UNC_H_TRACKER_CYCLES_NE.ALL",
+      EventDef::Encoding{.code = 0x3, .umask = 0x3, .msr_values = {0x00}},
+      R"(Tracker Cycles Not Empty; All Requests)",
+      R"(Counts the number of cycles when the local HA tracker pool is not empty.  This can be used with edge detect to identify the number of situations when the pool became empty.  This should not be confused with RTID credit usage -- which must be tracked inside each cbo individually -- but represents the actual tracker buffer structure.  In other words, this buffer could be completely empty, but there may still be credits in use by the CBos.  This stat can be used in conjunction with the occupancy accumulation stat in order to calculate average queue occpancy.  HA trackers are allocated as soon as a request enters the HA if an HT (Home Tracker) entry is available and is released after the snoop response and data return (or post in the case of a write) and the response is returned on the ring.; Requests coming from both local and remote sockets.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_MISC0.PF_TIMEOUT",
+      EventDef::Encoding{.code = 0x14, .umask = 0x80, .msr_values = {0x00}},
+      R"(Misc Events - Set 0; Prefetch TimeOut)",
+      R"(Indicates the fetch for a previous prefetch wasn't accepted by the prefetch.   This happens in the case of a prefetch TimeOut)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15353,7 +15317,43 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_cbox,
+      "UNC_C_LLC_VICTIMS.I_STATE",
+      EventDef::Encoding{.code = 0x37, .umask = 0x4, .msr_values = {0x00}},
+      R"(Lines Victimized; Lines in S State)",
+      R"(Counts the number of lines that were victimized on a fill.  This can be filtered by the state that the line was in.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_PKG_RESIDENCY_C1E_CYCLES",
+      EventDef::Encoding{.code = 0x4E, .umask = 0x0, .msr_values = {0x00}},
+      R"(Package C State Residency - C1E)",
+      R"(Counts the number of cycles when the package was in C1E.  This event can be used in conjunction with edge detect to count C1E entrances (or exits using invert).  Residency events do not include transition times.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_UFS_TRANSITIONS_RING_GV",
+      EventDef::Encoding{.code = 0x79, .umask = 0x0, .msr_values = {0x00}},
+      R"(UNC_P_UFS_TRANSITIONS_RING_GV)",
+      R"(Ring GV with same final and initial frequency)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 }
 
-} // namespace haswellx_uncore_v20
+} // namespace haswellx_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/ivybridge_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/ivybridge_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace ivybridge_core_v21 {
+namespace ivybridge_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from ivybridge_core_v21.json (317 events).
+    Events from ivybridge_core.json (317 events).
 
     Supported SKUs:
         - Arch: x86, Model: IVB id: 58
@@ -199,8 +199,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc.))",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3994,5 +3994,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace ivybridge_core_v21
+} // namespace ivybridge_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/ivybridge_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/ivybridge_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace ivybridge_uncore_v21 {
+namespace ivybridge_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from ivybridge_uncore_v21.json (34 events).
+    Events from ivybridge_uncore.json (34 events).
 
     Supported SKUs:
         - Arch: x86, Model: IVB id: 58
@@ -427,5 +427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace ivybridge_uncore_v21
+} // namespace ivybridge_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/nehalemex_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace nehalemex_core_v2 {
+namespace nehalemex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from NehalemEX_core_V2.json (553 events).
+    Events from NehalemEX_core.json (553 events).
 
     Supported SKUs:
         - Arch: x86, Model: NHM-EX id: 46
@@ -5085,8 +5085,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.IO_CSR_MMIO",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x8033}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the IO, CSR, MMIO unit)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5098,8 +5098,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_NO_OTHER_CORE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x133}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and not found in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5111,8 +5111,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x233}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC and HIT in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5124,8 +5124,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LLC_HIT_OTHER_CORE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x433}},
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
-      R"(Offcore data reads, RFO's and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the LLC  and HITM in a sibling core)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5163,8 +5163,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.LOCAL_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x4033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the local DRAM.)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5202,8 +5202,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1033}},
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
-      R"(Offcore data reads, RFO's and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
+      R"(Offcore data reads, RFOs, and prefetches that HIT in a remote cache )",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5215,8 +5215,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_CACHE_HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x833}},
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
-      R"(Offcore data reads, RFO's and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
+      R"(Offcore data reads, RFOs, and prefetches that HITM in a remote cache)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5228,8 +5228,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE_0.DATA_IN.REMOTE_DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x2033}},
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
-      R"(Offcore data reads, RFO's and prefetches statisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
+      R"(Offcore data reads, RFOs, and prefetches satisfied by the remote DRAM)",
       100000,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -7304,5 +7304,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace nehalemex_core_v2
+} // namespace nehalemex_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_core_v16 {
+namespace sandybridge_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_core_v16.json (406 events).
+    Events from sandybridge_core.json (406 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -88,7 +88,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x03, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Cases when loads get true Block-on-Store blocking code preventing store forwarding.)",
-      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceeding smaller uncompleted store.  See the table of not supported store forwards in the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
+      R"(This event counts loads that followed a store to the same address, where the data could not be forwarded inside the pipeline from the store to the load.  The most common reason why store forwarding would be blocked is when a load's address range overlaps with a preceding smaller uncompleted store.  See the table of not supported store forwards in the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.  The penalty for blocked store forwarding is that the load must wait for the store to complete before it can be issued.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -235,8 +235,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
-      R"(Number of occurences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
+      R"(Number of occurrences waiting for the checkpoints in Resource Allocation Table (RAT) to be recovered after Nuke due to all other cases except JEClear (e.g. whenever a ucode assist is needed like SSE exception, memory disambiguation, etc...).)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -320,8 +320,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "FP_COMP_OPS_EXE.X87",
       EventDef::Encoding{
           .code = 0x10, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
-      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULsand IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
+      R"(Number of FP Computational Uops Executed this cycle. The number of FADD, FSUB, FCOM, FMULs, integer MULs and IMULs, FDIVs, FPREMs, FSQRTS, integer DIVs, and IDIVs. This event does not distinguish an FADD used in the middle of a transcendental flow from a s.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -816,8 +816,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.PENDING",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(L1D miss oustandings duration in cycles.)",
-      R"(L1D miss oustandings duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
+      R"(L1D miss outstanding duration in cycles.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -856,8 +856,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "L1D_PEND_MISS.FB_FULL",
       EventDef::Encoding{
           .code = 0x48, .umask = 0x02, .cmask = 1, .msr_values = {0x00}},
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
-      R"(Cycles a demand request was blocked due to Fill Buffers inavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
+      R"(Cycles a demand request was blocked due to Fill Buffers unavailability.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1025,7 +1025,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x20, .cmask = 1, .msr_values = {0}},
       R"(Performance sensitive flags-merging uops added by Sandy Bridge u-arch.)",
-      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual.)",
+      R"(This event counts the number of cycles spent executing performance-sensitive flags-merging uops. For example, shift CL (merge_arith_flags). For more details, See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1037,7 +1037,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x59, .umask = 0x40, .cmask = 0, .msr_values = {0}},
       R"(Cycles with at least one slow LEA uop being allocated.)",
-      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
+      R"(This event counts the number of cycles with at least one slow LEA uop being allocated. A uop is generally considered as slow LEA if it has three sources (for example, two sources and immediate) regardless of whether it is a result of LEA instruction or not. Examples of the slow LEA uop are or uops with base, index, and offset source operands using base and index reqisters, where base is EBR/RBP/R13, using RIP relative or 16-bit addressing modes. See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more details about slow LEA instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1345,8 +1345,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by Decode Stream Buffer (DSB) that are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1357,8 +1357,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_DSB_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x10, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Cycles when uops initiated by Decode Stream Buffer (DSB) are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1373,8 +1373,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .edge = true,
           .cmask = 1,
           .msr_values = {0}},
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
-      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequenser (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
+      R"(Deliveries to Instruction Decode Queue (IDQ) initiated by Decode Stream Buffer (DSB) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1409,8 +1409,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_MITE_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops initiated by MITE and delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1445,8 +1445,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_UOPS",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 0, .msr_values = {0}},
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(Uops delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1457,8 +1457,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "IDQ.MS_CYCLES",
       EventDef::Encoding{
           .code = 0x79, .umask = 0x30, .cmask = 1, .msr_values = {0}},
-      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequenser (MS) is busy.)",
-      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel\xae 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
+      R"(Cycles when uops are being delivered to Instruction Decode Queue (IDQ) while Microcode Sequencer (MS) is busy.)",
+      R"(This event counts cycles during which the microcode sequencer assisted the front-end in delivering uops.  Microcode assists are used for complex instructions or scenarios that can't be handled by the standard decoder.  Using other instructions, if possible, will usually improve performance.  See the Intel(R) 64 and IA-32 Architectures Optimization Reference Manual for more information.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2405,8 +2405,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_REQUESTS.DEMAND_CODE_RD",
       EventDef::Encoding{
           .code = 0xB0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Cacheable and noncachaeble code read requests.)",
-      R"(Cacheable and noncachaeble code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
+      R"(Cacheable and noncacheable code read requests.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3194,7 +3194,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x41, .cmask = 0, .msr_values = {0}},
       R"(Retired load uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split load uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -3206,7 +3206,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x42, .cmask = 0, .msr_values = {0}},
       R"(Retired store uops that split across a cacheline boundary. (Precise Event - PEBS).)",
-      R"(This event counts line-splitted store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
+      R"(This event counts line-split store uops retired to the architected path. A line split is across 64B cache-line which includes a page split (4K). (Precise Event - PEBS))",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
@@ -4136,8 +4136,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.COREWB.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10008}},
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
-      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE (Description is auto-generated))",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
+      R"(OFFCORE_RESPONSE.COREWB.ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5064,7 +5064,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.ANY_REQUEST.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80408fff}},
-      R"( REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = ANY_REQUEST and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       R"(This event counts any requests that miss the LLC where the data was returned from local DRAM)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5077,8 +5077,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10433}},
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = DATA_INTO_CORE and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5090,8 +5090,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DATA_IN_SOCKET.LLC_MISS_LOCAL.ANY_LLC_HIT",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x17004001b3}},
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
-      R"( REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
+      R"(REQUEST = DATA_IN_SOCKET and RESPONSE = LLC_MISS_LOCAL and SNOOP = ANY_LLC_HIT)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5103,8 +5103,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400004}},
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = DEMAND_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5116,8 +5116,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.DEMAND_RFO.LLC_HIT_M.HITM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1000040002}},
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
-      R"( REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
+      R"(REQUEST = DEMAND_RFO and RESPONSE = LLC_HIT_M and SNOOP = HITM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5129,8 +5129,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400010}},
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5142,8 +5142,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10040}},
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_RFO and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5155,8 +5155,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400040}},
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_RFO and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5168,8 +5168,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5181,8 +5181,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_DATA_RD.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400080}},
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_DATA_RD and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5194,8 +5194,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.ANY_RESPONSE",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x10200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = ANY_RESPONSE)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5207,8 +5207,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "OFFCORE_RESPONSE.PF_L_IFETCH.LLC_MISS_LOCAL.DRAM",
       EventDef::Encoding{
           .code = 0xB7, .umask = 0x1, .cmask = 0, .msr_values = {0x1f80400200}},
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
-      R"( REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
+      R"(REQUEST = PF_LLC_IFETCH and RESPONSE = LLC_MISS_LOCAL and SNOOP = DRAM)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5216,5 +5216,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_core_v16
+} // namespace sandybridge_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sandybridge_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace sandybridge_uncore_v16 {
+namespace sandybridge_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from sandybridge_uncore_v16.json (34 events).
+    Events from sandybridge_uncore.json (34 events).
 
     Supported SKUs:
         - Arch: x86, Model: SNB id: 42
@@ -427,5 +427,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace sandybridge_uncore_v16
+} // namespace sandybridge_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
@@ -9,17 +9,19 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace skylake_core_v48 {
+namespace skylake_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from skylake_core_v48.json (546 events).
+    Events from skylake_core.json (551 events).
 
     Supported SKUs:
         - Arch: x86, Model: SKL id: 78
         - Arch: x86, Model: SKL id: 94
         - Arch: x86, Model: SKL id: 142
         - Arch: x86, Model: SKL id: 158
+        - Arch: x86, Model: SKL id: 165
+        - Arch: x86, Model: SKL id: 166
   */
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -31,7 +33,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -43,7 +46,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -59,7 +63,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -71,7 +76,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -83,7 +89,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -95,7 +102,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -107,7 +115,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -119,7 +128,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -127,11 +137,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 4K page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (4K sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -139,11 +150,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 2M/4M page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 2M/4M pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (2M/4M sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -151,23 +163,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 1G page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (1G sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "DTLB_LOAD_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x08, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Load miss in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts demand data loads that caused a completed page walk of any page size (4K/2M/4M/1G). This implies it missed in all TLB levels. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks  (all page sizes) caused by demand data loads. This implies it missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -179,7 +193,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -191,7 +206,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -203,7 +219,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -215,7 +232,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -227,7 +245,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -243,7 +262,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -255,7 +275,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -267,7 +288,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -283,7 +305,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -295,7 +318,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -307,7 +331,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -319,7 +344,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -331,7 +357,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -343,7 +370,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -355,7 +383,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -367,7 +396,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -379,7 +409,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -391,7 +422,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -403,7 +435,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -415,7 +448,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -427,7 +461,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -439,7 +474,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -451,7 +487,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -463,7 +500,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -475,7 +513,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -487,7 +526,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -499,7 +539,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -511,7 +552,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -547,7 +589,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -559,7 +602,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -571,7 +615,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -583,7 +628,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -595,7 +641,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -611,7 +658,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -627,7 +675,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -639,7 +688,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -655,7 +705,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -667,7 +718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -683,7 +735,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -695,7 +748,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -707,7 +761,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -719,7 +774,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -731,7 +787,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -747,7 +804,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -759,7 +817,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -771,7 +830,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -779,11 +839,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 4K page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (4K sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -791,11 +852,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 2M/4M page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 2M/4M pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (2M/4M sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -803,23 +865,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 1G page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 1G pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (1G sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "DTLB_STORE_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x49, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Store misses in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts demand data stores that caused a completed page walk of any page size (4K/2M/4M/1G). This implies it missed in all TLB levels. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks  (all page sizes) caused by demand data stores. This implies it missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -831,7 +895,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -843,7 +908,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -855,7 +921,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -867,19 +934,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "EPT.WALK_PENDING",
       EventDef::Encoding{
-          .code = 0x4F, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+          .code = 0x4f, .umask = 0x10, .cmask = 0, .msr_values = {0}},
       R"(Counts 1 per cycle for each PMH that is busy with a EPT (Extended Page Table) walk for any request type.)",
       R"(Counts cycles for each PMH (Page Miss Handler) that is busy with an EPT (Extended Page Table) walk for any request type.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -891,7 +960,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -903,7 +973,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -915,7 +986,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -927,7 +999,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -939,7 +1012,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -951,7 +1025,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -963,7 +1038,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -975,7 +1051,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "INST_DECODED.DECODERS",
+      EventDef::Encoding{
+          .code = 0x55, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Instruction decoders utilized in a cycle)",
+      R"(Number of decoders utilized in a cycle when the MITE (legacy decode pipeline) fetches instructions.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -987,7 +1077,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -999,7 +1090,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1011,7 +1103,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1023,7 +1116,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1035,7 +1129,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1047,7 +1142,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1059,7 +1155,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1076,7 +1173,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1088,7 +1186,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1100,7 +1199,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1112,7 +1212,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1124,7 +1225,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1136,7 +1238,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1148,7 +1251,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1160,7 +1264,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1172,7 +1277,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1184,7 +1290,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1196,7 +1303,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1208,7 +1316,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1220,7 +1329,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1232,7 +1342,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1244,7 +1355,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1256,7 +1368,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1268,7 +1381,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1280,7 +1394,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1292,7 +1407,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1304,7 +1420,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1316,7 +1433,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1328,7 +1446,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1340,7 +1459,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1352,7 +1472,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1368,7 +1489,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1380,7 +1502,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1392,7 +1515,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1404,7 +1528,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1416,7 +1541,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1428,7 +1554,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1440,7 +1567,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1448,11 +1576,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (4K))",
-      R"(Counts completed page walks (4K page size) caused by a code fetch. This implies it missed in the ITLB and further levels of TLB. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (4K page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1460,11 +1589,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (2M/4M))",
-      R"(Counts code misses in all ITLB levels that caused a completed page walk (2M and 4M page sizes). The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (2M/4M page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1472,23 +1602,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (1G))",
-      R"(Counts store misses in all DTLB levels that cause a completed page walk (1G page size). The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (1G page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "ITLB_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x85, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts completed page walks (2M and 4M page sizes) caused by a code fetch. This implies it missed in the ITLB and further levels of TLB. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (all page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1500,7 +1632,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1512,7 +1645,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1524,7 +1658,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1536,7 +1671,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1548,7 +1684,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1560,7 +1697,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1572,7 +1710,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1584,7 +1723,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1596,7 +1736,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1612,7 +1753,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1624,7 +1766,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1636,7 +1779,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1648,7 +1792,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1660,7 +1805,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1672,7 +1818,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1684,7 +1831,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1696,7 +1844,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1708,7 +1857,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1720,7 +1870,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1732,7 +1883,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1744,7 +1896,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1756,7 +1909,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1768,7 +1922,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1780,7 +1935,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1792,7 +1948,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1804,7 +1961,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1816,7 +1974,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1828,7 +1987,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1840,7 +2000,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1852,7 +2013,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1864,7 +2026,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1876,7 +2039,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1888,7 +2052,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1900,7 +2065,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1912,7 +2078,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1924,7 +2091,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1936,7 +2104,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1948,7 +2117,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1961,7 +2131,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1973,7 +2144,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1985,7 +2157,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1997,7 +2170,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2009,7 +2183,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2021,7 +2196,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2033,7 +2209,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2045,7 +2222,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2057,7 +2235,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2069,7 +2248,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2085,7 +2265,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2097,7 +2278,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2109,7 +2291,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2121,7 +2304,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2133,7 +2317,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2145,7 +2330,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2157,7 +2343,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2169,7 +2356,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2181,7 +2369,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2193,7 +2382,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2209,7 +2399,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2221,7 +2412,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2233,7 +2425,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2258,7 +2451,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2270,7 +2464,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2314,6 +2509,18 @@ Note: Invoking MITE requires two or three cycles delay.)",
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "INST_RETIRED.NOP",
+      EventDef::Encoding{
+          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of all retired NOP instructions.)",
+      R"(Number of all retired NOP instructions.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      R"(SKL091, SKL044)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "OTHER_ASSISTS.ANY",
       EventDef::Encoding{
           .code = 0xC1, .umask = 0x3F, .cmask = 0, .msr_values = {0x00}},
@@ -2322,7 +2529,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2334,7 +2542,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2350,7 +2559,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2359,14 +2569,28 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .code = 0xC2,
           .umask = 0x02,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Number of cycles using always true condition (uops_ret < 16) applied to non PEBS uops retired event.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_RETIRED.MACRO_FUSED",
+      EventDef::Encoding{
+          .code = 0xc2, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Number of macro-fused uops retired. (non precise))",
+      R"(Counts the number of macro-fused uops retired. (non precise))",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2382,7 +2606,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2406,7 +2631,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2526,7 +2752,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2538,7 +2765,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2550,7 +2778,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2562,7 +2791,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2574,19 +2804,21 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FRONTEND_RETIRED.DSB_MISS",
       EventDef::Encoding{
           .code = 0xC6, .umask = 0x01, .cmask = 0, .msr_values = {0x11}},
-      R"(Retired Instructions who experienced decode stream buffer (DSB - the decoded instruction-cache) miss.)",
-      R"(Counts retired Instructions that experienced DSB (Decode stream buffer i.e. the decoded instruction-cache) miss. )",
+      R"(Retired Instructions who experienced a critical DSB miss.)",
+      R"(Number of retired Instructions that experienced a critical DSB (Decode stream buffer i.e. the decoded instruction-cache) miss. Critical means stalls were exposed to the back-end as a result of the DSB miss.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2598,7 +2830,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2610,7 +2843,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2622,7 +2856,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2634,7 +2869,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2646,7 +2882,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2658,7 +2895,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2670,7 +2908,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2682,7 +2921,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2694,7 +2934,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2706,7 +2947,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2718,7 +2960,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2730,7 +2973,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2742,7 +2986,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2754,7 +2999,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2766,7 +3012,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2778,7 +3025,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2790,79 +3038,99 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "FRONTEND_RETIRED.ANY_DSB_MISS",
+      EventDef::Encoding{
+          .code = 0xC6, .umask = 0x01, .cmask = 0, .msr_values = {0x1}},
+      R"(Retired Instructions who experienced DSB miss.)",
+      R"(Counts retired Instructions that experienced DSB (Decode stream buffer i.e. the decoded instruction-cache) miss.)",
+      100007,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD scalar computational double precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD scalar computational double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SIMD scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD scalar computational single precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD scalar computational single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SIMD scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 128-bit packed computational double precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 128-bit packed computational double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 128-bit packed computational single precision floating-point instruction retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 128-bit packed computational single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 256-bit packed double computational precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 256-bit packed double computational precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 256-bit packed single computational precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 256-bit packed single computational precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2874,7 +3142,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2886,7 +3155,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2898,7 +3168,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2910,7 +3181,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2922,7 +3194,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2934,7 +3207,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2946,7 +3220,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2958,7 +3233,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2970,7 +3246,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2982,7 +3259,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2994,7 +3272,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3006,7 +3285,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3018,7 +3298,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3030,7 +3311,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3042,7 +3324,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3054,7 +3337,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3066,7 +3350,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3078,7 +3363,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       203,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3090,7 +3376,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3102,7 +3389,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3114,7 +3402,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3126,7 +3415,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3138,7 +3428,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3150,7 +3441,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3162,7 +3454,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3174,7 +3467,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       1009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3186,7 +3480,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       503,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3198,7 +3493,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       101,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3206,11 +3502,12 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x11, .cmask = 0, .msr_values = {0}},
       R"(Retired load instructions that miss the STLB.)",
-      R"(Retired load instructions that miss the STLB.)",
+      R"(Number of retired load instructions that (start a) miss in the 2nd-level TLB (STLB).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3218,12 +3515,13 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x12, .cmask = 0, .msr_values = {0}},
       R"(Retired store instructions that miss the STLB.)",
-      R"(Retired store instructions that miss the STLB.)",
+      R"(Number of retired store instructions that (start a) miss in the 2nd-level TLB (STLB).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3235,7 +3533,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3247,7 +3546,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3260,7 +3560,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3272,7 +3573,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3285,7 +3587,22 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "MEM_INST_RETIRED.ANY",
+      EventDef::Encoding{
+          .code = 0xD0, .umask = 0x83, .cmask = 0, .msr_values = {0}},
+      R"(All retired memory instructions.)",
+      R"(Counts all retired memory instructions - loads and stores.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{
+          .data_la = true, .l1_hit_indication = true, .pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3297,7 +3614,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3309,7 +3627,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3321,7 +3640,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3333,7 +3653,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3345,7 +3666,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3357,7 +3679,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3369,7 +3692,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3381,7 +3705,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3393,7 +3718,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3405,7 +3731,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3417,7 +3744,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3429,7 +3757,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3441,7 +3770,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3453,7 +3783,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3465,7 +3796,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3477,7 +3809,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3489,7 +3822,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3501,7 +3835,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3513,7 +3848,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3525,7 +3861,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3535,7 +3872,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FFC408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3551,7 +3888,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x203C408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3567,7 +3904,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103C408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3579,11 +3916,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x043C408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x43C408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3595,11 +3929,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x023C408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x23C408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3611,11 +3942,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x013C408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x13C408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3627,11 +3955,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00BC408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0xBC408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3643,11 +3968,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x007C408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x7C408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3663,7 +3985,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC4008000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3679,7 +4001,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2004008000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3695,7 +4017,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1004008000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3707,11 +4029,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS_LOCAL_DRAM.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0404008000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x404008000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3723,11 +4042,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS_LOCAL_DRAM.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0204008000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x204008000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3739,11 +4055,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS_LOCAL_DRAM.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0104008000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x104008000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3755,11 +4068,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS_LOCAL_DRAM.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0084008000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x84008000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3771,11 +4081,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_MISS_LOCAL_DRAM.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0044008000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x44008000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3791,7 +4098,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3807,7 +4114,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3823,7 +4130,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000408000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3835,11 +4142,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L4_HIT_LOCAL_L4.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3851,11 +4155,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L4_HIT_LOCAL_L4.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3867,11 +4168,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L4_HIT_LOCAL_L4.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3883,11 +4181,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L4_HIT_LOCAL_L4.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3899,11 +4194,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L4_HIT_LOCAL_L4.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040408000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40408000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3919,7 +4211,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC01C8000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3935,7 +4227,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x20001C8000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3951,7 +4243,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10001C8000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3963,11 +4255,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04001C8000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4001C8000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3979,11 +4268,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x02001C8000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x2001C8000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -3995,11 +4281,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01001C8000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1001C8000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4011,11 +4294,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00801C8000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x801C8000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4027,11 +4307,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00401C8000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x401C8000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4047,7 +4324,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0108000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4063,7 +4340,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000108000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4079,7 +4356,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000108000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4091,11 +4368,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_S.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400108000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400108000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4107,11 +4381,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_S.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200108000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200108000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4123,11 +4394,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_S.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100108000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100108000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4139,11 +4407,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_S.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080108000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80108000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4155,11 +4420,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_S.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040108000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40108000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4175,7 +4437,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0088000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4191,7 +4453,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000088000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4207,7 +4469,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000088000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4219,11 +4481,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_E.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400088000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400088000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4235,11 +4494,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_E.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200088000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200088000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4251,11 +4507,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_E.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100088000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100088000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4267,11 +4520,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_E.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080088000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80088000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4283,11 +4533,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_E.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040088000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40088000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4303,7 +4550,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0048000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4319,7 +4566,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000048000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4335,7 +4582,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000048000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4347,11 +4594,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_M.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400048000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400048000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4363,11 +4607,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_M.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200048000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200048000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4379,11 +4620,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_M.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100048000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100048000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4395,11 +4633,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_M.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080048000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80048000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4411,11 +4646,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.L3_HIT_M.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040048000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40048000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4431,7 +4663,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0028000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4447,7 +4679,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000028000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4463,7 +4695,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000028000}},
-      R"(Counts any other requests )",
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4475,11 +4707,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.SUPPLIER_NONE.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400028000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400028000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4491,11 +4720,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.SUPPLIER_NONE.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200028000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200028000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4507,11 +4733,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.SUPPLIER_NONE.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100028000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100028000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4523,11 +4746,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.SUPPLIER_NONE.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080028000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80028000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4539,11 +4759,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.SUPPLIER_NONE.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040028000}},
-      R"(Counts any other requests )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40028000}},
+      R"(Counts any other requests)",
       R"(Counts any other requests)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4555,11 +4772,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.OTHER.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000018000}},
-      R"(Counts any other requestshave any response type. )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x18000}},
+      R"(Counts any other requestshave any response type.)",
       R"(Counts any other requestshave any response type.)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4575,7 +4789,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FFC400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4591,7 +4805,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x203C400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4607,7 +4821,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103C400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4619,11 +4833,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x043C400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x43C400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4635,11 +4846,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x023C400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x23C400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4651,11 +4859,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x013C400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x13C400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4667,11 +4872,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00BC400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0xBC400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4683,11 +4885,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x007C400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x7C400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4703,7 +4902,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC4000004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4719,7 +4918,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2004000004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4735,7 +4934,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1004000004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4747,11 +4946,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0404000004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x404000004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4763,11 +4959,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0204000004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x204000004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4779,11 +4972,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0104000004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x104000004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4795,11 +4985,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0084000004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x84000004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4811,11 +4998,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0044000004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x44000004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4831,7 +5015,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4847,7 +5031,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4863,7 +5047,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000400004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4875,11 +5059,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L4_HIT_LOCAL_L4.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4891,11 +5072,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L4_HIT_LOCAL_L4.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4907,11 +5085,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L4_HIT_LOCAL_L4.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4923,11 +5098,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L4_HIT_LOCAL_L4.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4939,11 +5111,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L4_HIT_LOCAL_L4.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040400004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40400004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4959,7 +5128,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC01C0004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4975,7 +5144,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x20001C0004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -4991,7 +5160,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10001C0004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5003,11 +5172,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04001C0004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4001C0004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5019,11 +5185,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x02001C0004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x2001C0004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5035,11 +5198,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01001C0004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1001C0004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5051,11 +5211,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00801C0004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x801C0004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5067,11 +5224,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00401C0004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x401C0004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5087,7 +5241,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0100004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5103,7 +5257,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000100004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5119,7 +5273,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000100004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5131,11 +5285,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_S.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400100004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400100004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5147,11 +5298,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_S.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200100004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200100004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5163,11 +5311,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_S.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100100004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100100004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5179,11 +5324,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_S.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080100004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80100004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5195,11 +5337,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_S.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040100004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40100004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5215,7 +5354,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0080004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5231,7 +5370,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000080004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5247,7 +5386,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000080004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5259,11 +5398,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_E.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400080004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400080004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5275,11 +5411,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_E.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200080004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200080004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5291,11 +5424,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_E.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100080004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100080004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5307,11 +5437,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_E.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080080004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80080004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5323,11 +5450,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_E.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040080004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40080004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5343,7 +5467,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0040004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5359,7 +5483,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000040004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5375,7 +5499,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000040004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5387,11 +5511,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_M.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400040004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400040004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5403,11 +5524,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_M.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200040004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200040004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5419,11 +5537,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_M.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100040004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100040004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5435,11 +5550,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_M.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080040004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80040004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5451,11 +5563,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT_M.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040040004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40040004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5471,7 +5580,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0020004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5487,7 +5596,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000020004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5503,7 +5612,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000020004}},
-      R"(Counts all demand code reads )",
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5515,11 +5624,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.SUPPLIER_NONE.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400020004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400020004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5531,11 +5637,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.SUPPLIER_NONE.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200020004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200020004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5547,11 +5650,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.SUPPLIER_NONE.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100020004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100020004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5563,11 +5663,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.SUPPLIER_NONE.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080020004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80020004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5579,11 +5676,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.SUPPLIER_NONE.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040020004}},
-      R"(Counts all demand code reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40020004}},
+      R"(Counts all demand code reads)",
       R"(Counts all demand code reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5595,11 +5689,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010004}},
-      R"(Counts all demand code readshave any response type. )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10004}},
+      R"(Counts all demand code readshave any response type.)",
       R"(Counts all demand code readshave any response type.)",
       100003,
       std::nullopt, // ScaleUnit
@@ -5615,7 +5706,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FFC400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5631,7 +5722,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x203C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5647,7 +5738,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5659,11 +5750,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x043C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x43C400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5675,11 +5763,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x023C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x23C400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5691,11 +5776,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x013C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x13C400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5707,11 +5789,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00BC400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0xBC400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5723,11 +5802,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x007C400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x7C400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5743,7 +5819,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC4000002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5759,7 +5835,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2004000002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5775,7 +5851,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1004000002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5787,11 +5863,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0404000002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x404000002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5803,11 +5876,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0204000002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x204000002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5819,11 +5889,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0104000002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x104000002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5835,11 +5902,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0084000002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x84000002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5851,11 +5915,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0044000002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x44000002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5871,7 +5932,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5887,7 +5948,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5903,7 +5964,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000400002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5915,11 +5976,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L4_HIT_LOCAL_L4.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5931,11 +5989,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L4_HIT_LOCAL_L4.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5947,11 +6002,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L4_HIT_LOCAL_L4.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5963,11 +6015,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L4_HIT_LOCAL_L4.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5979,11 +6028,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L4_HIT_LOCAL_L4.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040400002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40400002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -5999,7 +6045,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC01C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6015,7 +6061,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x20001C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6031,7 +6077,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10001C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6043,11 +6089,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04001C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4001C0002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6059,11 +6102,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x02001C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x2001C0002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6075,11 +6115,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01001C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1001C0002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6091,11 +6128,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00801C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x801C0002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6107,11 +6141,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00401C0002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x401C0002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6127,7 +6158,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0100002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6143,7 +6174,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000100002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6159,7 +6190,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000100002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6171,11 +6202,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_S.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400100002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400100002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6187,11 +6215,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_S.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200100002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200100002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6203,11 +6228,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_S.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100100002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100100002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6219,11 +6241,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_S.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080100002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80100002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6235,11 +6254,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_S.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040100002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40100002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6255,7 +6271,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0080002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6271,7 +6287,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000080002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6287,7 +6303,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000080002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6299,11 +6315,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_E.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400080002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400080002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6315,11 +6328,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_E.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200080002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200080002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6331,11 +6341,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_E.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100080002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100080002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6347,11 +6354,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_E.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080080002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80080002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6363,11 +6367,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_E.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040080002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40080002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6383,7 +6384,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0040002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6399,7 +6400,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000040002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6415,7 +6416,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000040002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6427,11 +6428,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_M.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400040002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400040002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6443,11 +6441,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_M.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200040002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200040002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6459,11 +6454,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_M.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100040002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100040002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6475,11 +6467,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_M.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080040002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80040002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6491,11 +6480,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT_M.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040040002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40040002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6511,7 +6497,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0020002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6527,7 +6513,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000020002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6543,7 +6529,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000020002}},
-      R"(Counts all demand data writes (RFOs) )",
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6555,11 +6541,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.SUPPLIER_NONE.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400020002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400020002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6571,11 +6554,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.SUPPLIER_NONE.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200020002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200020002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6587,11 +6567,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.SUPPLIER_NONE.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100020002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100020002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6603,11 +6580,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.SUPPLIER_NONE.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080020002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80020002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6619,11 +6593,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.SUPPLIER_NONE.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040020002}},
-      R"(Counts all demand data writes (RFOs) )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40020002}},
+      R"(Counts all demand data writes (RFOs))",
       R"(Counts all demand data writes (RFOs))",
       100003,
       std::nullopt, // ScaleUnit
@@ -6635,11 +6606,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010002}},
-      R"(Counts all demand data writes (RFOs)have any response type. )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10002}},
+      R"(Counts all demand data writes (RFOs)have any response type.)",
       R"(Counts all demand data writes (RFOs)have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6655,7 +6623,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FFC400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6671,7 +6639,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x203C400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6687,7 +6655,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x103C400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6699,11 +6667,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x043C400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x43C400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6715,11 +6680,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x023C400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x23C400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6731,11 +6693,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x013C400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x13C400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6747,11 +6706,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00BC400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0xBC400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6763,11 +6719,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x007C400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x7C400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6783,7 +6736,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC4000001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6799,7 +6752,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2004000001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6815,7 +6768,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1004000001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6827,11 +6780,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0404000001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x404000001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6843,11 +6793,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0204000001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x204000001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6859,11 +6806,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0104000001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x104000001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6875,11 +6819,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0084000001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x84000001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6891,11 +6832,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0044000001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x44000001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6911,7 +6849,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6927,7 +6865,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6943,7 +6881,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000400001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6955,11 +6893,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L4_HIT_LOCAL_L4.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6971,11 +6906,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L4_HIT_LOCAL_L4.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -6987,11 +6919,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L4_HIT_LOCAL_L4.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7003,11 +6932,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L4_HIT_LOCAL_L4.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7019,11 +6945,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L4_HIT_LOCAL_L4.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040400001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40400001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7039,7 +6962,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC01C0001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7055,7 +6978,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x20001C0001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7071,7 +6994,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x10001C0001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7083,11 +7006,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04001C0001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4001C0001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7099,11 +7019,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x02001C0001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x2001C0001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7115,11 +7032,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01001C0001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1001C0001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7131,11 +7045,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00801C0001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x801C0001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7147,11 +7058,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x00401C0001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x401C0001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7167,7 +7075,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0100001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7183,7 +7091,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000100001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7199,7 +7107,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000100001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7211,11 +7119,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_S.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400100001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400100001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7227,11 +7132,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_S.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200100001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200100001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7243,11 +7145,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_S.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100100001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100100001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7259,11 +7158,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_S.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080100001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80100001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7275,11 +7171,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_S.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040100001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40100001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7295,7 +7188,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0080001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7311,7 +7204,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000080001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7327,7 +7220,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000080001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7339,11 +7232,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_E.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400080001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400080001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7355,11 +7245,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_E.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200080001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200080001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7371,11 +7258,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_E.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100080001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100080001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7387,11 +7271,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_E.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080080001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80080001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7403,11 +7284,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_E.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040080001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40080001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7423,7 +7301,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0040001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7439,7 +7317,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000040001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7455,7 +7333,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000040001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7467,11 +7345,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_M.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400040001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400040001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7483,11 +7358,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_M.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200040001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200040001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7499,11 +7371,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_M.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100040001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100040001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7515,11 +7384,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_M.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080040001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80040001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7531,11 +7397,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT_M.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040040001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40040001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7551,7 +7414,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x3FC0020001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7567,7 +7430,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x2000020001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7583,7 +7446,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .umask = 0x01,
           .cmask = 0,
           .msr_values = {0x1000020001}},
-      R"(Counts demand data reads )",
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7595,11 +7458,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.SUPPLIER_NONE.SNOOP_HIT_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0400020001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x400020001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7611,11 +7471,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.SUPPLIER_NONE.SNOOP_MISS",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0200020001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x200020001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7627,11 +7484,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.SUPPLIER_NONE.SNOOP_NOT_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0100020001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x100020001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7643,11 +7497,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.SUPPLIER_NONE.SNOOP_NONE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0080020001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x80020001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7659,11 +7510,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.SUPPLIER_NONE.SPL_HIT",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0040020001}},
-      R"(Counts demand data reads )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x40020001}},
+      R"(Counts demand data reads)",
       R"(Counts demand data reads)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7675,11 +7523,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010001}},
-      R"(Counts demand data readshave any response type. )",
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10001}},
+      R"(Counts demand data readshave any response type.)",
       R"(Counts demand data readshave any response type.)",
       100003,
       std::nullopt, // ScaleUnit
@@ -7688,5 +7533,5 @@ Note: Invoking MITE requires two or three cycles delay.)",
       ));
 }
 
-} // namespace skylake_core_v48
+} // namespace skylake_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/skylake_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylake_uncore.cpp
@@ -9,17 +9,19 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace skylake_uncore_v48 {
+namespace skylake_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from skylake_uncore_v48.json (23 events).
+    Events from skylake_uncore.json (23 events).
 
     Supported SKUs:
         - Arch: x86, Model: SKL id: 78
         - Arch: x86, Model: SKL id: 94
         - Arch: x86, Model: SKL id: 142
         - Arch: x86, Model: SKL id: 158
+        - Arch: x86, Model: SKL id: 165
+        - Arch: x86, Model: SKL id: 166
   */
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_cbox,
@@ -217,8 +219,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_arb,
       "UNC_ARB_TRK_REQUESTS.ALL",
       EventDef::Encoding{.code = 0x81, .umask = 0x01, .cmask = 0},
-      R"(Total number of Core outgoing entries allocated. Accounts for Coherent and non-coherent traffic.)",
-      R"(Total number of Core outgoing entries allocated. Accounts for Coherent and non-coherent traffic.)",
+      R"(UNC_ARB_TRK_REQUESTS.ALL (Description is auto-generated))",
+      R"(UNC_ARB_TRK_REQUESTS.ALL (Description is auto-generated))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -298,5 +300,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace skylake_uncore_v48
+} // namespace skylake_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace skylakex_core_v1_21 {
+namespace skylakex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from skylakex_core_v1.21.json (449 events).
+    Events from skylakex_core.json (455 events).
 
     Supported SKUs:
         - Arch: x86, Model: SKX id: 85 Steps: ['0', '1', '2', '3', '4']
@@ -28,7 +28,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -40,7 +41,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -56,7 +58,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -68,7 +71,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -80,7 +84,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -92,7 +97,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -104,7 +110,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -116,7 +123,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -124,11 +132,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 4K page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (4K sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -136,11 +145,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 2M/4M page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 2M/4M pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (2M/4M sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -148,23 +158,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x08, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data load to a 1G page)",
-      R"(Counts page walks completed due to demand data loads whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (1G sizes) caused by demand data loads. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "DTLB_LOAD_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x08, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x08, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Load miss in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts demand data loads that caused a completed page walk of any page size (4K/2M/4M/1G). This implies it missed in all TLB levels. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks  (all page sizes) caused by demand data loads. This implies it missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -176,7 +188,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -188,7 +201,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -200,19 +214,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "MEMORY_DISAMBIGUATION.HISTORY_RESET",
       EventDef::Encoding{
           .code = 0x09, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(MEMORY_DISAMBIGUATION.HISTORY_RESET (Description is auto-generated))",
-      R"(MEMORY_DISAMBIGUATION.HISTORY_RESET (Description is auto-generated))",
+      R"(MEMORY_DISAMBIGUATION.HISTORY_RESET)",
+      R"(MEMORY_DISAMBIGUATION.HISTORY_RESET)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -224,7 +240,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -240,7 +257,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -252,7 +270,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -268,7 +287,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -280,7 +300,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -292,7 +313,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -304,7 +326,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -316,7 +339,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -328,7 +352,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -340,7 +365,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -352,7 +378,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -364,7 +391,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -376,7 +404,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -388,7 +417,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -400,7 +430,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -412,7 +443,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -424,7 +456,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -436,7 +469,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -448,7 +482,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -460,7 +495,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -472,7 +508,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -484,7 +521,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -496,7 +534,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -508,7 +547,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -520,7 +560,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -532,7 +573,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -544,7 +586,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -556,7 +599,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -592,7 +636,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -604,7 +649,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -616,7 +662,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -628,7 +675,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -640,7 +688,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -656,7 +705,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -672,7 +722,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -684,7 +735,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -700,7 +752,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -716,7 +769,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -728,7 +782,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -740,7 +795,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -752,7 +808,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       25003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -764,7 +821,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -776,7 +834,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -792,7 +851,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -804,7 +864,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -816,7 +877,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -824,11 +886,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 4K page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 4K pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (4K sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -836,11 +899,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 2M/4M page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 2M/4M pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (2M/4M sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -848,23 +912,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x49, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Page walk completed due to a demand data store to a 1G page)",
-      R"(Counts page walks completed due to demand data stores whose address translations missed in the TLB and were mapped to 1G pages.  The page walks can end with or without a page fault.)",
+      R"(Counts completed page walks  (1G sizes) caused by demand data stores. This implies address translations missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "DTLB_STORE_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x49, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x49, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Store misses in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts demand data stores that caused a completed page walk of any page size (4K/2M/4M/1G). This implies it missed in all TLB levels. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks  (all page sizes) caused by demand data stores. This implies it missed in the DTLB and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -876,7 +942,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -888,7 +955,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -900,7 +968,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -912,19 +981,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "EPT.WALK_PENDING",
       EventDef::Encoding{
-          .code = 0x4F, .umask = 0x10, .cmask = 0, .msr_values = {0}},
+          .code = 0x4f, .umask = 0x10, .cmask = 0, .msr_values = {0}},
       R"(Counts 1 per cycle for each PMH that is busy with a EPT (Extended Page Table) walk for any request type.)",
       R"(Counts cycles for each PMH (Page Miss Handler) that is busy with an EPT (Extended Page Table) walk for any request type.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -936,7 +1007,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -948,7 +1020,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -960,7 +1033,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -972,7 +1046,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -984,7 +1059,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -996,7 +1072,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1008,7 +1085,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1020,7 +1098,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "INST_DECODED.DECODERS",
+      EventDef::Encoding{
+          .code = 0x55, .umask = 0x01, .cmask = 0, .msr_values = {0}},
+      R"(Instruction decoders utilized in a cycle)",
+      R"(Number of decoders utilized in a cycle when the MITE (legacy decode pipeline) fetches instructions.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1032,7 +1124,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1044,7 +1137,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1056,7 +1150,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1068,7 +1163,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1080,7 +1176,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1092,7 +1189,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1109,7 +1207,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1121,7 +1220,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1133,7 +1233,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1145,7 +1246,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1157,7 +1259,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1169,7 +1272,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1181,7 +1285,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1193,7 +1298,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1205,7 +1311,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1217,7 +1324,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1229,7 +1337,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1241,7 +1350,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1253,7 +1363,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1265,7 +1376,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1277,7 +1389,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1289,7 +1402,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1301,7 +1415,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1313,7 +1428,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1325,7 +1441,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1337,7 +1454,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1349,7 +1467,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1361,7 +1480,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1373,7 +1493,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1385,7 +1506,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1397,7 +1519,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1409,7 +1532,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1425,7 +1549,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1437,7 +1562,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1449,7 +1575,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1461,7 +1588,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1473,7 +1601,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1485,7 +1614,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1493,11 +1623,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (4K))",
-      R"(Counts completed page walks (4K page size) caused by a code fetch. This implies it missed in the ITLB and further levels of TLB. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (4K page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1505,11 +1636,12 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x04, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (2M/4M))",
-      R"(Counts code misses in all ITLB levels that caused a completed page walk (2M and 4M page sizes). The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (2M/4M page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1517,23 +1649,25 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x85, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (1G))",
-      R"(Counts store misses in all DTLB levels that cause a completed page walk (1G page size). The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (1G page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "ITLB_MISSES.WALK_COMPLETED",
       EventDef::Encoding{
-          .code = 0x85, .umask = 0x0E, .cmask = 0, .msr_values = {0}},
+          .code = 0x85, .umask = 0x0e, .cmask = 0, .msr_values = {0}},
       R"(Code miss in all TLB levels causes a page walk that completes. (All page sizes))",
-      R"(Counts completed page walks (2M and 4M page sizes) caused by a code fetch. This implies it missed in the ITLB and further levels of TLB. The page walk can end with or without a fault.)",
+      R"(Counts completed page walks (all page sizes) caused by a code fetch. This implies it missed in the ITLB (Instruction TLB) and further levels of TLB. The page walk can end with or without a fault.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1545,7 +1679,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1557,7 +1692,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1569,7 +1705,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1581,7 +1718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1597,7 +1735,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1609,7 +1748,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1621,7 +1761,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1633,7 +1774,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1645,7 +1787,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1657,7 +1800,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1669,7 +1813,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1681,7 +1826,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1693,7 +1839,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1705,7 +1852,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1717,7 +1865,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1729,7 +1878,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1741,7 +1891,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1753,7 +1904,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1765,7 +1917,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1777,7 +1930,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1789,7 +1943,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1801,7 +1956,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1813,7 +1969,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1825,7 +1982,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1837,7 +1995,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1849,7 +2008,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1861,7 +2021,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1873,7 +2034,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1885,7 +2047,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1897,7 +2060,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1909,7 +2073,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1921,7 +2086,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1933,7 +2099,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1945,7 +2112,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1957,7 +2125,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1969,7 +2138,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1981,7 +2151,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -1993,7 +2164,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2006,7 +2178,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2018,7 +2191,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2030,7 +2204,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2042,7 +2217,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2054,7 +2230,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2066,7 +2243,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2078,7 +2256,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2090,7 +2269,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2102,7 +2282,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2114,7 +2295,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2126,7 +2308,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2138,7 +2321,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2150,7 +2334,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2166,7 +2351,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2178,7 +2364,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2190,7 +2377,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2206,7 +2394,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2218,7 +2407,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2230,7 +2420,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2242,7 +2433,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2254,7 +2446,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2266,7 +2459,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2278,7 +2472,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2303,7 +2498,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2315,7 +2511,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2359,6 +2556,18 @@ Note: Invoking MITE requires two or three cycles delay.)",
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "INST_RETIRED.NOP",
+      EventDef::Encoding{
+          .code = 0xC0, .umask = 0x02, .cmask = 0, .msr_values = {0}},
+      R"(Number of all retired NOP instructions.)",
+      R"(Number of all retired NOP instructions.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      R"(SKL091, SKL044)"));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "OTHER_ASSISTS.ANY",
       EventDef::Encoding{
           .code = 0xC1, .umask = 0x3F, .cmask = 0, .msr_values = {0x00}},
@@ -2367,7 +2576,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2376,14 +2586,15 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .code = 0xC2,
           .umask = 0x02,
           .inv = true,
-          .cmask = 10,
+          .cmask = 16,
           .msr_values = {0}},
       R"(Cycles with less than 10 actually retired uops.)",
       R"(Number of cycles using always true condition (uops_ret < 16) applied to non PEBS uops retired event.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2399,7 +2610,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2411,7 +2623,21 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "UOPS_RETIRED.MACRO_FUSED",
+      EventDef::Encoding{
+          .code = 0xc2, .umask = 0x04, .cmask = 0, .msr_values = {0}},
+      R"(Number of macro-fused uops retired. (non precise))",
+      R"(Counts the number of macro-fused uops retired. (non precise))",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2427,7 +2653,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2451,7 +2678,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2571,7 +2799,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2583,7 +2812,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2595,7 +2825,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2607,7 +2838,21 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "BR_MISP_RETIRED.RET",
+      EventDef::Encoding{
+          .code = 0xC5, .umask = 0x08, .cmask = 0, .msr_values = {0}},
+      R"(This event counts the number of mispredicted ret instructions retired. Non PEBS)",
+      R"(This is a non-precise version (that is, does not use PEBS) of the event that counts mispredicted return instructions retired.)",
+      100007,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2619,7 +2864,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       400009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2631,7 +2877,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2643,7 +2890,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2655,7 +2903,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2667,7 +2916,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2679,7 +2929,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2691,7 +2942,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2703,19 +2955,21 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FRONTEND_RETIRED.DSB_MISS",
       EventDef::Encoding{
           .code = 0xC6, .umask = 0x01, .cmask = 0, .msr_values = {0x11}},
-      R"(Retired Instructions who experienced decode stream buffer (DSB - the decoded instruction-cache) miss.)",
-      R"(Counts retired Instructions that experienced DSB (Decode stream buffer i.e. the decoded instruction-cache) miss. )",
+      R"(Retired Instructions who experienced a critical DSB miss.)",
+      R"(Number of retired Instructions that experienced a critical DSB (Decode stream buffer i.e. the decoded instruction-cache) miss. Critical means stalls were exposed to the back-end as a result of the DSB miss.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2727,7 +2981,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2739,7 +2994,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2751,7 +3007,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2763,7 +3020,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2775,7 +3033,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2787,7 +3046,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2799,7 +3059,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2811,7 +3072,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2823,7 +3085,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2835,103 +3098,125 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "FRONTEND_RETIRED.ANY_DSB_MISS",
+      EventDef::Encoding{
+          .code = 0xC6, .umask = 0x01, .cmask = 0, .msr_values = {0x1}},
+      R"(Retired Instructions who experienced DSB miss.)",
+      R"(Counts retired Instructions that experienced DSB (Decode stream buffer i.e. the decoded instruction-cache) miss.)",
+      100007,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{.pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational scalar double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computation. Applies to SSE* and AVX* scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD scalar computational double precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD scalar computational double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SIMD scalar double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.SCALAR_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational scalar single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computation. Applies to SSE* and AVX* scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD scalar computational single precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD scalar computational single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 1 computational operation. Applies to SIMD scalar single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT RCP FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT14 RCP14 DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT14 RCP14 DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 128-bit packed computational double precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 128-bit packed computational double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 2 computation operations, one for each element.  Applies to packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 128-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 128-bit packed computational single precision floating-point instruction retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 128-bit packed computational single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 256-bit packed double computational precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 256-bit packed double computational precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 4 computation operations, one for each element.  Applies to packed double precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT FM(N)ADD/SUB.  FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
-      R"(Number of SSE/AVX computational 256-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Counts once for most SIMD 256-bit packed single computational precision floating-point instructions retired. Counts twice for DPP and FM(N)ADD/SUB instructions retired.)",
+      R"(Counts once for most SIMD 256-bit packed single computational precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to packed single precision floating-point instructions: ADD SUB HADD HSUB SUBADD MUL DIV MIN MAX SQRT RSQRT RCP DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 512-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 8 calculations per element.)",
-      R"(Number of SSE/AVX computational 512-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 8 calculations per element.)",
+      R"(Counts number of SSE/AVX computational 512-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT14 RCP14 FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Number of SSE/AVX computational 512-bit packed double precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 8 computation operations, one for each element.  Applies to SSE* and AVX* packed double precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT14 RCP14 FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
       EventDef::Encoding{
           .code = 0xC7, .umask = 0x80, .cmask = 0, .msr_values = {0}},
-      R"(Number of SSE/AVX computational 512-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 16 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 16 calculations per element.)",
-      R"(Number of SSE/AVX computational 512-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 16 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX RCP14 RSQRT14 SQRT DPP FM(N)ADD/SUB.  DPP and FM(N)ADD/SUB instructions count twice as they perform 16 calculations per element.)",
+      R"(Counts number of SSE/AVX computational 512-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 16 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT14 RCP14 FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element.)",
+      R"(Number of SSE/AVX computational 512-bit packed single precision floating-point instructions retired; some instructions will count twice as noted below.  Each count represents 16 computation operations, one for each element.  Applies to SSE* and AVX* packed single precision floating-point instructions: ADD SUB MUL DIV MIN MAX SQRT RSQRT14 RCP14 FM(N)ADD/SUB. FM(N)ADD/SUB instructions count twice as they perform 2 calculations per element. The DAZ and FTZ flags in the MXCSR register need to be set when using these events.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2943,7 +3228,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2955,7 +3241,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2967,7 +3254,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2979,7 +3267,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -2991,7 +3280,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3003,7 +3293,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3015,7 +3306,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3027,7 +3319,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3039,7 +3332,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3051,7 +3345,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3063,7 +3358,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3075,7 +3371,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3087,7 +3384,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3099,7 +3397,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3111,7 +3410,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3123,7 +3423,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3135,7 +3436,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3147,7 +3449,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       203,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3159,7 +3462,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3171,7 +3475,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3183,7 +3488,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       101,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3195,7 +3501,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       503,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3207,7 +3514,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       1009,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3219,7 +3527,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3231,7 +3540,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3243,7 +3553,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3255,7 +3566,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3267,7 +3579,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 2},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3275,11 +3588,12 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x11, .cmask = 0, .msr_values = {0}},
       R"(Retired load instructions that miss the STLB.)",
-      R"(Retired load instructions that miss the STLB.)",
+      R"(Number of retired load instructions that (start a) miss in the 2nd-level TLB (STLB).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3287,12 +3601,13 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::Encoding{
           .code = 0xD0, .umask = 0x12, .cmask = 0, .msr_values = {0}},
       R"(Retired store instructions that miss the STLB.)",
-      R"(Retired store instructions that miss the STLB.)",
+      R"(Number of retired store instructions that (start a) miss in the 2nd-level TLB (STLB).)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3304,7 +3619,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3316,7 +3632,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3329,7 +3646,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3341,7 +3659,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3354,7 +3673,22 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{
           .data_la = true, .l1_hit_indication = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "MEM_INST_RETIRED.ANY",
+      EventDef::Encoding{
+          .code = 0xD0, .umask = 0x83, .cmask = 0, .msr_values = {0}},
+      R"(All retired memory instructions.)",
+      R"(Counts all retired memory instructions - loads and stores.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{
+          .data_la = true, .l1_hit_indication = true, .pebs = 1},
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3366,7 +3700,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3378,7 +3713,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3390,7 +3726,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3402,7 +3739,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3414,7 +3752,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       50021,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3426,7 +3765,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3438,7 +3778,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3450,7 +3791,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3462,7 +3804,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3474,7 +3817,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       20011,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3486,7 +3830,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3498,7 +3843,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3510,7 +3856,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3522,7 +3869,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3534,7 +3882,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3546,7 +3895,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100007,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{.data_la = true, .pebs = 1},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3558,91 +3908,99 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_IHITI",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x01, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_IHITI (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_IHITI (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_IHITI)",
+      R"(CORE_SNOOP_RESPONSE.RSP_IHITI)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_IHITFSE",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x02, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_IHITFSE (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_IHITFSE (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_IHITFSE)",
+      R"(CORE_SNOOP_RESPONSE.RSP_IHITFSE)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_SHITFSE",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x04, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_SHITFSE (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_SHITFSE (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_SHITFSE)",
+      R"(CORE_SNOOP_RESPONSE.RSP_SHITFSE)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_SFWDM",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x08, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_SFWDM (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_SFWDM (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_SFWDM)",
+      R"(CORE_SNOOP_RESPONSE.RSP_SFWDM)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_IFWDM",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x10, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_IFWDM (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_IFWDM (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_IFWDM)",
+      R"(CORE_SNOOP_RESPONSE.RSP_IFWDM)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_IFWDFE",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x20, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_IFWDFE (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_IFWDFE (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_IFWDFE)",
+      R"(CORE_SNOOP_RESPONSE.RSP_IFWDFE)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "CORE_SNOOP_RESPONSE.RSP_SFWDFE",
       EventDef::Encoding{
           .code = 0xEF, .umask = 0x40, .cmask = 0, .msr_values = {0}},
-      R"(CORE_SNOOP_RESPONSE.RSP_SFWDFE (Description is auto-generated))",
-      R"(CORE_SNOOP_RESPONSE.RSP_SFWDFE (Description is auto-generated))",
+      R"(CORE_SNOOP_RESPONSE.RSP_SFWDFE)",
+      R"(CORE_SNOOP_RESPONSE.RSP_SFWDFE)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3654,7 +4012,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3666,7 +4025,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3678,7 +4038,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3690,7 +4051,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3702,7 +4064,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       200003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3714,7 +4077,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3726,7 +4090,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
@@ -3738,18 +4103,16 @@ Note: Invoking MITE requires two or three cycles delay.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
-      R"(0)"));
+      std::nullopt // Errata
+      ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10001}},
       R"(Counts demand data reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3760,12 +4123,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0001}},
       R"(Counts demand data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3776,12 +4136,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0001}},
       R"(Counts demand data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3797,7 +4154,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0001}},
       R"(Counts demand data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3813,7 +4170,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0001}},
       R"(Counts demand data reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3829,7 +4186,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000001}},
       R"(Counts demand data reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3840,12 +4197,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00001}},
       R"(Counts demand data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3861,7 +4215,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00001}},
       R"(Counts demand data reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3872,12 +4226,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00001}},
       R"(Counts demand data reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3888,12 +4239,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800001}},
       R"(Counts demand data reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3904,12 +4252,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000001}},
       R"(Counts demand data reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts demand data reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3920,12 +4265,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10002}},
       R"(Counts all demand data writes (RFOs) that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3936,12 +4278,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0002}},
       R"(Counts all demand data writes (RFOs) that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3952,12 +4291,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0002}},
       R"(Counts all demand data writes (RFOs) that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3973,7 +4309,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0002}},
       R"(Counts all demand data writes (RFOs) that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3989,7 +4325,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0002}},
       R"(Counts all demand data writes (RFOs) that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4005,7 +4341,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000002}},
       R"(Counts all demand data writes (RFOs) that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4016,12 +4352,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00002}},
       R"(Counts all demand data writes (RFOs) that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4037,7 +4370,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00002}},
       R"(Counts all demand data writes (RFOs) that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4048,12 +4381,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00002}},
       R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4064,12 +4394,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800002}},
       R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4080,12 +4407,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000002}},
       R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand data writes (RFOs) that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4096,12 +4420,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10004}},
       R"(Counts all demand code reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4112,12 +4433,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0004}},
       R"(Counts all demand code reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4128,12 +4446,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0004}},
       R"(Counts all demand code reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4149,7 +4464,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0004}},
       R"(Counts all demand code reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4165,7 +4480,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0004}},
       R"(Counts all demand code reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4181,7 +4496,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000004}},
       R"(Counts all demand code reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4192,12 +4507,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00004}},
       R"(Counts all demand code reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4213,7 +4525,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00004}},
       R"(Counts all demand code reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4224,12 +4536,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00004}},
       R"(Counts all demand code reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4240,12 +4549,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800004}},
       R"(Counts all demand code reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4256,12 +4562,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000004}},
       R"(Counts all demand code reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand code reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4272,12 +4575,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10010}},
       R"(Counts prefetch (that bring data to L2) data reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4288,12 +4588,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0010}},
       R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4304,12 +4601,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0010}},
       R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4325,7 +4619,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0010}},
       R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4341,7 +4635,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0010}},
       R"(Counts prefetch (that bring data to L2) data reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4357,7 +4651,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4368,12 +4662,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4389,7 +4680,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4400,12 +4691,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4416,12 +4704,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4432,12 +4717,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000010}},
       R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch (that bring data to L2) data reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4448,12 +4730,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4464,12 +4743,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4480,12 +4756,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4501,7 +4774,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4517,7 +4790,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4533,7 +4806,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4544,12 +4817,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4565,7 +4835,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4576,12 +4846,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4592,12 +4859,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4608,12 +4872,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000020}},
       R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to L2) RFOs that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4624,12 +4885,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4640,12 +4898,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4656,12 +4911,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4677,7 +4929,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4693,7 +4945,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4709,7 +4961,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4720,12 +4972,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4741,7 +4990,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4752,12 +5001,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4768,12 +5014,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4784,12 +5027,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000080}},
       R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) data reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4800,12 +5040,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4816,12 +5053,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4832,12 +5066,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4853,7 +5084,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4869,7 +5100,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4885,7 +5116,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4896,12 +5127,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4917,7 +5145,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4928,12 +5156,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4944,12 +5169,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4960,12 +5182,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000100}},
       R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch (that bring data to LLC only) RFOs that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4976,12 +5195,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -4992,12 +5208,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5008,12 +5221,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5029,7 +5239,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5045,7 +5255,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5061,7 +5271,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5072,12 +5282,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5093,7 +5300,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5104,12 +5311,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5120,12 +5324,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5136,12 +5337,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000400}},
       R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts L1 data cache hardware prefetch requests and software prefetch requests that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5152,12 +5350,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10490}},
       R"(Counts all prefetch data reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5168,12 +5363,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0490}},
       R"(Counts all prefetch data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5184,12 +5376,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0490}},
       R"(Counts all prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5205,7 +5394,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0490}},
       R"(Counts all prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5221,7 +5410,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0490}},
       R"(Counts all prefetch data reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5237,7 +5426,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000490}},
       R"(Counts all prefetch data reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5248,12 +5437,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00490}},
       R"(Counts all prefetch data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5269,7 +5455,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00490}},
       R"(Counts all prefetch data reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5280,12 +5466,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00490}},
       R"(Counts all prefetch data reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5296,12 +5479,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800490}},
       R"(Counts all prefetch data reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5312,12 +5492,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000490}},
       R"(Counts all prefetch data reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all prefetch data reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5328,12 +5505,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10120}},
       R"(Counts prefetch RFOs that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5344,12 +5518,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0120}},
       R"(Counts prefetch RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5360,12 +5531,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0120}},
       R"(Counts prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5381,7 +5549,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0120}},
       R"(Counts prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5397,7 +5565,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0120}},
       R"(Counts prefetch RFOs that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5413,7 +5581,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000120}},
       R"(Counts prefetch RFOs that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5424,12 +5592,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00120}},
       R"(Counts prefetch RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5445,7 +5610,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00120}},
       R"(Counts prefetch RFOs that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5456,12 +5621,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00120}},
       R"(Counts prefetch RFOs that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5472,12 +5634,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800120}},
       R"(Counts prefetch RFOs that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5488,12 +5647,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000120}},
       R"(Counts prefetch RFOs that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts prefetch RFOs that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5504,12 +5660,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10491}},
       R"(Counts all demand & prefetch data reads that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5520,12 +5673,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0491}},
       R"(Counts all demand & prefetch data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5536,12 +5686,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0491}},
       R"(Counts all demand & prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5557,7 +5704,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0491}},
       R"(Counts all demand & prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5573,7 +5720,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0491}},
       R"(Counts all demand & prefetch data reads that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5589,7 +5736,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000491}},
       R"(Counts all demand & prefetch data reads that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5600,12 +5747,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00491}},
       R"(Counts all demand & prefetch data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5621,7 +5765,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00491}},
       R"(Counts all demand & prefetch data reads that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5632,12 +5776,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00491}},
       R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5648,12 +5789,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800491}},
       R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5664,12 +5802,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000491}},
       R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch data reads that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5680,12 +5815,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.ANY_RESPONSE",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0000010122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x10122}},
       R"(Counts all demand & prefetch RFOs that have any response type.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that have any response type.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5696,12 +5828,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_HIT.NO_SNOOP_NEEDED",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x01003C0122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x1003C0122}},
       R"(Counts all demand & prefetch RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that hit in the L3 and sibling core snoops are not needed as either the core-valid bit is not set or the shared line is present in multiple cores.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5712,12 +5841,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_HIT.HIT_OTHER_CORE_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x04003C0122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x4003C0122}},
       R"(Counts all demand & prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5733,7 +5859,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x10003C0122}},
       R"(Counts all demand & prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that hit in the L3 and the snoop to one of the sibling cores hits the line in M state and the line is forwarded.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5749,7 +5875,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3F803C0122}},
       R"(Counts all demand & prefetch RFOs that hit in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that hit in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5765,7 +5891,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x3FBC000122}},
       R"(Counts all demand & prefetch RFOs that miss in the L3.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss in the L3.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5776,12 +5902,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_MISS.REMOTE_HIT_FORWARD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x083FC00122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x83FC00122}},
       R"(Counts all demand & prefetch RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss the L3 and clean or shared data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5797,7 +5920,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
           .cmask = 0,
           .msr_values = {0x103FC00122}},
       R"(Counts all demand & prefetch RFOs that miss the L3 and the modified data is transferred from remote cache.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss the L3 and the modified data is transferred from remote cache.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5808,12 +5931,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_MISS.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063FC00122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63FC00122}},
       R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from local or remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from local or remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5824,12 +5944,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_MISS_REMOTE_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x063B800122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x63B800122}},
       R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from remote dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from remote dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5840,12 +5957,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_MISS_LOCAL_DRAM.SNOOP_MISS_OR_NO_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x0604000122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x604000122}},
       R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from local dram.)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(Counts all demand & prefetch RFOs that miss the L3 and the data is returned from local dram.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5856,12 +5970,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0001}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0001}},
       R"(OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5872,12 +5983,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0002}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0002}},
       R"(OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.DEMAND_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5888,12 +5996,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0004}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0004}},
       R"(OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.DEMAND_CODE_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5904,12 +6009,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0010}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0010}},
       R"(OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.PF_L2_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5920,12 +6022,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L2_RFO.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0020}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0020}},
       R"(OFFCORE_RESPONSE.PF_L2_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.PF_L2_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5936,12 +6035,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0080}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0080}},
       R"(OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.PF_L3_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5952,12 +6048,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L3_RFO.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0100}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0100}},
       R"(OFFCORE_RESPONSE.PF_L3_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.PF_L3_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5968,12 +6061,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0400}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0400}},
       R"(OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.PF_L1D_AND_SW.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -5984,12 +6074,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0490}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0490}},
       R"(OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.ALL_PF_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6000,12 +6087,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_PF_RFO.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0120}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0120}},
       R"(OFFCORE_RESPONSE.ALL_PF_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.ALL_PF_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6016,12 +6100,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0491}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0491}},
       R"(OFFCORE_RESPONSE.ALL_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.ALL_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6032,12 +6113,9 @@ Note: Invoking MITE requires two or three cycles delay.)",
       PmuType::cpu,
       "OFFCORE_RESPONSE.ALL_RFO.L3_HIT.SNOOP_HIT_WITH_FWD",
       EventDef::Encoding{
-          .code = 0xB7,
-          .umask = 0x01,
-          .cmask = 0,
-          .msr_values = {0x08003C0122}},
+          .code = 0xB7, .umask = 0x01, .cmask = 0, .msr_values = {0x8003C0122}},
       R"(OFFCORE_RESPONSE.ALL_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
-      R"(Offcore response can be programmed only with a specific pair of event select and counter MSR, and with specific event codes and predefine mask bit value in a dedicated MSR to specify attributes of the offcore transaction.)",
+      R"(OFFCORE_RESPONSE.ALL_RFO.L3_HIT.SNOOP_HIT_WITH_FWD)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6045,5 +6123,5 @@ Note: Invoking MITE requires two or three cycles delay.)",
       ));
 }
 
-} // namespace skylakex_core_v1_21
+} // namespace skylakex_core
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/skylakex_uncore.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylakex_uncore.cpp
@@ -9,11 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace skylakex_uncore_v1_21 {
+namespace skylakex_uncore {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from skylakex_uncore_v1.21.json (252 events).
+    Events from skylakex_uncore.json (268 events).
 
     Supported SKUs:
         - Arch: x86, Model: SKX id: 85 Steps: ['0', '1', '2', '3', '4']
@@ -23,7 +23,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IO_HIT",
       EventDef::Encoding{.code = 0x35, .umask = 0x14, .msr_values = {0x00}},
       R"(TOR Inserts; Hits from Local IO)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -35,7 +35,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IO_MISS",
       EventDef::Encoding{.code = 0x35, .umask = 0x24, .msr_values = {0x00}},
       R"(TOR Inserts; Misses from Local IO)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -47,7 +47,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IA",
       EventDef::Encoding{.code = 0x35, .umask = 0x31, .msr_values = {0x00}},
       R"(TOR Inserts; All from Local iA)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; All locally initiated requests from iA Cores)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; All locally initiated requests from iA Cores)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -59,7 +59,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IA_HIT",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
       R"(TOR Inserts; Hits from Local iA)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -70,8 +70,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS (Description is auto-generated))",
+      R"(TOR Inserts : All requests from iA Cores that Missed the LLC)",
+      R"(TOR Inserts : All requests from iA Cores that Missed the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -395,7 +395,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_SNOOP_RESP.RSP_WBWB",
       EventDef::Encoding{.code = 0x5C, .umask = 0x10, .msr_values = {0x00}},
       R"(Rsp*WB Snoop Responses Received)",
-      R"(Counts when a transaction with the opcode type Rsp*WB Snoop Response was received which indicates which indicates the data was written back to it's home.  This is returned when a non-RFO request hits a cacheline in the Modified state. The Cache can either downgrade the cacheline to a S (Shared) or I (Invalid) state depending on how the system has been configured.  This reponse will also be sent when a cache requests E (Exclusive) ownership of a cache line without receiving data, because the cache must acquire ownership.)",
+      R"(Counts when a transaction with the opcode type Rsp*WB Snoop Response was received which indicates which indicates the data was written back to its home.  This is returned when a non-RFO request hits a cacheline in the Modified state. The Cache can either downgrade the cacheline to a S (Shared) or I (Invalid) state depending on how the system has been configured.  This response will also be sent when a cache requests E (Exclusive) ownership of a cache line without receiving data, because the cache must acquire ownership.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -407,7 +407,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_SNOOP_RESP.RSP_FWD_WB",
       EventDef::Encoding{.code = 0x5C, .umask = 0x20, .msr_values = {0x00}},
       R"(Rsp*Fwd*WB Snoop Responses Received)",
-      R"(Counts when a transaction with the opcode type Rsp*Fwd*WB Snoop Response was received which indicates the data was written back to it's home socket, and the cacheline was forwarded to the requestor socket.  This snoop response is only used in >= 4 socket systems.  It is used when a snoop HITM's in a remote caching agent and it directly forwards data to a requestor, and simultaneously returns data to it's home socket to be written back to memory.)",
+      R"(Counts when a transaction with the opcode type Rsp*Fwd*WB Snoop Response was received which indicates the data was written back to its home socket, and the cacheline was forwarded to the requestor socket.  This snoop response is only used in &gt;= 4 socket systems.  It is used when a snoop HITM's in a remote caching agent and it directly forwards data to a requestor, and simultaneously returns data to its home socket to be written back to memory.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -550,8 +550,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_DRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_DRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_DRD (Description is auto-generated))",
+      R"(TOR Inserts : DRds issued by iA Cores that Hit the LLC)",
+      R"(TOR Inserts : DRds issued by iA Cores that Hit the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -562,8 +562,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_CRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_CRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_CRD (Description is auto-generated))",
+      R"(TOR Inserts : CRds issued by iA Cores that Hit the LLC)",
+      R"(TOR Inserts : CRds issued by iA Cores that Hit the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -574,8 +574,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_RFO",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_RFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_RFO (Description is auto-generated))",
+      R"(TOR Inserts : RFOs issued by iA Cores that Hit the LLC)",
+      R"(TOR Inserts : RFOs issued by iA Cores that Hit the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -586,8 +586,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefDRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefDRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefDRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefDRD)",
+      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefDRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -598,8 +598,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefCRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefCRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefCRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefCRD)",
+      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefCRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -610,8 +610,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefRFO",
       EventDef::Encoding{.code = 0x35, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefRFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_HIT_LlcPrefRFO (Description is auto-generated))",
+      R"(TOR Inserts : LLCPrefRFO issued by iA Cores that hit the LLC)",
+      R"(TOR Inserts : LLCPrefRFO issued by iA Cores that hit the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -622,8 +622,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_DRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_DRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_DRD (Description is auto-generated))",
+      R"(TOR Inserts : DRds issued by iA Cores that Missed the LLC)",
+      R"(TOR Inserts : DRds issued by iA Cores that Missed the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -634,8 +634,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_CRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_CRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_CRD (Description is auto-generated))",
+      R"(TOR Inserts : CRds issued by iA Cores that Missed the LLC)",
+      R"(TOR Inserts : CRds issued by iA Cores that Missed the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -646,8 +646,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_RFO",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_RFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_RFO (Description is auto-generated))",
+      R"(TOR Inserts : RFOs issued by iA Cores that Missed the LLC)",
+      R"(TOR Inserts : RFOs issued by iA Cores that Missed the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -658,8 +658,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefDRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefDRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefDRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefDRD)",
+      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefDRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -670,8 +670,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefCRD",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefCRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefCRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefCRD)",
+      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefCRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -682,8 +682,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefRFO",
       EventDef::Encoding{.code = 0x35, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefRFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_INSERTS.IA_MISS_LlcPrefRFO (Description is auto-generated))",
+      R"(TOR Inserts : LLCPrefRFO issued by iA Cores that missed the LLC)",
+      R"(TOR Inserts : LLCPrefRFO issued by iA Cores that missed the LLC : Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.   Does not include addressless requests such as locks and interrupts.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -694,8 +694,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_DRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_DRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_DRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_DRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_DRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -706,8 +706,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_CRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_CRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_CRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_CRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_CRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -718,8 +718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_RFO",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_RFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_RFO (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_RFO)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_RFO)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -730,8 +730,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefDRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefDRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefDRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefDRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefDRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -742,8 +742,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefCRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefCRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefCRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefCRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefCRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -754,8 +754,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefRFO",
       EventDef::Encoding{.code = 0x36, .umask = 0x11, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefRFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefRFO (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefRFO)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_HIT_LlcPrefRFO)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -766,8 +766,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -778,8 +778,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_CRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_CRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_CRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_CRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_CRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -790,8 +790,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -802,8 +802,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefDRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefDRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefDRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefDRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefDRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -814,8 +814,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefCRD",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefCRD (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefCRD (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefCRD)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefCRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -826,8 +826,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefRFO",
       EventDef::Encoding{.code = 0x36, .umask = 0x21, .msr_values = {0x00}},
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefRFO (Description is auto-generated))",
-      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefRFO (Description is auto-generated))",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefRFO)",
+      R"(UNC_CHA_TOR_OCCUPANCY.IA_MISS_LlcPrefRFO)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1043,7 +1043,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART0",
       EventDef::Encoding{.code = 0x83, .umask = 0x01, .msr_values = {0x00}},
       R"(Write request of 4 bytes made by IIO Part0 to Memory)",
-      R"(Counts every write request of 4 bytes of data made by IIO Part0 to a unit onthe main die (generally memory). In the general case, Part0 refers to a standard PCIe card of any size (x16,x8,x4) that is plugged directly into one of the PCIe slots. Part0 could also refer to any device plugged into the first slot of a PCIe riser card or to a device attached to the IIO unit which starts its use of the bus using lane 0 of the 16 lanes supported by the bus.)",
+      R"(Counts every write request of 4 bytes of data made by IIO Part0 to a unit on the main die (generally memory). In the general case, Part0 refers to a standard PCIe card of any size (x16,x8,x4) that is plugged directly into one of the PCIe slots. Part0 could also refer to any device plugged into the first slot of a PCIe riser card or to a device attached to the IIO unit which starts its use of the bus using lane 0 of the 16 lanes supported by the bus.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1615,6 +1615,198 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_INSERTS.CMPD.PART0",
+      EventDef::Encoding{.code = 0xC2, .umask = 0x03, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 0)",
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 0)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_INSERTS.CMPD.PART1",
+      EventDef::Encoding{.code = 0xC2, .umask = 0x03, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 1)",
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 1)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_INSERTS.CMPD.PART2",
+      EventDef::Encoding{.code = 0xC2, .umask = 0x03, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 2)",
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 2)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_INSERTS.CMPD.PART3",
+      EventDef::Encoding{.code = 0xC2, .umask = 0x03, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 3)",
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 3)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_OCCUPANCY.CMPD.PART0",
+      EventDef::Encoding{.code = 0xD5, .umask = 0x01, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 0)",
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 0)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_OCCUPANCY.CMPD.PART1",
+      EventDef::Encoding{.code = 0xD5, .umask = 0x02, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 1)",
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 1)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_OCCUPANCY.CMPD.PART2",
+      EventDef::Encoding{.code = 0xD5, .umask = 0x04, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 2)",
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 2)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_OCCUPANCY.CMPD.PART3",
+      EventDef::Encoding{.code = 0xD5, .umask = 0x08, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 3)",
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 3)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_INSERTS.CMPD.ALL_PARTS",
+      EventDef::Encoding{.code = 0xC2, .umask = 0x03, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 0-3)",
+      R"(PCIe Completion Buffer Inserts of completions with data: Part 0-3)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_COMP_BUF_OCCUPANCY.CMPD.ALL_PARTS",
+      EventDef::Encoding{.code = 0xD5, .umask = 0x0f, .msr_values = {0x00}},
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 0-3)",
+      R"(PCIe Completion Buffer occupancy of completions with data: Part 0-3)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_CACHE_TOTAL_OCCUPANCY.MEM",
+      EventDef::Encoding{.code = 0xF, .umask = 0x4, .msr_values = {0x00}},
+      R"(Total IRP occupancy of inbound read and write requests.)",
+      R"(Total IRP occupancy of inbound read and write requests.  This is effectively the sum of read occupancy and write occupancy.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_COHERENT_OPS.RFO",
+      EventDef::Encoding{.code = 0x10, .umask = 0x8, .msr_values = {0x00}},
+      R"(RFO request issued by the IRP unit to the mesh with the intention of writing a partial cacheline.)",
+      R"(RFO request issued by the IRP unit to the mesh with the intention of writing a partial cacheline to coherent memory.  RFO is a Read For Ownership command that requests ownership of the cacheline and moves data from the mesh to IRP cache.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_COHERENT_OPS.PCITOM",
+      EventDef::Encoding{.code = 0x10, .umask = 0x10, .msr_values = {0x00}},
+      R"(PCIITOM request issued by the IRP unit to the mesh with the intention of writing a full cacheline.)",
+      R"(PCIITOM request issued by the IRP unit to the mesh with the intention of writing a full cacheline to coherent memory, without a RFO.  PCIITOM is a speculative Invalidate to Modified command that requests ownership of the cacheline and does not move data from the mesh to IRP cache.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_FAF_INSERTS",
+      EventDef::Encoding{.code = 0x18, .umask = 0x0, .msr_values = {0x00}},
+      R"(Inbound read requests received by the IRP and inserted into the FAF queue.)",
+      R"(Inbound read requests to coherent memory, received by the IRP and inserted into the Fire and Forget queue (FAF), a queue used for processing inbound reads in the IRP.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_FAF_OCCUPANCY",
+      EventDef::Encoding{.code = 0x19, .umask = 0x0, .msr_values = {0x00}},
+      R"(Occupancy of the IRP FAF queue.)",
+      R"(Occupancy of the IRP Fire and Forget (FAF) queue, a queue used for processing inbound reads in the IRP.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_TRANSACTIONS.WR_PREF",
+      EventDef::Encoding{.code = 0x11, .umask = 0x8, .msr_values = {0x00}},
+      R"(Inbound write (fast path) requests received by the IRP.)",
+      R"(Inbound write (fast path) requests to coherent memory, received by the IRP resulting in write ownership requests issued by IRP to the mesh.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_upi,
       "UNC_UPI_CLOCKTICKS",
       EventDef::Encoding{.code = 0x1, .umask = 0x0, .msr_values = {0x00}},
@@ -1667,7 +1859,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_UPI_RxL_BYPASSED.SLOT0",
       EventDef::Encoding{.code = 0x31, .umask = 0x1, .msr_values = {0x00}},
       R"(FLITs received which bypassed the Slot0 Receive Buffer)",
-      R"(Counts incoming FLITs (FLow control unITs) which bypassed the slot0 RxQ buffer (Receive Queue) and passed directly to the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts incoming FLITs (FLow control unITs) which bypassed the slot0 RxQ buffer (Receive Queue) and passed directly to the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1679,7 +1871,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_UPI_RxL_BYPASSED.SLOT1",
       EventDef::Encoding{.code = 0x31, .umask = 0x2, .msr_values = {0x00}},
       R"(FLITs received which bypassed the Slot0 Receive Buffer)",
-      R"(Counts incoming FLITs (FLow control unITs) which bypassed the slot1 RxQ buffer  (Receive Queue) and passed directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(Counts incoming FLITs (FLow control unITs) which bypassed the slot1 RxQ buffer  (Receive Queue) and passed directly across the BGF and into the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1690,8 +1882,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_BYPASSED.SLOT2",
       EventDef::Encoding{.code = 0x31, .umask = 0x4, .msr_values = {0x00}},
-      R"(FLITs received which bypassed the Slot0 Recieve Buffer)",
-      R"(Counts incoming FLITs (FLow control unITs) whcih bypassed the slot2 RxQ buffer (Receive Queue)  and passed directly to the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transfered, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
+      R"(FLITs received which bypassed the Slot0 Receive Buffer)",
+      R"(Counts incoming FLITs (FLow control unITs) which bypassed the slot2 RxQ buffer (Receive Queue)  and passed directly to the Egress.  This is a latency optimization, and should generally be the common case.  If this value is less than the number of FLITs transferred, it implies that there was queueing getting onto the ring, and thus the transactions saw higher latency.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2074,8 +2266,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_m2m,
       "UNC_M2M_PREFCAM_DEMAND_PROMOTIONS",
       EventDef::Encoding{.code = 0x56, .umask = 0x0, .msr_values = {0x00}},
-      R"(Prefecth requests that got turn into a demand request)",
-      R"(Counts when the M2M (Mesh to Memory) promotes a outstanding request in the prefetch queue due to a subsequent demand read request that entered the M2M with the same address.  Explanatory Side Note: The Prefecth queue is made of CAM (Content Addressable Memory))",
+      R"(Prefetch requests that got turn into a demand request)",
+      R"(Counts when the M2M (Mesh to Memory) promotes a outstanding request in the prefetch queue due to a subsequent demand read request that entered the M2M with the same address.  Explanatory Side Note: The Prefetch queue is made of CAM (Content Addressable Memory))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2087,7 +2279,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M2M_PREFCAM_INSERTS",
       EventDef::Encoding{.code = 0x57, .umask = 0x0, .msr_values = {0x00}},
       R"(Inserts into the Memory Controller Prefetch Queue)",
-      R"(Counts when the M2M (Mesh to Memory) recieves a prefetch request and inserts it into its outstanding prefetch queue.  Explanatory Side Note: the prefect queue is made from CAM: Content Addressable Memory)",
+      R"(Counts when the M2M (Mesh to Memory) receives a prefetch request and inserts it into its outstanding prefetch queue.  Explanatory Side Note: the prefect queue is made from CAM: Content Addressable Memory)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2443,5 +2635,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace skylakex_uncore_v1_21
+} // namespace skylakex_uncore
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/json_events/generated/intel/skylakex_uncore_experimental.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylakex_uncore_experimental.cpp
@@ -9,12 +9,11 @@
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 
 namespace facebook::hbt::perf_event::generated {
-namespace skylakex_uncore_v1_21_experimental {
+namespace skylakex_uncore_experimental {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
   /*
-    Events from skylakex_uncore_v1.21_experimental.json (3062 experimental
-    events).
+    Events from skylakex_uncore_experimental.json (3040 experimental events).
 
     Supported SKUs:
         - Arch: x86, Model: SKX id: 85 Steps: ['0', '1', '2', '3', '4']
@@ -24,7 +23,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IO",
       EventDef::Encoding{.code = 0x35, .umask = 0x34, .msr_values = {0x00}},
       R"(TOR Inserts; All from Local IO)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; All locally generated IO traffic)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; All locally generated IO traffic)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -36,7 +35,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.ALL_IO_IA",
       EventDef::Encoding{.code = 0x35, .umask = 0x35, .msr_values = {0x00}},
       R"(TOR Inserts; All from Local iA and IO)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; All locally initiated requests)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; All locally initiated requests)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -48,7 +47,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.ALL_HIT",
       EventDef::Encoding{.code = 0x35, .umask = 0x15, .msr_values = {0x00}},
       R"(TOR Inserts; Hits from Local)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -60,7 +59,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.ALL_MISS",
       EventDef::Encoding{.code = 0x35, .umask = 0x25, .msr_values = {0x00}},
       R"(TOR Inserts; Misses from Local)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -1488,7 +1487,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_SNOOP_RESP_LOCAL.RSPSFWD",
       EventDef::Encoding{.code = 0x5D, .umask = 0x08, .msr_values = {0x00}},
       R"(Snoop Responses Received Local; RspSFwd)",
-      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd to local CA requests.  This is returned when a remote caching agent forwards data but holds on to its currentl copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
+      R"(Number of snoop responses received for a Local  request; Filters for a snoop response of RspSFwd to local CA requests.  This is returned when a remote caching agent forwards data but holds on to its current copy.  This is common for data and code reads that hit in a remote socket in E or F state.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2207,8 +2206,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_cha,
       "UNC_CHA_SNOOP_RESP.RSPS",
       EventDef::Encoding{.code = 0x5C, .umask = 0x02, .msr_values = {0x00}},
-      R"(UNC_CHA_SNOOP_RESP.RSPS (Description is auto-generated))",
-      R"(UNC_CHA_SNOOP_RESP.RSPS (Description is auto-generated))",
+      R"(Snoop Responses Received : RspS)",
+      R"(Snoop Responses Received : RspS : Counts the total number of RspI snoop responses received.  Whenever a snoops are issued, one or more snoop responses will be returned depending on the topology of the system.   In systems larger than 2s, when multiple snoops are returned this will count all the snoops that are received.  For example, if 3 snoops were issued and returned RspI, RspS, and RspSFwd; then each of these sub-events would increment by 1. : Filters for snoop responses of RspS.  RspS is returned when a remote cache has data but is not forwarding it.  It is a way to let the requesting socket know that it cannot allocate the data in E state.  No data is sent with S RspS.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2340,7 +2339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_LLC_LOOKUP.WRITE",
       EventDef::Encoding{.code = 0x34, .umask = 0x05, .msr_values = {0x00}},
       R"(Cache and Snoop Filter Lookups; Write Requests)",
-      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CHAFilter0[24:21,17] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cachable and UC.)",
+      R"(Counts the number of times the LLC was accessed - this includes code, data, prefetches and hints coming from L2.  This has numerous filters available.  Note the non-standard filtering equation.  This event will count requests that lookup the cache multiple times with multiple increments.  One must ALWAYS set umask bit 0 and select a state or states to match.  Otherwise, the event will count nothing.   CHAFilter0[24:21,17] bits correspond to [FMESI] state.; Writeback transactions from L2 to the LLC  This includes all write transactions -- both Cacheable and UC.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2412,7 +2411,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IRQ",
       EventDef::Encoding{.code = 0x35, .umask = 0x01, .msr_values = {0x00}},
       R"(TOR Inserts; IRQ)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2424,7 +2423,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.EVICT",
       EventDef::Encoding{.code = 0x35, .umask = 0x02, .msr_values = {0x00}},
       R"(TOR Inserts; SF/LLC Evictions)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; TOR allocation occurred as a result of SF/LLC evictions (came from the ISMQ))",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; TOR allocation occurred as a result of SF/LLC evictions (came from the ISMQ))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2436,7 +2435,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.PRQ",
       EventDef::Encoding{.code = 0x35, .umask = 0x04, .msr_values = {0x00}},
       R"(TOR Inserts; PRQ)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2448,7 +2447,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.IPQ",
       EventDef::Encoding{.code = 0x35, .umask = 0x08, .msr_values = {0x00}},
       R"(TOR Inserts; IPQ)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2460,7 +2459,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.HIT",
       EventDef::Encoding{.code = 0x35, .umask = 0x10, .msr_values = {0x00}},
       R"(TOR Inserts; Hit (Not a Miss))",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; HITs (hit is defined to be not a miss [see below], as a result for any request allocated into the TOR, one of either HIT or MISS must be true))",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; HITs (hit is defined to be not a miss [see below], as a result for any request allocated into the TOR, one of either HIT or MISS must be true))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2472,7 +2471,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TOR_INSERTS.MISS",
       EventDef::Encoding{.code = 0x35, .umask = 0x20, .msr_values = {0x00}},
       R"(TOR Inserts; Miss)",
-      R"(Counts the number of entries successfuly inserted into the TOR that match qualifications specified by the subevent.; Misses.  (a miss is defined to be any transaction from the IRQ, PRQ, RRQ, IPQ or (in the victim case) the ISMQ, that required the CHA to spawn a new UPI/SMI3 request on the UPI fabric (including UPI snoops and/or any RD/WR to a local memory controller, in the event that the CHA is the home node)).  Basically, if the LLC/SF/MLC complex were not able to service the request without involving another agent...it is a miss.  If only IDI snoops were required, it is not a miss (that means the SF/MLC com)",
+      R"(Counts the number of entries successfully inserted into the TOR that match qualifications specified by the subevent.; Misses.  (a miss is defined to be any transaction from the IRQ, PRQ, RRQ, IPQ or (in the victim case) the ISMQ, that required the CHA to spawn a new UPI/SMI3 request on the UPI fabric (including UPI snoops and/or any RD/WR to a local memory controller, in the event that the CHA is the home node)).  Basically, if the LLC/SF/MLC complex were not able to service the request without involving another agent...it is a miss.  If only IDI snoops were required, it is not a miss (that means the SF/MLC com)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6024,7 +6023,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TxR_VERT_CYCLES_FULL.BL_AG1",
       EventDef::Encoding{.code = 0x92, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Full; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6108,7 +6107,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TxR_VERT_CYCLES_NE.BL_AG1",
       EventDef::Encoding{.code = 0x93, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Not Empty; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6192,7 +6191,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TxR_VERT_INSERTS.BL_AG1",
       EventDef::Encoding{.code = 0x91, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Allocations; BL - Agent 1)",
-      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6276,7 +6275,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_CHA_TxR_VERT_OCCUPANCY.BL_AG1",
       EventDef::Encoding{.code = 0x90, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Occupancy; BL - Agent 1)",
-      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6887,8 +6886,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_iio,
       "UNC_IIO_NOTHING",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_IIO_NOTHING (Description is auto-generated))",
-      R"(UNC_IIO_NOTHING (Description is auto-generated))",
+      R"(UNC_IIO_NOTHING)",
+      R"(UNC_IIO_NOTHING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -6901,6 +6900,18 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x82, .umask = 0x0, .msr_values = {0x00}},
       R"(Symbol Times on Link)",
       R"(Gen1 - increment once every 4nS, Gen2 - increment once every 2nS, Gen3 - increment once every 1nS)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_iio,
+      "UNC_IIO_VTD_ACCESS.L4_PAGE_HIT",
+      EventDef::Encoding{.code = 0x41, .umask = 0x1, .msr_values = {0x00}},
+      R"(VTd Access; Vtd hit)",
+      R"(VTd Access; Vtd hit)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -8373,18 +8384,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_irp,
-      "UNC_I_CACHE_TOTAL_OCCUPANCY.MEM",
-      EventDef::Encoding{.code = 0xF, .umask = 0x4, .msr_values = {0x00}},
-      R"(Total Write Cache Occupancy; Mem)",
-      R"(Accumulates the number of reads and writes that are outstanding in the uncore in each cycle.  This is effectively the sum of the READ_OCCUPANCY and WRITE_OCCUPANCY events.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
       "UNC_I_CLOCKTICKS",
       EventDef::Encoding{.code = 0x1, .umask = 0x0, .msr_values = {0x00}},
       R"(IRP Clocks)",
@@ -8424,30 +8423,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_I_COHERENT_OPS.DRD",
       EventDef::Encoding{.code = 0x10, .umask = 0x4, .msr_values = {0x00}},
       R"(Coherent Ops; DRd)",
-      R"(Counts the number of coherency related operations servied by the IRP)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_COHERENT_OPS.RFO",
-      EventDef::Encoding{.code = 0x10, .umask = 0x8, .msr_values = {0x00}},
-      R"(Coherent Ops; RFO)",
-      R"(Counts the number of coherency related operations servied by the IRP)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_COHERENT_OPS.PCITOM",
-      EventDef::Encoding{.code = 0x10, .umask = 0x10, .msr_values = {0x00}},
-      R"(Coherent Ops; PCIItoM)",
       R"(Counts the number of coherency related operations servied by the IRP)",
       std::nullopt,
       std::nullopt, // ScaleUnit
@@ -8497,30 +8472,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x17, .umask = 0x0, .msr_values = {0x00}},
       R"(FAF RF full)",
       R"(FAF RF full)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_FAF_INSERTS",
-      EventDef::Encoding{.code = 0x18, .umask = 0x0, .msr_values = {0x00}},
-      R"(FAF - request insert from TC.)",
-      R"(FAF - request insert from TC.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
-      "UNC_I_FAF_OCCUPANCY",
-      EventDef::Encoding{.code = 0x19, .umask = 0x0, .msr_values = {0x00}},
-      R"(FAF occupancy)",
-      R"(FAF occupancy)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -8985,18 +8936,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_irp,
-      "UNC_I_TRANSACTIONS.WR_PREF",
-      EventDef::Encoding{.code = 0x11, .umask = 0x8, .msr_values = {0x00}},
-      R"(Inbound Transaction Count; Write Prefetches)",
-      R"(Counts the number of Inbound transactions from the IRP to the Uncore.  This can be filtered based on request type in addition to the source queue.  Note the special filtering equation.  We do OR-reduction on the request type.  If the SOURCE bit is set, then we also do AND qualification based on the source portID.; Tracks the number of write prefetches.)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_irp,
       "UNC_I_TRANSACTIONS.ATOMIC",
       EventDef::Encoding{.code = 0x11, .umask = 0x10, .msr_values = {0x00}},
       R"(Inbound Transaction Count; Atomic)",
@@ -9200,11 +9139,71 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_SNOOP_RESP.ALL_HIT_I",
+      EventDef::Encoding{.code = 0x12, .umask = 0x72, .msr_values = {0x00}},
+      R"(Responses to snoops of any type that hit I line in the IIO cache)",
+      R"(Responses to snoops of any type (code, data, invalidate) that hit I line in the IIO cache)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_SNOOP_RESP.ALL_HIT_ES",
+      EventDef::Encoding{.code = 0x12, .umask = 0x74, .msr_values = {0x00}},
+      R"(Responses to snoops of any type that hit E or S line in the IIO cache)",
+      R"(Responses to snoops of any type (code, data, invalidate) that hit E or S line in the IIO cache)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_SNOOP_RESP.ALL_HIT_M",
+      EventDef::Encoding{.code = 0x12, .umask = 0x78, .msr_values = {0x00}},
+      R"(Responses to snoops of any type that hit M line in the IIO cache)",
+      R"(Responses to snoops of any type (code, data, invalidate) that hit M line in the IIO cache)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_SNOOP_RESP.ALL_HIT",
+      EventDef::Encoding{.code = 0x12, .umask = 0x7e, .msr_values = {0x00}},
+      R"(Responses to snoops of any type that hit M, E, S or I line in the IIO)",
+      R"(Responses to snoops of any type (code, data, invalidate) that hit M, E, S or I line in the IIO)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_irp,
+      "UNC_I_SNOOP_RESP.ALL_MISS",
+      EventDef::Encoding{.code = 0x12, .umask = 0x71, .msr_values = {0x00}},
+      R"(Responses to snoops of any type that miss the IIO cache)",
+      R"(Responses to snoops of any type (code, data, invalidate) that miss the IIO cache)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ0",
       EventDef::Encoding{.code = 0x18, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ0 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ0 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ0)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9215,8 +9214,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ1",
       EventDef::Encoding{.code = 0x18, .umask = 0x02, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ1 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ1 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ1)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9227,8 +9226,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ2",
       EventDef::Encoding{.code = 0x18, .umask = 0x04, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ2 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ2 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ2)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AD_VNA_EQ2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9239,8 +9238,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.BL_VNA_EQ0",
       EventDef::Encoding{.code = 0x18, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.BL_VNA_EQ0 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.BL_VNA_EQ0 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.BL_VNA_EQ0)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.BL_VNA_EQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9251,8 +9250,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ0",
       EventDef::Encoding{.code = 0x18, .umask = 0x10, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ0 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ0 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ0)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9263,8 +9262,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AD_VNA_LE2",
       EventDef::Encoding{.code = 0x14, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AD_VNA_LE2 (Description is auto-generated))",
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AD_VNA_LE2 (Description is auto-generated))",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AD_VNA_LE2)",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AD_VNA_LE2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9275,8 +9274,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_BYP_BLOCKED.FLOWQ_BL_VNA_EQ0",
       EventDef::Encoding{.code = 0x14, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_BL_VNA_EQ0 (Description is auto-generated))",
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_BL_VNA_EQ0 (Description is auto-generated))",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_BL_VNA_EQ0)",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_BL_VNA_EQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9287,8 +9286,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AK_VNA_LE3",
       EventDef::Encoding{.code = 0x14, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AK_VNA_LE3 (Description is auto-generated))",
-      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AK_VNA_LE3 (Description is auto-generated))",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AK_VNA_LE3)",
+      R"(UNC_UPI_M3_BYP_BLOCKED.FLOWQ_AK_VNA_LE3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9299,8 +9298,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_BYP_BLOCKED.BGF_CRD",
       EventDef::Encoding{.code = 0x14, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_BYP_BLOCKED.BGF_CRD (Description is auto-generated))",
-      R"(UNC_UPI_M3_BYP_BLOCKED.BGF_CRD (Description is auto-generated))",
+      R"(UNC_UPI_M3_BYP_BLOCKED.BGF_CRD)",
+      R"(UNC_UPI_M3_BYP_BLOCKED.BGF_CRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9311,8 +9310,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_BYP_BLOCKED.GV_BLOCK",
       EventDef::Encoding{.code = 0x14, .umask = 0x10, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_BYP_BLOCKED.GV_BLOCK (Description is auto-generated))",
-      R"(UNC_UPI_M3_BYP_BLOCKED.GV_BLOCK (Description is auto-generated))",
+      R"(UNC_UPI_M3_BYP_BLOCKED.GV_BLOCK)",
+      R"(UNC_UPI_M3_BYP_BLOCKED.GV_BLOCK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9323,8 +9322,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_CRD_RETURN_BLOCKED",
       EventDef::Encoding{.code = 0x16, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_CRD_RETURN_BLOCKED (Description is auto-generated))",
-      R"(UNC_UPI_M3_CRD_RETURN_BLOCKED (Description is auto-generated))",
+      R"(UNC_UPI_M3_CRD_RETURN_BLOCKED)",
+      R"(UNC_UPI_M3_CRD_RETURN_BLOCKED)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9335,8 +9334,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_LE2",
       EventDef::Encoding{.code = 0x15, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_LE2 (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_LE2 (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_LE2)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_LE2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9347,8 +9346,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_BTW_2_THRESH",
       EventDef::Encoding{.code = 0x15, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_BTW_2_THRESH (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_BTW_2_THRESH (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_BTW_2_THRESH)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AD_VNA_BTW_2_THRESH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9359,8 +9358,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_EQ0",
       EventDef::Encoding{.code = 0x15, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_EQ0 (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_EQ0 (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_EQ0)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_EQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9371,8 +9370,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_BTW_0_THRESH",
       EventDef::Encoding{.code = 0x15, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_BTW_0_THRESH (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_BTW_0_THRESH (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_BTW_0_THRESH)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_BL_VNA_BTW_0_THRESH)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9383,8 +9382,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AK_VNA_LE3",
       EventDef::Encoding{.code = 0x15, .umask = 0x10, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AK_VNA_LE3 (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AK_VNA_LE3 (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AK_VNA_LE3)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.FLOWQ_AK_VNA_LE3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9395,8 +9394,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.BGF_CRD",
       EventDef::Encoding{.code = 0x15, .umask = 0x20, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.BGF_CRD (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.BGF_CRD (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.BGF_CRD)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.BGF_CRD)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9407,8 +9406,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_M3_RXQ_BLOCKED.GV_BLOCK",
       EventDef::Encoding{.code = 0x15, .umask = 0x40, .msr_values = {0x00}},
-      R"(UNC_UPI_M3_RXQ_BLOCKED.GV_BLOCK (Description is auto-generated))",
-      R"(UNC_UPI_M3_RXQ_BLOCKED.GV_BLOCK (Description is auto-generated))",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.GV_BLOCK)",
+      R"(UNC_UPI_M3_RXQ_BLOCKED.GV_BLOCK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9455,8 +9454,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_REQ_SLOT2_FROM_M3.VNA",
       EventDef::Encoding{.code = 0x46, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VNA (Description is auto-generated))",
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VNA (Description is auto-generated))",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VNA)",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VNA)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9467,8 +9466,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_REQ_SLOT2_FROM_M3.VN0",
       EventDef::Encoding{.code = 0x46, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN0 (Description is auto-generated))",
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN0 (Description is auto-generated))",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN0)",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9479,8 +9478,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_REQ_SLOT2_FROM_M3.VN1",
       EventDef::Encoding{.code = 0x46, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN1 (Description is auto-generated))",
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN1 (Description is auto-generated))",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN1)",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.VN1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9491,8 +9490,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_REQ_SLOT2_FROM_M3.ACK",
       EventDef::Encoding{.code = 0x46, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.ACK (Description is auto-generated))",
-      R"(UNC_UPI_REQ_SLOT2_FROM_M3.ACK (Description is auto-generated))",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.ACK)",
+      R"(UNC_UPI_REQ_SLOT2_FROM_M3.ACK)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9683,8 +9682,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ1",
       EventDef::Encoding{.code = 0x33, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ1 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ1 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ1)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9695,8 +9694,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ2",
       EventDef::Encoding{.code = 0x33, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ2 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ2 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ2)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S0_RXQ2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9707,8 +9706,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ0",
       EventDef::Encoding{.code = 0x33, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ0 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ0 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ0)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9719,8 +9718,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ2",
       EventDef::Encoding{.code = 0x33, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ2 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ2 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ2)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S1_RXQ2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9731,8 +9730,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ0",
       EventDef::Encoding{.code = 0x33, .umask = 0x10, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ0 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ0 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ0)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ0)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9743,8 +9742,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ1",
       EventDef::Encoding{.code = 0x33, .umask = 0x20, .msr_values = {0x00}},
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ1 (Description is auto-generated))",
-      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ1 (Description is auto-generated))",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ1)",
+      R"(UNC_UPI_RxL_SLOT_BYPASS.S2_RXQ1)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9755,8 +9754,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.CFG_CTL",
       EventDef::Encoding{.code = 0x2A, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.CFG_CTL (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.CFG_CTL (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.CFG_CTL)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.CFG_CTL)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9767,8 +9766,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.RXQ",
       EventDef::Encoding{.code = 0x2A, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9779,8 +9778,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_BYPASS",
       EventDef::Encoding{.code = 0x2A, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_BYPASS (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_BYPASS (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_BYPASS)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_BYPASS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9791,8 +9790,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_CRED",
       EventDef::Encoding{.code = 0x2A, .umask = 0x8, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_CRED (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_CRED (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_CRED)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RXQ_CRED)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9803,8 +9802,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.TXQ",
       EventDef::Encoding{.code = 0x2A, .umask = 0x10, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.TXQ (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.TXQ (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.TXQ)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.TXQ)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9815,8 +9814,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.RETRY",
       EventDef::Encoding{.code = 0x2A, .umask = 0x20, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RETRY (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RETRY (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RETRY)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.RETRY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9827,8 +9826,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.DFX",
       EventDef::Encoding{.code = 0x2A, .umask = 0x40, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.DFX (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.DFX (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.DFX)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.DFX)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9839,8 +9838,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_CLK_ACTIVE.SPARE",
       EventDef::Encoding{.code = 0x2A, .umask = 0x80, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.SPARE (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_CLK_ACTIVE.SPARE (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.SPARE)",
+      R"(UNC_UPI_TxL0P_CLK_ACTIVE.SPARE)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9851,8 +9850,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_POWER_CYCLES_LL_ENTER",
       EventDef::Encoding{.code = 0x28, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_POWER_CYCLES_LL_ENTER (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_POWER_CYCLES_LL_ENTER (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_POWER_CYCLES_LL_ENTER)",
+      R"(UNC_UPI_TxL0P_POWER_CYCLES_LL_ENTER)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9863,8 +9862,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_TxL0P_POWER_CYCLES_M3_EXIT",
       EventDef::Encoding{.code = 0x29, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_UPI_TxL0P_POWER_CYCLES_M3_EXIT (Description is auto-generated))",
-      R"(UNC_UPI_TxL0P_POWER_CYCLES_M3_EXIT (Description is auto-generated))",
+      R"(UNC_UPI_TxL0P_POWER_CYCLES_M3_EXIT)",
+      R"(UNC_UPI_TxL0P_POWER_CYCLES_M3_EXIT)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9971,8 +9970,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_upi,
       "UNC_UPI_VNA_CREDIT_RETURN_BLOCKED_VN01",
       EventDef::Encoding{.code = 0x45, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_UPI_VNA_CREDIT_RETURN_BLOCKED_VN01 (Description is auto-generated))",
-      R"(UNC_UPI_VNA_CREDIT_RETURN_BLOCKED_VN01 (Description is auto-generated))",
+      R"(UNC_UPI_VNA_CREDIT_RETURN_BLOCKED_VN01)",
+      R"(UNC_UPI_VNA_CREDIT_RETURN_BLOCKED_VN01)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -9993,34 +9992,10 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_upi,
-      "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1",
-      EventDef::Encoding{.code = 0x18, .umask = 0x20, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1 (Description is auto-generated))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_upi,
-      "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2",
-      EventDef::Encoding{.code = 0x18, .umask = 0x40, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2 (Description is auto-generated))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_upi,
       "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ3",
       EventDef::Encoding{.code = 0x18, .umask = 0x80, .msr_values = {0x00}},
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ3 (Description is auto-generated))",
-      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ3 (Description is auto-generated))",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ3)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ3)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -10045,6 +10020,30 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x2, .umask = 0x80, .msr_values = {0x00}},
       R"(Valid Flits Sent; Protocol Header)",
       R"(Shows legal flit time (hides impact of L0p and L0c).; Enables count of protocol headers in slot 0,1,2 (depending on slot uMask bits))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_upi,
+      "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1",
+      EventDef::Encoding{.code = 0x18, .umask = 0x20, .msr_values = {0x00}},
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ1)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_upi,
+      "UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2",
+      EventDef::Encoding{.code = 0x18, .umask = 0x40, .msr_values = {0x00}},
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2)",
+      R"(UNC_UPI_FLOWQ_NO_VNA_CRD.AK_VNA_EQ2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -11005,42 +11004,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x48, .umask = 0x0, .msr_values = {0x00}},
       R"(Data Pending Occupancy)",
       R"(Data Pending Occupancy)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m2m,
-      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN0",
-      EventDef::Encoding{.code = 0x4E, .umask = 0x1, .msr_values = {0x00}},
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 0)",
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 0)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m2m,
-      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN1",
-      EventDef::Encoding{.code = 0x4E, .umask = 0x2, .msr_values = {0x00}},
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 1)",
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 1)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m2m,
-      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN2",
-      EventDef::Encoding{.code = 0x4E, .umask = 0x4, .msr_values = {0x00}},
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 2)",
-      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14052,7 +14015,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M2M_TxR_VERT_CYCLES_FULL.BL_AG1",
       EventDef::Encoding{.code = 0x92, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Full; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14136,7 +14099,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M2M_TxR_VERT_CYCLES_NE.BL_AG1",
       EventDef::Encoding{.code = 0x93, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Not Empty; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14220,7 +14183,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M2M_TxR_VERT_INSERTS.BL_AG1",
       EventDef::Encoding{.code = 0x91, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Allocations; BL - Agent 1)",
-      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14376,7 +14339,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M2M_TxR_VERT_OCCUPANCY.BL_AG1",
       EventDef::Encoding{.code = 0x90, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Occupancy; BL - Agent 1)",
-      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -14773,6 +14736,42 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0xC0, .umask = 0x00, .msr_values = {0x00}},
       R"(CMS Clockticks)",
       R"(CMS Clockticks)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m2m,
+      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN0",
+      EventDef::Encoding{.code = 0x4E, .umask = 0x01, .msr_values = {0x00}},
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 0)",
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 0)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m2m,
+      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN1",
+      EventDef::Encoding{.code = 0x4E, .umask = 0x02, .msr_values = {0x00}},
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 1)",
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 1)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m2m,
+      "UNC_M2M_WPQ_CYCLES_SPEC_CREDITS.CHN2",
+      EventDef::Encoding{.code = 0x4E, .umask = 0x04, .msr_values = {0x00}},
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 2)",
+      R"(M2M->iMC WPQ Cycles w/Credits - Special; Channel 2)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -15277,54 +15276,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{.code = 0x20, .umask = 0x40, .msr_values = {0x00}},
       R"(UPI0 AD Credits Empty; VN1 RSP Messages)",
       R"(No credits available to send to UPIs on the AD Ring)",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m3upi,
-      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VNA",
-      EventDef::Encoding{.code = 0x21, .umask = 0x1, .msr_values = {0x00}},
-      R"(UPI0 BL Credits Empty; VNA)",
-      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m3upi,
-      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_RSP",
-      EventDef::Encoding{.code = 0x21, .umask = 0x2, .msr_values = {0x00}},
-      R"(UPI0 BL Credits Empty; VN0 REQ Messages)",
-      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m3upi,
-      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_NCS_NCB",
-      EventDef::Encoding{.code = 0x21, .umask = 0x4, .msr_values = {0x00}},
-      R"(UPI0 BL Credits Empty; VN0 RSP Messages)",
-      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
-      std::nullopt,
-      std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{},
-      std::nullopt // Errata
-      ));
-
-  pmu_manager.addEvent(std::make_shared<EventDef>(
-      PmuType::uncore_m3upi,
-      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_WB",
-      EventDef::Encoding{.code = 0x21, .umask = 0x8, .msr_values = {0x00}},
-      R"(UPI0 BL Credits Empty; VN0 SNP Messages)",
-      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -18840,7 +18791,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_RxC_BYPASSED.AD_S0_IDLE",
       EventDef::Encoding{.code = 0x40, .umask = 0x01, .msr_values = {0x00}},
       R"(Ingress Queue Bypasses; AD to Slot 0 on Idle)",
-      R"(Number ot times message is bypassed around the Ingress Queue; AD is taking bypass to slot 0 of independent flit while pipeline is idle)",
+      R"(Number of times message is bypassed around the Ingress Queue; AD is taking bypass to slot 0 of independent flit while pipeline is idle)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -18852,7 +18803,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_RxC_BYPASSED.AD_S0_BL_ARB",
       EventDef::Encoding{.code = 0x40, .umask = 0x02, .msr_values = {0x00}},
       R"(Ingress Queue Bypasses; AD to Slot 0 on BL Arb)",
-      R"(Number ot times message is bypassed around the Ingress Queue; AD is taking bypass to slot 0 of independent flit while bl message is in arbitration)",
+      R"(Number of times message is bypassed around the Ingress Queue; AD is taking bypass to slot 0 of independent flit while bl message is in arbitration)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -18864,7 +18815,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_RxC_BYPASSED.AD_S1_BL_SLOT",
       EventDef::Encoding{.code = 0x40, .umask = 0x04, .msr_values = {0x00}},
       R"(Ingress Queue Bypasses; AD + BL to Slot 1)",
-      R"(Number ot times message is bypassed around the Ingress Queue; AD is taking bypass to flit slot 1 while merging with bl message in same flit)",
+      R"(Number of times message is bypassed around the Ingress Queue; AD is taking bypass to flit slot 1 while merging with bl message in same flit)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -18876,7 +18827,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_RxC_BYPASSED.AD_S2_BL_SLOT",
       EventDef::Encoding{.code = 0x40, .umask = 0x08, .msr_values = {0x00}},
       R"(Ingress Queue Bypasses; AD + BL to Slot 2)",
-      R"(Number ot times message is bypassed around the Ingress Queue; AD is taking bypass to flit slot 2 while merging with bl message in same flit)",
+      R"(Number of times message is bypassed around the Ingress Queue; AD is taking bypass to flit slot 2 while merging with bl message in same flit)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -19463,8 +19414,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_m3upi,
       "UNC_M3UPI_RxC_FLITS_MISC",
       EventDef::Encoding{.code = 0x5A, .umask = 0x00, .msr_values = {0x00}},
-      R"(UNC_M3UPI_RxC_FLITS_MISC (Description is auto-generated))",
-      R"(UNC_M3UPI_RxC_FLITS_MISC (Description is auto-generated))",
+      R"(UNC_M3UPI_RxC_FLITS_MISC)",
+      R"(UNC_M3UPI_RxC_FLITS_MISC)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -21960,7 +21911,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_TxR_VERT_CYCLES_FULL.BL_AG1",
       EventDef::Encoding{.code = 0x92, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Full; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Full.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22044,7 +21995,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_TxR_VERT_CYCLES_NE.BL_AG1",
       EventDef::Encoding{.code = 0x93, .umask = 0x40, .msr_values = {0x00}},
       R"(Cycles CMS Vertical Egress Queue Is Not Empty; BL - Agent 1)",
-      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of cycles the Common Mesh Stop Egress was Not Empty.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22128,7 +22079,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_TxR_VERT_INSERTS.BL_AG1",
       EventDef::Encoding{.code = 0x91, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Allocations; BL - Agent 1)",
-      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Number of allocations into the Common Mesh Stop Egress.  The Egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22284,7 +22235,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M3UPI_TxR_VERT_OCCUPANCY.BL_AG1",
       EventDef::Encoding{.code = 0x90, .umask = 0x40, .msr_values = {0x00}},
       R"(CMS Vert Egress Occupancy; BL - Agent 1)",
-      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transfering writeback data to the cache.)",
+      R"(Occupancy event for the Egress buffers in the Common Mesh Stop  The egress is used to queue up requests destined for the Vertical Ring on the Mesh.; Ring transactions from Agent 1 destined for the BL ring.  This is commonly used for transferring writeback data to the cache.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22628,6 +22579,54 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 
   pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m3upi,
+      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VNA",
+      EventDef::Encoding{.code = 0x21, .umask = 0x01, .msr_values = {0x00}},
+      R"(UPI0 BL Credits Empty; VNA)",
+      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m3upi,
+      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_RSP",
+      EventDef::Encoding{.code = 0x21, .umask = 0x02, .msr_values = {0x00}},
+      R"(UPI0 BL Credits Empty; VN0 REQ Messages)",
+      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m3upi,
+      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_NCS_NCB",
+      EventDef::Encoding{.code = 0x21, .umask = 0x04, .msr_values = {0x00}},
+      R"(UPI0 BL Credits Empty; VN0 RSP Messages)",
+      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_m3upi,
+      "UNC_M3UPI_UPI_PEER_BL_CREDITS_EMPTY.VN0_WB",
+      EventDef::Encoding{.code = 0x21, .umask = 0x08, .msr_values = {0x00}},
+      R"(UPI0 BL Credits Empty; VN0 SNP Messages)",
+      R"(No credits available to send to UPI on the BL Ring (diff between non-SMI and SMI mode))",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::uncore_pcu,
       "UNC_P_CLOCKTICKS",
       EventDef::Encoding{.code = 0x0, .umask = 0x0, .msr_values = {0x00}},
@@ -22643,8 +22642,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_CORE_TRANSITION_CYCLES",
       EventDef::Encoding{.code = 0x60, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_CORE_TRANSITION_CYCLES (Description is auto-generated))",
-      R"(UNC_P_CORE_TRANSITION_CYCLES (Description is auto-generated))",
+      R"(UNC_P_CORE_TRANSITION_CYCLES)",
+      R"(UNC_P_CORE_TRANSITION_CYCLES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22655,8 +22654,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_DEMOTIONS",
       EventDef::Encoding{.code = 0x30, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_DEMOTIONS (Description is auto-generated))",
-      R"(UNC_P_DEMOTIONS (Description is auto-generated))",
+      R"(UNC_P_DEMOTIONS)",
+      R"(UNC_P_DEMOTIONS)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22763,8 +22762,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_MCP_PROCHOT_CYCLES",
       EventDef::Encoding{.code = 0x6, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_MCP_PROCHOT_CYCLES (Description is auto-generated))",
-      R"(UNC_P_MCP_PROCHOT_CYCLES (Description is auto-generated))",
+      R"(UNC_P_MCP_PROCHOT_CYCLES)",
+      R"(UNC_P_MCP_PROCHOT_CYCLES)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22835,8 +22834,44 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_pcu,
       "UNC_P_PMAX_THROTTLED_CYCLES",
       EventDef::Encoding{.code = 0x7, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_P_PMAX_THROTTLED_CYCLES (Description is auto-generated))",
-      R"(UNC_P_PMAX_THROTTLED_CYCLES (Description is auto-generated))",
+      R"(UNC_P_PMAX_THROTTLED_CYCLES)",
+      R"(UNC_P_PMAX_THROTTLED_CYCLES)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_POWER_STATE_OCCUPANCY.CORES_C0",
+      EventDef::Encoding{.code = 0x80, .umask = 0x40, .msr_values = {0x00}},
+      R"(Number of cores in C-State; C0 and C1)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_POWER_STATE_OCCUPANCY.CORES_C3",
+      EventDef::Encoding{.code = 0x80, .umask = 0x80, .msr_values = {0x00}},
+      R"(Number of cores in C-State; C3)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
+      std::nullopt,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::uncore_pcu,
+      "UNC_P_POWER_STATE_OCCUPANCY.CORES_C6",
+      EventDef::Encoding{.code = 0x80, .umask = 0xC0, .msr_values = {0x00}},
+      R"(Number of cores in C-State; C6 and C7)",
+      R"(This is an occupancy event that tracks the number of cores that are in the chosen C-State.  It can be used by itself to get the average number of cores in that C-state with threshholding to generate histograms, or with other PCU events and occupancy triggering to capture other details.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22860,7 +22895,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_P_PROCHOT_INTERNAL_CYCLES",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(Internal Prochot)",
-      R"(Counts the number of cycles that we are in Interal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
+      R"(Counts the number of cycles that we are in Internal PROCHOT mode.  This mode is triggered when a sensor on the die determines that we are too hot and must throttle to avoid damaging the chip.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22979,8 +23014,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_ubox,
       "UNC_U_RACU_DRNG.RDRAND",
       EventDef::Encoding{.code = 0x4C, .umask = 0x1, .msr_values = {0x00}},
-      R"(UNC_U_RACU_DRNG.RDRAND (Description is auto-generated))",
-      R"(UNC_U_RACU_DRNG.RDRAND (Description is auto-generated))",
+      R"(UNC_U_RACU_DRNG.RDRAND)",
+      R"(UNC_U_RACU_DRNG.RDRAND)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -22991,8 +23026,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_ubox,
       "UNC_U_RACU_DRNG.RDSEED",
       EventDef::Encoding{.code = 0x4C, .umask = 0x2, .msr_values = {0x00}},
-      R"(UNC_U_RACU_DRNG.RDSEED (Description is auto-generated))",
-      R"(UNC_U_RACU_DRNG.RDSEED (Description is auto-generated))",
+      R"(UNC_U_RACU_DRNG.RDSEED)",
+      R"(UNC_U_RACU_DRNG.RDSEED)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -23003,8 +23038,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_ubox,
       "UNC_U_RACU_DRNG.PFTCH_BUF_EMPTY",
       EventDef::Encoding{.code = 0x4C, .umask = 0x4, .msr_values = {0x00}},
-      R"(UNC_U_RACU_DRNG.PFTCH_BUF_EMPTY (Description is auto-generated))",
-      R"(UNC_U_RACU_DRNG.PFTCH_BUF_EMPTY (Description is auto-generated))",
+      R"(UNC_U_RACU_DRNG.PFTCH_BUF_EMPTY)",
+      R"(UNC_U_RACU_DRNG.PFTCH_BUF_EMPTY)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -23196,7 +23231,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       "UNC_M_ECC_CORRECTABLE_ERRORS",
       EventDef::Encoding{.code = 0x9, .umask = 0x0, .msr_values = {0x00}},
       R"(ECC Correctable Errors)",
-      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit erros in lockstep mode.)",
+      R"(Counts the number of ECC errors detected and corrected by the iMC on this channel.  This counter is only useful with ECC DRAM devices.  This count will increment one time for each correction regardless of the number of bits corrected.  The iMC can correct up to 4 bit errors in independent channel mode and 8 bit errors in lockstep mode.)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -23375,8 +23410,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       PmuType::uncore_imc,
       "UNC_M_POWER_PCU_THROTTLING",
       EventDef::Encoding{.code = 0x42, .umask = 0x0, .msr_values = {0x00}},
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
-      R"(UNC_M_POWER_PCU_THROTTLING (Description is auto-generated))",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
+      R"(UNC_M_POWER_PCU_THROTTLING)",
       std::nullopt,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -27752,5 +27787,5 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 }
 
-} // namespace skylakex_uncore_v1_21_experimental
+} // namespace skylakex_uncore_experimental
 } // namespace facebook::hbt::perf_event::generated

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -38,6 +38,7 @@ TEST(PerCpuThreadSwitchGenerator, SmokeTest) {
 
   g.open(2);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -66,6 +67,7 @@ TEST(PerCpuCountSampleGenerator, SmokeTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -140,6 +142,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Open without pinning the events.
   g.open(false);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -255,6 +258,7 @@ TEST(BPerfCountReader, SmokeTest) {
       std::make_unique<FdWrapper>(cgroup_path));
 
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   // Object to store data read from counters.
   // Definition comes from GroupReadValues<>.
@@ -311,6 +315,7 @@ TEST(PerCpuCountSampleGenerator, TracePointTest) {
 
   g.open(2, 2 * 1024 * 1024);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.getCpuGenerator(1).consume(10);
   g.getCpuGenerator(3).consume(10);
@@ -338,6 +343,7 @@ TEST(PerCpuDummyGenerator, SmokeTest) {
 
   g.open();
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
 
   g.now();
   g.tstampFromTsc(1000000);
@@ -380,6 +386,8 @@ TEST(CpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   sleep(1);
   g.disable();
   // we should receive a itrace start perf event
@@ -435,6 +443,8 @@ TEST(PerCpuTraceAuxGenerator, SmokeTest) {
           "test_aux_cpu_generator"));
   g.open(16, CpuTraceAuxGenerator::AUXBufferMode::OVERWRITABLE);
   g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
   *phase = 1;
   while (*phase == 1)
     ;


### PR DESCRIPTION
Summary:
This is an intermidate diff to keep ShipIt from OOMing, full summary of changes in D42151461.

Intel has retired download.01.org json events and moved them over to github with several changes.
* Version json files no longer exist
* Json files now included a header and event section.
* List of events in the Event section is equivalent to old files
* mapfiles.csv has three new sections: Core Type, Native Model ID, and Core Role Name

Differential Revision: D42201400

