### PR TITLE
add logrotate to debian

### DIFF
--- a/scripts/debian/make_deb.sh
+++ b/scripts/debian/make_deb.sh
@@ -19,6 +19,8 @@ mkdir -p "$DEBDIR/usr/local/bin/"
 mkdir -p "$DEBDIR/usr/lib/systemd/system/"
 # control file goes here
 mkdir -p "$DEBDIR/DEBIAN"
+# logrotate config file goes here
+mkdir -p "$DEBDIR/etc/logrotate.d/"
 
 # Build the binaries
 IFS=" " read -r -a generated_bins <<< "$(./scripts/build.sh | tail -n 1)"
@@ -26,6 +28,7 @@ IFS=" " read -r -a generated_bins <<< "$(./scripts/build.sh | tail -n 1)"
 cp -p "${generated_bins[@]}" "$DEBDIR/usr/local/bin"
 cp -p scripts/dynolog.service "$DEBDIR/usr/lib/systemd/system"
 cp -p scripts/pytorch/unitrace.py "$DEBDIR/usr/local/bin"
+cp -p scripts/dynolog.conf "$DEBDIR/etc/logrotate.d"
 perl -p -e "s/__VERSION__/$VERSION/" scripts/debian/control > "$DEBDIR/DEBIAN/control"
 
 tree "$DEBDIR"

--- a/scripts/dynolog.conf
+++ b/scripts/dynolog.conf
@@ -1,0 +1,8 @@
+/var/log/dynolog.log {
+    daily
+    rotate 7
+    size 10M
+    dateext
+    compress
+    delaycompress
+}

--- a/scripts/rpm/make_rpm.sh
+++ b/scripts/rpm/make_rpm.sh
@@ -55,6 +55,7 @@ cp "${generated_bins[@]}" "dynolog-${VERSION}/"
 # Add static files
 cp "$SCRIPTS/dynolog.service" "dynolog-${VERSION}/"
 cp "$SCRIPTS/pytorch/unitrace.py" "dynolog-${VERSION}/"
+cp "$SCRIPTS/dynolog.conf" "dynolog-${VERSION}/"
 
 # Compress sources
 tar --create --file "dynolog-${VERSION}.tar.gz" "dynolog-${VERSION}"


### PR DESCRIPTION
Summary: This diff adds logrotate config to the debian package to avoid log running out of space

Differential Revision:
D43178075

Privacy Context Container: L1137347

