### PR TITLE
Remove unnecessary prof_fields arg from DCGM field group stub

### DIFF
--- a/dynolog/src/gpumon/DcgmApiStub.cpp
+++ b/dynolog/src/gpumon/DcgmApiStub.cpp
@@ -211,14 +211,10 @@ dcgmReturn_t dcgmGroupAddEntity_stub(
 
 dcgmReturn_t dcgmFieldGroupCreate_stub(
     dcgmHandle_t dcgmHandle,
-    std::vector<unsigned short> fieldIds,
-    const std::vector<unsigned short>& profFieldIds,
+    const std::vector<unsigned short>& fieldIds,
     char* fieldGroupName,
     dcgmFieldGrp_t* dcgmFieldGroupId) {
   if (auto api = detail::getDcgmAPI(); api) {
-    if (api->dcgm_major_version == 3) {
-      fieldIds.insert(fieldIds.end(), profFieldIds.begin(), profFieldIds.end());
-    }
     return api->dcgmFieldGroupCreate(
         dcgmHandle,
         fieldIds.size(),

--- a/dynolog/src/gpumon/DcgmApiStub.h
+++ b/dynolog/src/gpumon/DcgmApiStub.h
@@ -80,8 +80,6 @@ dcgmReturn_t dcgmGroupAddEntity_stub(
  * @param dcgmHandle         IN: DCGM handle
  * @param fieldIds           IN: Field IDs to be added to the newly-created
  * field group
- * @param profFieldIds       IN: Prof Field IDs to be added to the newly-created
- * field group, needed for DCGM 3.0
  * @param fieldGroupName     IN: Unique name for this group of fields. This must
  * not be the same as any existing field groups.
  * @param dcgmFieldGroupId  OUT: Handle to the newly-created field group
@@ -97,8 +95,7 @@ dcgmReturn_t dcgmGroupAddEntity_stub(
  */
 dcgmReturn_t dcgmFieldGroupCreate_stub(
     dcgmHandle_t dcgmHandle,
-    std::vector<unsigned short> fieldIds,
-    const std::vector<unsigned short>& profFieldIds,
+    const std::vector<unsigned short>& fieldIds,
     char* fieldGroupName,
     dcgmFieldGrp_t* dcgmFieldGroupId);
 

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -139,7 +139,7 @@ DcgmGroupInfo::DcgmGroupInfo(
     : updateIntervalMs_(updateIntervalMs) {
   init();
   createGroups();
-  createFieldGroups(fields, prof_fields);
+  createFieldGroups(fields);
   watchFields();
   watchProfFields(prof_fields);
 }
@@ -200,19 +200,14 @@ void DcgmGroupInfo::createGroups() {
 // TODO: make field ids configurable from configerator
 // TODO: make more than one field group configuration available
 void DcgmGroupInfo::createFieldGroups(
-    const std::vector<unsigned short>& fields,
-    const std::vector<unsigned short>& prof_fields) {
+    const std::vector<unsigned short>& fields) {
   if (isFailing() || fields.size() == 0) {
     // initialization failed, no group will be created
     return;
   }
   dcgmFieldGrp_t fieldGroupId;
   if (retCode_ = dcgmFieldGroupCreate_stub(
-          dcgmHandle_,
-          fields,
-          prof_fields,
-          (char*)fieldGroupName.c_str(),
-          &fieldGroupId);
+          dcgmHandle_, fields, (char*)fieldGroupName.c_str(), &fieldGroupId);
       retCode_ != DCGM_ST_OK) {
     errorCode_ = retCode_;
     LOG(ERROR) << "Failed dcgmFieldGroupCreate() return: " << retCode_

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -42,9 +42,7 @@ class DcgmGroupInfo {
       int updateIntervalMs);
   void init();
   void createGroups();
-  void createFieldGroups(
-      const std::vector<unsigned short>& fields,
-      const std::vector<unsigned short>& prof_fields);
+  void createFieldGroups(const std::vector<unsigned short>& fields);
   void watchFields();
   void watchProfFields(const std::vector<unsigned short>& prof_fields);
 


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/dynolog/commit/f95615e93867cd3d787a2e3a9089ea93c9fb42ff introduced unnecessary changes to the `dcgmFieldGroupCreate_stub` interface which caused issues internally - this patch reverts these changes.

