### PR TITLE
Initial support for adding internal HW metrics

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -4,6 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "hbt/src/perf_event/AmdEvents.h"
+#ifdef FACEBOOK
+#include "hbt/src/perf_event/fb/AmdEvents.h"
+#endif
 
 namespace facebook::hbt::perf_event {
 
@@ -35,6 +38,9 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
   switch (cpu_info.cpu_arch) {
     case CpuArch::MILAN:
       milan::addEvents(pmu_manager);
+#ifdef FACEBOOK
+      milan::addEventsFb(pmu_manager);
+#endif
       break;
     default:
       HBT_LOG_ERROR()

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -162,6 +162,10 @@ constexpr PmuMsr kL3FillRdCnt{.amdL3 = {.event = 0x9A, .unitMask = 0x1F}};
 
 } // namespace amd_msr
 
-void addAmdEvents(const CpuInfo& info, PmuDeviceManager& pmu_manager);
+namespace milan {
+void addEvents(PmuDeviceManager& pmu_manager);
+}
+
+void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager);
 
 } // namespace facebook::hbt::perf_event


### PR DESCRIPTION
Summary: To add metrics for internal use provide a compiler flag to separate defining and including these metrics

Differential Revision: D43543109

