### PR TITLE
Update docs to use rpm/deb package

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,5 +23,9 @@ mkdir -p build; cd build;
 cmake -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 
+mkdir -p bin
+ln -sf "$PWD/dynolog/src/dynolog" bin/dynolog
+ln -sf "$PWD/release/dyno" bin/dyno
+
 echo "Binary files ="
 echo "$PWD/dynolog/src/dynolog" "$PWD/release/dyno"


### PR DESCRIPTION
Summary:
Updates readme with getting started, now that we have releases we can directly download and install RPMs or debian package.
Pass through the documentation, added few badges too

Differential Revision: D43365495

