### PR TITLE
Metric values primitive for aggregating in space

### DIFF
--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(extra_types STATIC ExtraTypes.h ExtraTypes.cpp)
 add_library(metric_series STATIC MetricSeries.h)
 set_target_properties(metric_series PROPERTIES LINKER_LANGUAGE CXX)
+add_library(metric_values STATIC MetricValues.h)
+set_target_properties(metric_values PROPERTIES LINKER_LANGUAGE CXX)
 add_library(metric_frame_ts_unit STATIC
     MetricFrameTsUnit.h MetricFrameTsUnit.cpp MetricFrameTsUnitInterface.h)
 add_library(metric_frame STATIC

--- a/dynolog/src/metric_frame/MetricValues.h
+++ b/dynolog/src/metric_frame/MetricValues.h
@@ -1,0 +1,92 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <numeric>
+#include <optional>
+#include <vector>
+
+namespace facebook::dynolog {
+
+/* MetricValues:
+ *  An list of metric values that can be aggregated in various ways.
+ *  MetricValues is similar to MetricSeries except it helps to track
+ *  and aggregate values across space rather than time.
+ *  For example, aggregate cpu time across cpu cores.
+ */
+template <typename T>
+class MetricValues final {
+ public:
+  explicit MetricValues(size_t size = 0) : data_{std::vector<T>(size)} {}
+
+  explicit MetricValues(std::vector<T>&& values) : data_{std::move(values)} {}
+
+  size_t size() const {
+    return data_.size();
+  }
+
+  void push_back(T val) {
+    data_.push_back(val);
+  }
+
+  const T& at(size_t idx) {
+    return data_.at(idx);
+  }
+
+  const T& operator[](const size_t idx) const {
+    return *(begin() + idx);
+  }
+
+  void resize(const size_t size) {
+    data_.resize(size);
+  }
+
+  T sum() const {
+    return std::accumulate(begin(), end(), T{0});
+  }
+
+  std::optional<float> avg() const {
+    if (size() == 0) {
+      return std::nullopt;
+    }
+    return static_cast<float>(sum()) / size();
+  }
+
+  std::optional<T> percentile(float percentage) const {
+    if (size() == 0) {
+      return std::nullopt;
+    }
+    std::vector<T> dataCopy(begin(), end());
+    auto nthIdx = lround(percentage * (dataCopy.size() - 1));
+    std::nth_element(
+        dataCopy.begin(), dataCopy.begin() + nthIdx, dataCopy.end());
+    return dataCopy[nthIdx];
+  }
+
+  std::optional<std::pair<T, T>> minmax() const {
+    if (size() == 0) {
+      return std::nullopt;
+    }
+    const auto [min_it, max_it] = std::minmax_element(begin(), end());
+    return std::make_pair(*min_it, *max_it);
+  }
+
+ private:
+  auto begin() const {
+    return data_.begin();
+  }
+
+  auto end() const {
+    return data_.end();
+  }
+
+  std::vector<T> data_;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/tests/metric_frame/CMakeLists.txt
+++ b/dynolog/tests/metric_frame/CMakeLists.txt
@@ -2,6 +2,9 @@
 dynolog_add_test(MetricSeriesTest MetricSeriesTest.cpp)
 target_link_libraries(MetricSeriesTest PRIVATE metric_series)
 
+dynolog_add_test(MetricValuesTest MetricValuesTest.cpp)
+target_link_libraries(MetricValuesTest PRIVATE metric_values)
+
 dynolog_add_test(MetricFrameTsUnitTest MetricFrameTsUnitTest.cpp)
 target_link_libraries(MetricFrameTsUnitTest PRIVATE metric_frame_ts_unit)
 

--- a/dynolog/tests/metric_frame/MetricValuesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricValuesTest.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "dynolog/src/metric_frame/MetricValues.h"
+
+#include <optional>
+
+using namespace ::testing;
+using namespace ::facebook::dynolog;
+
+TEST(MetricValuesTest, basicTest) {
+  MetricValues<int> v(5);
+  EXPECT_EQ(v.size(), 5);
+  EXPECT_EQ(v[3], 0);
+
+  MetricValues<float> v1({0.1, 0.2, 0.3});
+  EXPECT_EQ(v1.size(), 3);
+
+  EXPECT_FLOAT_EQ(v1[0], 0.1);
+  EXPECT_FLOAT_EQ(v1[1], 0.2);
+
+  v1.resize(5);
+  EXPECT_EQ(v1.size(), 5);
+
+  v1.push_back(42);
+  EXPECT_EQ(v1.size(), 6);
+}
+
+TEST(MetricValuesTest, aggTest) {
+  MetricValues<uint32_t> v;
+
+  // empty lists will fail in some aggregations
+  EXPECT_FALSE(v.avg());
+  EXPECT_FALSE(v.minmax());
+  EXPECT_FALSE(v.percentile(0.5));
+  EXPECT_EQ(v.sum(), 0);
+
+  for (int i = 0; i < 5; i++) {
+    v.push_back(i);
+  }
+
+  EXPECT_EQ(v.sum(), 10);
+
+  auto minmaxMaybe = v.minmax();
+  EXPECT_TRUE(minmaxMaybe);
+  EXPECT_EQ(minmaxMaybe.value().first, 0);
+  EXPECT_EQ(minmaxMaybe.value().second, 4);
+
+  auto avgMaybe = v.avg();
+  EXPECT_TRUE(avgMaybe);
+  EXPECT_EQ(avgMaybe.value(), 2.0);
+
+  auto p50Maybe = v.percentile(0.5);
+  EXPECT_TRUE(p50Maybe);
+  EXPECT_EQ(p50Maybe.value(), 2.0);
+}


### PR DESCRIPTION
Summary: Add a primitive to aggregating values across space (devices / GPUs /cores). This can be used to compute aggregates across a set of measurements for the same quantity across different devices

Differential Revision: D43168464

