### PR TITLE
Fix AMD L2 Prefetches metric and Code cleanups

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -46,6 +46,7 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
   // to addEvents in json_events/generated/intel/JsonEvents.h
   switch (cpu_info.cpu_arch) {
     case CpuArch::MILAN:
+    case CpuArch::BERGAMO:
       milan::addEvents(pmu_manager);
 #ifdef FACEBOOK
       milan::addEventsFb(pmu_manager);

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -120,10 +120,6 @@ constexpr PmuMsr kUnhaltedCycles{.amdCore = {.event = 0x76}};
 constexpr PmuMsr kL1ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x7}}; // Same as e=0x60,u=0x10
 
-// L1 dCache
-constexpr PmuMsr kL1DCacheMisses{
-    .amdCore = {.event = 0x41, .unitMask = 0x1f}}; // AMD recommended way
-
 // L2 Cache
 constexpr PmuMsr kL2ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x1}};
@@ -134,10 +130,12 @@ constexpr PmuMsr kL2DCacheMisses{.amdCore = {.event = 0x64, .unitMask = 0x8}};
 // L2 with Prefetcher
 constexpr PmuMsr kL2Accesses{.amdCore = {.event = 0x64, .unitMask = 0x7f}};
 constexpr PmuMsr kL2Misses{.amdCore = {.event = 0x64, .unitMask = 0x9}};
-constexpr PmuMsr kL2PrefetcherHitsInL2{.amdCore = {.event = 0x70}};
-constexpr PmuMsr kL2PrefetcherHitsInL3{.amdCore = {.event = 0x71}};
-constexpr PmuMsr kL2PrefetcherMissesInL3{.amdCore = {.event = 0x72}};
-
+constexpr PmuMsr kL2PrefetcherHitsInL2{
+    .amdCore = {.event = 0x70, .unitMask = 0x1f}};
+constexpr PmuMsr kL2PrefetcherHitsInL3{
+    .amdCore = {.event = 0x71, .unitMask = 0x1f}};
+constexpr PmuMsr kL2PrefetcherMissesInL3{
+    .amdCore = {.event = 0x72, .unitMask = 0x1f}};
 // Flops
 constexpr PmuMsr kRetiredX87Flops{.amdCore = {.event = 0x2, .unitMask = 0x7}};
 constexpr PmuMsr kRetiredSseAvxFlops{

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <iostream>
+
 namespace facebook::hbt::perf_event {
 
 enum class CpuFamily { AMD, INTEL, UNKNOWN };
@@ -37,6 +40,8 @@ inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
 enum class CpuArch {
   // AMD Architectures
   MILAN,
+  GENOA,
+  BERGAMO,
   // Intel Architectures Sorted by model id.
   BDW,
   BDW_DE,
@@ -62,6 +67,10 @@ inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
   switch (ev) {
     case CpuArch::MILAN:
       return os << "MILAN";
+    case CpuArch::GENOA:
+      return os << "GENOA";
+    case CpuArch::BERGAMO:
+      return os << "BERGAMO";
     case CpuArch::BDW:
       return os << "BDW";
     case CpuArch::BDW_DE:
@@ -107,8 +116,12 @@ inline CpuArch makeCpuArch(
   auto cpu_family = makeCpuFamily(cpu_family_num);
   if (cpu_family == CpuFamily::AMD) {
     switch (cpu_model_num) {
-      case 1:
+      case 0x01:
         return CpuArch::MILAN;
+      case 0x11:
+        return CpuArch::GENOA;
+      case 0xA0:
+        return CpuArch::BERGAMO;
     }
   } else if (cpu_family == CpuFamily::INTEL) {
     switch (cpu_model_num) {


### PR DESCRIPTION
Summary:
* Add unitMasks for L2 Prefetcher code
* Add Bergamo and Genoa CPU models
* Minor code fixups

Differential Revision: D44671393

