### PR TITLE
Implement querying dynolog version via Rust CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 project(Dynolog VERSION 1.0)
 option(BUILD_TESTS "Build the unit tests" ON)
 option(USE_ODS_GRAPH_API "Enable logger to Meta ODS using public Graph API."
-ON)
+OFF)
 option(USE_JSON_GENERATED_PERF_EVENTS "Add performance events generated using
 Intel json spec, see hbt/src/perf_event/json_events/intel"
 OFF)

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -12,4 +12,5 @@
 pub mod dcgm;
 pub mod gputrace;
 pub mod status;
+pub mod version;
 // ... add new command modules here

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::net::TcpStream;
+
+use anyhow::Result;
+
+#[path = "utils.rs"]
+mod utils;
+
+// This module contains the handling logic for querying dyno version
+
+/// Get version info
+pub fn run_version(client: TcpStream) -> Result<()> {
+    utils::send_msg(&client, r#"{"fn":"getVersion"}"#).expect("Error sending message to service");
+
+    let resp_str = utils::get_resp(&client).expect("Unable to decode output bytes");
+
+    println!("response = {}", resp_str);
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,8 +42,10 @@ struct Opts {
 
 #[derive(Debug, Parser)]
 enum Command {
-    /// Check the status of dynolog process
+    /// Check the status of a dynolog process
     Status,
+    /// Check the version of a dynolog process
+    Version,
     /// Capture gputrace
     Gputrace {
         /// Job id of the application to trace
@@ -104,6 +106,7 @@ fn main() -> Result<()> {
 
     match cmd {
         Command::Status => status::run_status(dyno_client),
+        Command::Version => version::run_version(dyno_client),
         Command::Gputrace {
             job_id,
             pids,

--- a/dynolog/src/ServiceHandler.cpp
+++ b/dynolog/src/ServiceHandler.cpp
@@ -12,6 +12,10 @@ int ServiceHandler::getStatus() {
   return 1;
 }
 
+std::string ServiceHandler::getVersion() {
+  return DYNOLOG_VERSION;
+}
+
 GpuProfilerResult ServiceHandler::setKinetOnDemandRequest(
     int job_id,
     const std::set<int>& pids,

--- a/dynolog/src/ServiceHandler.h
+++ b/dynolog/src/ServiceHandler.h
@@ -22,6 +22,7 @@ class ServiceHandler {
       : dcgm_(dcgm) {}
   // returns the state of the service
   int getStatus();
+  std::string getVersion();
 
   GpuProfilerResult setKinetOnDemandRequest(
       int job_id,

--- a/dynolog/src/rpc/SimpleJsonServerInl.h
+++ b/dynolog/src/rpc/SimpleJsonServerInl.h
@@ -73,6 +73,9 @@ std::string SimpleJsonServer<TServiceHandler>::processOneImpl(
   if (request["fn"] == "getStatus") {
     int status = handler_->getStatus();
     response["status"] = status;
+  } else if (request["fn"] == "getVersion") {
+    std::string version = handler_->getVersion();
+    response["version"] = version;
   } else if (request["fn"] == "setKinetOnDemandRequest") {
     if (!request.contains("config") || !request.contains("pids")) {
       response["status"] = "failed";


### PR DESCRIPTION
Summary: We can now query the version of any running dynolog instances from a given host

Reviewed By: haowangludx

Differential Revision: D43269566

