### PR TITLE
add perf read values as a default type in metric frame

### DIFF
--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,7 +1,9 @@
+add_library(extra_types STATIC ExtraTypes.h ExtraTypes.cpp)
 add_library(metric_series STATIC MetricSeries.h)
 set_target_properties(metric_series PROPERTIES LINKER_LANGUAGE CXX)
 add_library(metric_frame_ts_unit STATIC
     MetricFrameTsUnit.h MetricFrameTsUnit.cpp MetricFrameTsUnitInterface.h)
 add_library(metric_frame STATIC
     MetricFrame.h MetricFrame.cpp MetricFrameBase.h MetricFrameBase.cpp)
-target_link_libraries(metric_frame metric_series metric_frame_ts_unit)
+target_link_libraries(metric_frame
+    metric_series metric_frame_ts_unit extra_types)

--- a/dynolog/src/metric_frame/ExtraTypes.cpp
+++ b/dynolog/src/metric_frame/ExtraTypes.cpp
@@ -1,0 +1,12 @@
+#include "dynolog/src/metric_frame/ExtraTypes.h"
+
+namespace facebook::dynolog {
+
+std::ostream& operator<<(
+    std::ostream& os,
+    const PerfReadValues& perfReadValues) {
+  os << perfReadValues.toString();
+  return os;
+}
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/ExtraTypes.h
+++ b/dynolog/src/metric_frame/ExtraTypes.h
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <ostream>
+
+namespace facebook::dynolog {
+
+struct PerfReadValues {
+  uint64_t timeEnabled = 0;
+  uint64_t timeRunning = 0;
+  uint64_t count = 0;
+
+  std::string toString() const {
+    return std::string("<PerfReadValue timeEnabled=") +
+        std::to_string(timeEnabled) +
+        " timeRunning=" + std::to_string(timeRunning) +
+        " count=" + std::to_string(count) + ">";
+  }
+
+  PerfReadValues operator-(const PerfReadValues& other) const {
+    if (other.timeRunning > timeRunning || other.timeEnabled > timeEnabled ||
+        other.count > count) {
+      throw std::underflow_error(
+          std::string("lhs value ") + toString() +
+          " is smaller than rhs value " + other.toString());
+    }
+    PerfReadValues res;
+    res.timeEnabled = timeEnabled - other.timeEnabled;
+    res.timeRunning = timeRunning - other.timeRunning;
+    res.count = count - other.count;
+    return res;
+  }
+
+  template <typename R>
+  R getCount() const {
+    if (timeRunning == 0) {
+      return static_cast<R>(0);
+    }
+    return static_cast<R>(
+        static_cast<double>(count) * static_cast<double>(timeEnabled) /
+        static_cast<double>(timeRunning));
+  }
+
+  // override type cast to double operator here.
+  // when cast PerfReadValues to double, it will calculate a single double value
+  // based on timeEnabled and timeRunning.
+  operator double() const {
+    return getCount<double>();
+  }
+};
+
+std::ostream& operator<<(
+    std::ostream& os,
+    const PerfReadValues& perfReadValues);
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -40,10 +40,12 @@ bool MetricFrameMap::eraseSeries(const std::string& name) {
 
 bool MetricFrameMap::addSamples(const MapSamplesT& samples, TimePoint time) {
   for (const auto& [name, sampleVar] : samples) {
-    auto seriesIt = series_.find(name);
-    if (seriesIt == series_.end()) {
-      continue;
+    if (!series_.count(name)) {
+      return false;
     }
+  }
+  for (const auto& [name, sampleVar] : samples) {
+    auto seriesIt = series_.find(name);
     auto& seriesVar = seriesIt->second;
     addSample(sampleVar, seriesVar);
   }

--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -52,6 +52,11 @@ std::optional<MetricFrameSlice> MetricFrameBase::slice(
   return MetricFrameSlice(*this, rangeMaybe.value());
 }
 
+template <bool flag = false>
+void unknown_type_assert() {
+  static_assert(flag, "type provided to add samples is not supported");
+}
+
 void MetricFrameBase::addSample(
     const SampleVarT& sampleVar,
     MetricSeriesVar& seriesVar) {
@@ -62,6 +67,10 @@ void MetricFrameBase::addSample(
           arg->addSample(std::get<int64_t>(sampleVar));
         } else if constexpr (std::is_same_v<T, MetricSeriesDoublePtr>) {
           arg->addSample(std::get<double>(sampleVar));
+        } else if constexpr (std::is_same_v<T, MetricSeriesPerfReadValuePtr>) {
+          arg->addSample(std::get<PerfReadValues>(sampleVar));
+        } else {
+          unknown_type_assert();
         }
       },
       seriesVar);

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -9,16 +9,21 @@
 #include "dynolog/src/metric_frame/MetricSeries.h"
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <variant>
 
 namespace facebook::dynolog {
 
-using SampleVarT = std::variant<int64_t, double>;
+using SampleVarT = std::variant<int64_t, double, PerfReadValues>;
 using MetricSeriesInt64Ptr = std::shared_ptr<MetricSeries<int64_t>>;
 using MetricSeriesDoublePtr = std::shared_ptr<MetricSeries<double>>;
-using MetricSeriesVar =
-    std::variant<MetricSeriesInt64Ptr, MetricSeriesDoublePtr>;
+using MetricSeriesPerfReadValuePtr =
+    std::shared_ptr<MetricSeries<PerfReadValues>>;
+using MetricSeriesVar = std::variant<
+    MetricSeriesInt64Ptr,
+    MetricSeriesDoublePtr,
+    MetricSeriesPerfReadValuePtr>;
 
 class MetricFrameSlice;
 

--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -16,6 +16,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "dynolog/src/metric_frame/ExtraTypes.h"
+
 namespace facebook::dynolog {
 
 template <typename T>

--- a/dynolog/tests/metric_frame/MetricFrameTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTest.cpp
@@ -15,6 +15,32 @@ using namespace ::facebook::dynolog;
 
 using namespace std::literals::chrono_literals;
 
+TEST(PerfReadValuesTest, operator) {
+  PerfReadValues v1, v2;
+  v1.timeEnabled = 100;
+  v1.timeRunning = 50;
+  v2.timeEnabled = 150;
+  v2.timeRunning = 80;
+  v1.count = 50;
+  v2.count = 80;
+
+  auto diff = v2 - v1;
+  EXPECT_EQ(diff.timeEnabled, 50);
+  EXPECT_EQ(diff.timeRunning, 30);
+  EXPECT_EQ(diff.count, 30);
+
+  std::cerr << diff << std::endl;
+}
+
+TEST(PerfReadValuesTest, getCount) {
+  PerfReadValues v;
+  v.timeEnabled = 50;
+  v.timeRunning = 30;
+  v.count = 30;
+  EXPECT_NEAR(v.getCount<double>(), 30.0 * 50.0 / 30.0, 1e-6);
+  EXPECT_EQ(v.getCount<uint64_t>(), static_cast<uint64_t>(30.0 * 50.0 / 30.0));
+}
+
 TEST(MetricSeriesSliceTest, constructor) {
   auto ts = std::make_shared<MetricFrameTsUnitFixInterval>(
       std::chrono::seconds{60}, 10);
@@ -156,4 +182,47 @@ TEST(MetricSeriesSliceTest, metricFrameVectorSmokeTest) {
   EXPECT_NEAR(seriesSlice2->rate<double>(1s), 0.01667, 1e-3);
   EXPECT_EQ(seriesSlice2->rate<int>(1min), 1);
   EXPECT_NEAR(seriesSlice2->diff(), 5, 1e-3);
+}
+
+TEST(MetricSeriesSliceTest, perfReadValuesCompabilityTest) {
+  auto ts = std::make_shared<MetricFrameTsUnitFixInterval>(
+      std::chrono::seconds{60}, 10);
+  MetricFrameMap frame(10, "test", "test metric frame", std::move(ts));
+  auto series = std::make_shared<MetricSeries<PerfReadValues>>(
+      10, "perf_values", "perf read values metric");
+  ASSERT_TRUE(frame.addSeries("perf_values_1", std::move(series)));
+
+  auto now = std::chrono::steady_clock::now();
+  PerfReadValues sample = {.timeEnabled = 60, .timeRunning = 60, .count = 60};
+  ASSERT_TRUE(frame.addSamples({{"perf_values_1", sample}}, now));
+  sample.timeEnabled = 120;
+  sample.timeRunning = 90;
+  sample.count = 90;
+  ASSERT_TRUE(frame.addSamples({{"perf_values_1", sample}}, now + 60s));
+
+  ASSERT_TRUE(frame.slice(now, now + 60s).has_value());
+  auto frameSlice = frame.slice(now, now + 60s).value();
+  auto seriesSlice = frameSlice.series<PerfReadValues>("perf_values_1");
+  ASSERT_TRUE(seriesSlice.has_value());
+  auto rate = seriesSlice->rate<double>(1s);
+  EXPECT_NEAR(rate, 1, 1e-3);
+
+  sample.timeEnabled = 180;
+  sample.timeRunning = 90;
+  sample.count = 90;
+  ASSERT_TRUE(frame.addSamples({{"perf_values_1", sample}}, now + 120s));
+
+  ASSERT_TRUE(frame.slice(now + 60s, now + 120s).has_value());
+  auto frameSlice2 = frame.slice(now + 60s, now + 120s).value();
+  auto seriesSlice2 = frameSlice2.series<PerfReadValues>("perf_values_1");
+  ASSERT_TRUE(seriesSlice2.has_value());
+  rate = seriesSlice2->rate<double>(1s);
+  EXPECT_NEAR(rate, 0, 1e-3);
+
+  ASSERT_TRUE(frame.slice(now, now + 120s).has_value());
+  auto frameSlice3 = frame.slice(now, now + 120s).value();
+  auto seriesSlice3 = frameSlice3.series<PerfReadValues>("perf_values_1");
+  ASSERT_TRUE(seriesSlice3.has_value());
+  rate = seriesSlice3->rate<double>(1s);
+  EXPECT_NEAR(rate, 1, 1e-3);
 }

--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -303,6 +303,19 @@ class Monitor {
     return it->second;
   }
 
+  bool eraseCountReader(const MuxGroupId& mux_group_id, const ElemId& elem_id) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if (!count_readers_.count(elem_id)) {
+      return false;
+    }
+    if (!removeMuxEntry_(mux_group_id, elem_id)) {
+      return false;
+    }
+    count_readers_.erase(elem_id);
+    sync_();
+    return true;
+  }
+
 #ifdef HBT_ENABLE_BPERF
   /// Read counts for all events opened in counting mode
   /// in all BPerfCountReaders.


### PR DESCRIPTION
Summary: make MetricFrame support storing raw perf counters values (those with enabled time and running time).

Differential Revision: D42241157

