### PR TITLE
make gnerated perf events optional in the build, speed up builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(Dynolog VERSION 1.0)
 option(BUILD_TESTS "Build the unit tests" ON)
 option(USE_ODS_GRAPH_API "Enable logger to Meta ODS using public Graph API."
 ON)
+option(USE_JSON_GENERATED_PERF_EVENTS "Add performance events generated using
+Intel json spec, see hbt/src/perf_event/json_events/intel"
+OFF)
 
 file(READ "version.txt" DYNOLOG_VERSION)
 string(STRIP ${DYNOLOG_VERSION} DYNOLOG_VERSION)

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -14,7 +14,9 @@
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
 #include "hbt/src/perf_event/json_events/generated/CpuArch.h"
+#ifdef USE_JSON_GENERATED_PERF_EVENTS
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
+#endif // USE_JSON_GENERATED_PERF_EVENTS
 
 #include <map>
 #include <memory>
@@ -434,6 +436,7 @@ std::shared_ptr<PmuDeviceManager> makePmuDeviceManager() {
     //
     // Add Intel generated events
     //
+#ifdef USE_JSON_GENERATED_PERF_EVENTS
     try {
       generated::addEvents(
           cpu_info.cpu_model_num, cpu_info.cpu_step_num, *pmu_manager);
@@ -441,6 +444,7 @@ std::shared_ptr<PmuDeviceManager> makePmuDeviceManager() {
       HBT_LOG_ERROR() << "Could not load auto-generated events due to: \""
                       << e.what() << "\"";
     }
+#endif // USE_JSON_GENERATED_PERF_EVENTS
   }
 
   // Add predefined offcore events

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 add_compile_options("-Wconversion")
+if(USE_JSON_GENERATED_PERF_EVENTS)
+  add_definitions(-DUSE_JSON_GENERATED_PERF_EVENTS)
+endif()
 
 add_subdirectory(json_events)
 add_subdirectory(tests)
@@ -33,9 +36,11 @@ target_link_libraries(BuiltinMetrics
                         PUBLIC PmuDevices
                         PUBLIC System
                         PUBLIC IptEventBuilder
-                        PUBLIC JsonEvents
                         PUBLIC Metrics
                         PUBLIC CpuArch)
+if(USE_JSON_GENERATED_PERF_EVENTS)
+  target_link_libraries(BuiltinMetrics PUBLIC JsonEvents)
+endif()
 
 add_library(PerCpuBase PerCpuBase.h)
 target_link_libraries(PerCpuBase PUBLIC CpuEventsGroup)

--- a/hbt/src/perf_event/json_events/generated/CMakeLists.txt
+++ b/hbt/src/perf_event/json_events/generated/CMakeLists.txt
@@ -3,4 +3,6 @@
 add_library(CpuArch CpuArch.h)
 set_target_properties(CpuArch PROPERTIES LINKER_LANGUAGE CXX)
 
-add_subdirectory(intel)
+if(USE_JSON_GENERATED_PERF_EVENTS)
+  add_subdirectory(intel)
+endif()

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ echo "Running cmake"
 mkdir -p build; cd build;
 
 # note we can build without ninja if not available on this system
-cmake -DCMAKE_BUILD_TYPE=Release -G=Ninja "$@" ..
+cmake -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 
 echo "Binary files ="


### PR DESCRIPTION
Summary: Adds a build option for perf events auto generated via json. These are taking too long to build but are currently unused

Reviewed By: haowangludx

Differential Revision: D43215238

