### PR TITLE
Fix typos: hanlded -> handled

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -247,7 +247,7 @@ void populateGenericEventsSoftware(
       "alignment_faults",
       EventDef::Encoding{.code = PERF_COUNT_SW_ALIGNMENT_FAULTS},
       "Alignment faults handled by kernel",
-      "Alignment faults hanlded by kernel. "
+      "Alignment faults handled by kernel. "
       "These are instances where accesses are not aligned with pages. "
       "It usually has has a significant slowdown (100x or worse)."));
 


### PR DESCRIPTION
Summary:
I noticed 'hanlded' in a perf event definition. A quick search of fbcode shows that it is present elsewhere.

khan_typo

Reviewed By: jordalgo

Differential Revision: D43332458

