### PR TITLE
workaround vrh task handle longer than max unix socket path

### DIFF
--- a/dynolog/src/ipcfabric/Endpoint.h
+++ b/dynolog/src/ipcfabric/Endpoint.h
@@ -67,13 +67,13 @@ struct EndPointCtxt {
 
 template <size_t kMaxNumFds = 0>
 class EndPoint final {
+  using TCtxt = EndPointCtxt<kMaxNumFds>;
+
+ public:
   // Maximum defined in man unix, but minus 2 because abstract sockets, first
   // and last are '\0'.
   constexpr static size_t kMaxNameLen = 108 - 2;
 
-  using TCtxt = EndPointCtxt<kMaxNumFds>;
-
- public:
   explicit EndPoint(const std::string& address) {
     socket_fd_ = socket(AF_UNIX, SOCK_DGRAM, 0);
     if (socket_fd_ == -1) {


### PR DESCRIPTION
Summary:
UNIX socket has limit on socket name to be 108, there are tupperware task that has longer than 108 characters.

This diff
- truncates the construction of DynoIPCLogger to last 106 bytes of the tw task name, because the region/cluster info is usually not useful for identifying the task
- change the matching logic in GPU and Task module to be sub-string

Reviewed By: jj10306

Differential Revision: D44050720

