### PR TITLE
support perf collection using hbt

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -303,6 +303,19 @@ class Monitor {
     return it->second;
   }
 
+  bool eraseCountReader(const MuxGroupId& mux_group_id, const ElemId& elem_id) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if (!count_readers_.count(elem_id)) {
+      return false;
+    }
+    if (!removeMuxEntry_(mux_group_id, elem_id)) {
+      return false;
+    }
+    count_readers_.erase(elem_id);
+    sync_();
+    return true;
+  }
+
 #ifdef HBT_ENABLE_BPERF
   /// Read counts for all events opened in counting mode
   /// in all BPerfCountReaders.


### PR DESCRIPTION
Summary: Since HBT basically use the same interface to open perf/bperf counter, modify the current bperf counters management logic in TwTaskMonitor to also support opening perf counters using HBT.

Differential Revision: D41856027

