### PR TITLE
Fix -Wbitwise-instead-of-logical in 5 files starting w/ fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h

### DIFF
--- a/hbt/src/mon/Filter.h
+++ b/hbt/src/mon/Filter.h
@@ -218,9 +218,9 @@ struct BinaryOp : public FilterChain::Step {
 
           for (size_t s = 0; s < b_sel_slices.size(); ++s) {
             if constexpr (BinaryOpType::Or == kType) {
-              new_sel_slices[s] = new_sel_slices[s] | b_sel_slices[s];
+              new_sel_slices[s] = new_sel_slices[s] || b_sel_slices[s];
             } else if (BinaryOpType::And == kType) {
-              new_sel_slices[s] = new_sel_slices[s] & b_sel_slices[s];
+              new_sel_slices[s] = new_sel_slices[s] && b_sel_slices[s];
             } else if (BinaryOpType::Xor == kType) {
               new_sel_slices[s] = new_sel_slices[s] ^ b_sel_slices[s];
             }


### PR DESCRIPTION
Summary:
With LLVM-15, `&&` and `||` are required for boolean operands, rather than `&` and `|` which can be confused for bitwise operations. Fixing such ambiguity helps makes our code more readable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D42347735

