### PR TITLE
support override by kernel release using CustomCondition

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -409,11 +409,19 @@ struct Kernel {
   static Kernel create() {
     struct utsname buffer;
     int err = uname(&buffer);
-    std::string release;
 
     HBT_THROW_SYSTEM_IF(err != 0, errno)
         << "uname threw an error when trying to identify the kernel image";
     return Kernel(buffer.release);
+  }
+
+  static std::optional<Kernel> createNoThrow() {
+    try {
+      return create();
+    } catch (const std::system_error& e) {
+      HBT_LOG_ERROR() << e.what();
+    }
+    return std::nullopt;
   }
 
   std::optional<std::string> image_expected_path() const {


### PR DESCRIPTION
Summary:
kernel release is not supported by ConfigeratorOverrideAPI by default by we could add a general support of this in dynolog using CustomCondition.

after this change, one could use something like below to specify the kernel version where override config need to be used
```
"conditions": {"custom": {"KERNEL_RELEASE_REGEXP": "5.12.0-0_fbk9"}}
```

Reviewed By: bigzachattack, jj10306

Differential Revision: D43761118

