### PR TITLE
Add helper for reading the effective cpuset for a cgroup

### DIFF
--- a/hbt/src/common/System.cpp
+++ b/hbt/src/common/System.cpp
@@ -242,6 +242,10 @@ CpuSet CpuSet::makeFromCpuSet(cpu_set_t cpu_set) {
   return makeCpuSet(cpu_set);
 }
 
+CpuSet CpuSet::makeFromCpusList(const std::string& cpuList) {
+  return makeCpuSet(parseCpusList(cpuList));
+}
+
 CpuSet CpuSet::getOrDefault(std::optional<CpuSet> opt) {
   if (opt.has_value()) {
     return *opt;

--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -228,6 +228,7 @@ struct CpuSet {
   static CpuSet makeAllOnline();
 
   static CpuSet makeFromCpuSet(cpu_set_t cpu_set);
+  static CpuSet makeFromCpusList(const std::string& cpuList);
 
   template <class TCont>
   static cpu_set_t make_cpu_set_t(const TCont& s) {

--- a/hbt/src/common/tests/SystemTest.cpp
+++ b/hbt/src/common/tests/SystemTest.cpp
@@ -171,6 +171,67 @@ TEST(ParseCpu, CpuList) {
   }
 }
 
+TEST(CpuSet, MakeFromCpusList) {
+  // Skip on CI due to offline CPUs
+  // Error = <CpuSet max_cpu_id: 1 max_cpu_id_online: 1 cpus: 1 > unknown file:
+  // Failure
+  if (std::getenv("GITHUB_WORKFLOW") != nullptr) {
+    GTEST_SKIP() << "Skipping CPU set test on CI.";
+  }
+
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("");
+    EXPECT_EQ(cpuSet.asSet().size(), 0);
+  }
+
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("\n");
+    EXPECT_EQ(cpuSet.asSet().size(), 0);
+  }
+
+  {
+    auto cpuSet = CpuSet::makeFromCpusList(" \n ");
+    EXPECT_EQ(cpuSet.asSet().size(), 0);
+  }
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("5");
+    EXPECT_EQ(cpuSet.asSet().size(), 1);
+    EXPECT_TRUE(cpuSet.hasCpu(5));
+  }
+
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("0-1");
+    EXPECT_EQ(cpuSet.asSet().size(), 2);
+    EXPECT_TRUE(cpuSet.hasCpu(0));
+    EXPECT_TRUE(cpuSet.hasCpu(1));
+  }
+
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("3, 0-1");
+    EXPECT_EQ(cpuSet.asSet().size(), 3);
+    EXPECT_TRUE(cpuSet.hasCpu(0));
+    EXPECT_TRUE(cpuSet.hasCpu(1));
+    EXPECT_TRUE(cpuSet.hasCpu(3));
+  }
+  {
+    auto cpuSet = CpuSet::makeFromCpusList("4-5, 0-1,7");
+    EXPECT_EQ(cpuSet.asSet().size(), 5);
+    EXPECT_TRUE(cpuSet.hasCpu(0));
+    EXPECT_TRUE(cpuSet.hasCpu(1));
+    EXPECT_TRUE(cpuSet.hasCpu(4));
+    EXPECT_TRUE(cpuSet.hasCpu(5));
+    EXPECT_TRUE(cpuSet.hasCpu(7));
+  }
+  {
+    auto cpuSet = CpuSet::makeFromCpusList(" 0,2,  4, 6");
+    EXPECT_EQ(cpuSet.asSet().size(), 4);
+    EXPECT_TRUE(cpuSet.hasCpu(0));
+    EXPECT_TRUE(cpuSet.hasCpu(2));
+    EXPECT_TRUE(cpuSet.hasCpu(4));
+    EXPECT_TRUE(cpuSet.hasCpu(6));
+  }
+}
+
 TEST(Pow2, isPow2) {
   for (uint64_t i = 0; i < 63; ++i) {
     EXPECT_TRUE(isPow2(1ull << i));


### PR DESCRIPTION
Summary: Some per-task metrics will need to aggregate per-CPU information for the CPUs pinned by the allotment.

Reviewed By: briancoutinho, haowangludx

Differential Revision: D44146394

