### PR TITLE
Update Milan L3 counters to use recommendations from PPR

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -29,6 +29,15 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "Instructions retired.",
           "Instructions executed. Does not count speculative execution."),
       std::vector<EventId>({"retired_instructions", "retired-instructions"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l3_cache_misses",
+          EventDef::Encoding{.code = amd_msr::kL3CacheMisses.val},
+          "L3 Cache misses",
+          "L3 Cache misses"),
+      std::vector<EventId>({"l3-cache-misses"}));
 }
 } // namespace milan
 

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -157,8 +157,42 @@ constexpr PmuMsr kIcMabRequestsDemad{
     .amdCore = {.event = 0x85, .event_11_8 = 0x2}};
 
 // L3 counters
-constexpr PmuMsr kL3FillRdRespLat{.amdL3 = {.event = 0x90}};
-constexpr PmuMsr kL3FillRdCnt{.amdL3 = {.event = 0x9A, .unitMask = 0x1F}};
+constexpr PmuMsr kL3CacheAccess{
+    .amdL3 = {
+        .event = 0x04,
+        .unitMask = 0xFF,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x0,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3CacheMisses{
+    .amdL3 = {
+        .event = 0x04,
+        .unitMask = 0x01,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x0,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3FillRdRespLat{
+    .amdL3 = {
+        .event = 0x90,
+        .unitMask = 0x00,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x0,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3FillRdCnt{
+    .amdL3 = {
+        .event = 0x9A,
+        .unitMask = 0x1F,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x0,
+        .threadMask = 0x3}};
 
 } // namespace amd_msr
 


### PR DESCRIPTION
Summary: Update/Add L3 Counters based on the PPR for Milan processors

Differential Revision: D44489085

