### PR TITLE
remove range v3 invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,6 @@ target_link_libraries(dynolog_lib PUBLIC pfs)
 add_subdirectory(third_party/fmt)
 target_link_libraries(dynolog_lib PUBLIC fmt::fmt)
 
-set(BUILD_SAMPLES OFF CACHE BOOL "")
-add_subdirectory(third_party/range-v3)
-
 if(USE_ODS_GRAPH_API)
   add_subdirectory(third_party/cpr)
   target_link_libraries(dynolog_lib PUBLIC cpr::cpr)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -14,8 +14,6 @@ if(USE_ODS_GRAPH_API)
   target_compile_options(dynolog_lib PUBLIC "-DUSE_GRAPH_ENDPOINT")
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/third_party/range-v3/include)
-
 target_link_libraries(dynolog_lib PUBLIC Monitor)
 target_link_libraries(dynolog_lib PUBLIC BuiltinMetrics)
 

--- a/hbt/src/common/CMakeLists.txt
+++ b/hbt/src/common/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(System System.h System.cpp)
 target_include_directories(System PUBLIC ${PROJECT_SOURCE_DIR})
 target_link_libraries(System PUBLIC fmt::fmt)
 target_link_libraries(System PUBLIC pfs)
-target_link_libraries(System PUBLIC range-v3::range-v3)
 target_link_libraries(System PUBLIC Defs)
 target_link_libraries(System PUBLIC CpuArch)
 

--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -9,9 +9,9 @@
 #include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 #include "pfs/procfs.hpp"
 
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <limits.h>
-#include <range/v3/view.hpp>
 #include <sys/prctl.h>
 #include <unistd.h>
 #include <algorithm>
@@ -484,7 +484,7 @@ inline std::optional<std::string> readProcFsCmdLine(pid_t tid) noexcept {
   pfs::procfs pfs;
   try {
     auto vec = pfs.get_task(tid).get_cmdline();
-    return vec | ranges::views::join(' ') | ranges::to<std::string>();
+    return fmt::format("{}", fmt::join(vec, " "));
   } catch (const std::system_error&) {
     return std::nullopt;
   }


### PR DESCRIPTION
Summary:
Remove usage of range-v3 in preparation to take out the dependency
This also avoid long file issue on Windows build of pytorch

Differential Revision: D42731018

