### PR TITLE
clear bperf attr map when dynolog starts

### DIFF
--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,7 +1,10 @@
+add_library(extra_types STATIC ExtraTypes.h)
+set_target_properties(extra_types PROPERTIES LINKER_LANGUAGE CXX)
 add_library(metric_series STATIC MetricSeries.h)
 set_target_properties(metric_series PROPERTIES LINKER_LANGUAGE CXX)
 add_library(metric_frame_ts_unit STATIC
     MetricFrameTsUnit.h MetricFrameTsUnit.cpp MetricFrameTsUnitInterface.h)
 add_library(metric_frame STATIC
     MetricFrame.h MetricFrame.cpp MetricFrameBase.h MetricFrameBase.cpp)
-target_link_libraries(metric_frame metric_series metric_frame_ts_unit)
+target_link_libraries(metric_frame
+    metric_series metric_frame_ts_unit extra_types)

--- a/dynolog/src/metric_frame/ExtraTypes.h
+++ b/dynolog/src/metric_frame/ExtraTypes.h
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+namespace facebook::dynolog {
+
+struct PerfReadValues {
+  uint64_t timeEnabled = 0;
+  uint64_t timeRunning = 0;
+  uint64_t count = 0;
+
+  std::string toString() const {
+    return std::string("<PerfReadValue timeEnabled=") +
+        std::to_string(timeEnabled) +
+        " timeRunning=" + std::to_string(timeRunning) +
+        " count=" + std::to_string(count) + ">";
+  }
+
+  PerfReadValues operator-(const PerfReadValues& other) const {
+    if (other.timeRunning > timeRunning || other.timeEnabled > timeEnabled ||
+        other.count > count) {
+      throw std::underflow_error(
+          std::string("lhs value ") + toString() +
+          " is smaller than rhs value " + other.toString());
+    }
+    PerfReadValues res;
+    res.timeEnabled = timeEnabled - other.timeEnabled;
+    res.timeRunning = timeRunning - other.timeRunning;
+    res.count = count - other.count;
+    return res;
+  }
+
+  template <typename R>
+  R getCount() const {
+    if (timeRunning == 0) {
+      return static_cast<R>(0);
+    }
+    return static_cast<R>(
+        static_cast<double>(count) * static_cast<double>(timeEnabled) /
+        static_cast<double>(timeRunning));
+  }
+
+  operator double() const {
+    return getCount<double>();
+  }
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -40,10 +40,12 @@ bool MetricFrameMap::eraseSeries(const std::string& name) {
 
 bool MetricFrameMap::addSamples(const MapSamplesT& samples, TimePoint time) {
   for (const auto& [name, sampleVar] : samples) {
-    auto seriesIt = series_.find(name);
-    if (seriesIt == series_.end()) {
-      continue;
+    if (!series_.count(name)) {
+      return false;
     }
+  }
+  for (const auto& [name, sampleVar] : samples) {
+    auto seriesIt = series_.find(name);
     auto& seriesVar = seriesIt->second;
     addSample(sampleVar, seriesVar);
   }

--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -52,6 +52,11 @@ std::optional<MetricFrameSlice> MetricFrameBase::slice(
   return MetricFrameSlice(*this, rangeMaybe.value());
 }
 
+template <bool flag = false>
+void static_no_match() {
+  static_assert(flag, "type provided to add samples is not supported");
+}
+
 void MetricFrameBase::addSample(
     const SampleVarT& sampleVar,
     MetricSeriesVar& seriesVar) {
@@ -62,6 +67,10 @@ void MetricFrameBase::addSample(
           arg->addSample(std::get<int64_t>(sampleVar));
         } else if constexpr (std::is_same_v<T, MetricSeriesDoublePtr>) {
           arg->addSample(std::get<double>(sampleVar));
+        } else if constexpr (std::is_same_v<T, MetricSeriesPerfReadValuePtr>) {
+          arg->addSample(std::get<PerfReadValues>(sampleVar));
+        } else {
+          static_no_match();
         }
       },
       seriesVar);

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -9,16 +9,21 @@
 #include "dynolog/src/metric_frame/MetricSeries.h"
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <variant>
 
 namespace facebook::dynolog {
 
-using SampleVarT = std::variant<int64_t, double>;
+using SampleVarT = std::variant<int64_t, double, PerfReadValues>;
 using MetricSeriesInt64Ptr = std::shared_ptr<MetricSeries<int64_t>>;
 using MetricSeriesDoublePtr = std::shared_ptr<MetricSeries<double>>;
-using MetricSeriesVar =
-    std::variant<MetricSeriesInt64Ptr, MetricSeriesDoublePtr>;
+using MetricSeriesPerfReadValuePtr =
+    std::shared_ptr<MetricSeries<PerfReadValues>>;
+using MetricSeriesVar = std::variant<
+    MetricSeriesInt64Ptr,
+    MetricSeriesDoublePtr,
+    MetricSeriesPerfReadValuePtr>;
 
 class MetricFrameSlice;
 

--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -16,6 +16,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "dynolog/src/metric_frame/ExtraTypes.h"
+
 namespace facebook::dynolog {
 
 template <typename T>

--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -303,6 +303,19 @@ class Monitor {
     return it->second;
   }
 
+  bool eraseCountReader(const MuxGroupId& mux_group_id, const ElemId& elem_id) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if (!count_readers_.count(elem_id)) {
+      return false;
+    }
+    if (!removeMuxEntry_(mux_group_id, elem_id)) {
+      return false;
+    }
+    count_readers_.erase(elem_id);
+    sync_();
+    return true;
+  }
+
 #ifdef HBT_ENABLE_BPERF
   /// Read counts for all events opened in counting mode
   /// in all BPerfCountReaders.

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -27,7 +27,7 @@ enum class BPerfEventType {
 // This map doesn't hold reference on any of these programs or maps.
 struct bperf_attr_map_key {
   __u32 size;
-  __u32 flags;
+  __u32 flags = 0;
   char name[BPERF_METRIC_NAME_SIZE];
   bperf_attr_map_key(std::string n, int s);
 };


### PR DESCRIPTION
Summary:
always remove bperf attribute map when dynolog starts.

the bperf attribute map is used to share opened bperf counters across processes. however there isn't a gc method to remove unused attribute in the map. this will cause attribute map becomes full so we are unable to open any new bperf counters.

since currently dynolog is the only processes managing bperf counters, it's safe to always clear this bperf map

Differential Revision: D42352138

