### PR TITLE
add thread counter reader

### DIFF
--- a/hbt/src/common/Defs.h
+++ b/hbt/src/common/Defs.h
@@ -225,6 +225,16 @@ class LogEntry final {
 
 #define __HBT_EXPAND_OPD(opd) HBT_STRINGIFY(opd) << " (" << (opd) << ")"
 
+#ifdef NDEBUG
+#define HBT_DLOG_INFO() \
+  while (false)         \
+  HBT_LOG_INFO()
+#else
+// Add a debug mode specific log info. Warnings and errors should always be
+// logged.
+#define HBT_DLOG_INFO() HBT_LOG_INFO()
+#endif
+
 //
 // Debug checks.
 // Note that non-debug checks are not provided because hbt developers

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -49,6 +49,10 @@ target_link_libraries(PerCpuBase PUBLIC Metrics)
 add_library(PerCpuCountReader PerCpuCountReader.h)
 target_link_libraries(PerCpuCountReader PUBLIC PerCpuBase)
 
+add_library(ThreadCountReader ThreadCountReader.h)
+target_link_libraries(ThreadCountReader PUBLIC CpuEventsGroup)
+target_link_libraries(ThreadCountReader PUBLIC Metrics)
+
 add_library(PerCpuSampleGeneratorBase PerCpuSampleGeneratorBase.h)
 target_link_libraries(PerCpuSampleGeneratorBase PUBLIC PerCpuBase)
 

--- a/hbt/src/perf_event/PerCpuCountReader.h
+++ b/hbt/src/perf_event/PerCpuCountReader.h
@@ -99,7 +99,8 @@ class PerCpuCountReader : public PerCpuBase<CpuCountReader> {
   }
 
   size_t getNumEvents() const {
-    return *this->metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch);
+    return this->metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch)
+        .value_or(0);
   }
 
   /// Utility method to create ReadValues structure of the right size.

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -222,7 +222,7 @@ void parseSysFsPmuFormat_(fs::directory_entry dentry, PmuDevice& pmu_device) {
 void parseSysFsPmuCaps_(fs::directory_entry dentry, PmuDevice& pmu_device) {
   auto caps_dir = dentry.path() / "caps";
   if (!fs::is_directory(caps_dir)) {
-    HBT_LOG_INFO() << caps_dir << " is not a directory";
+    HBT_DLOG_INFO() << caps_dir << " is not a directory";
     return;
   }
   for (const auto& cap_entry : fs::directory_iterator(caps_dir)) {

--- a/hbt/src/perf_event/ThreadCountReader.h
+++ b/hbt/src/perf_event/ThreadCountReader.h
@@ -1,0 +1,121 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/CpuEventsGroup.h"
+#include "hbt/src/perf_event/Metrics.h"
+
+#include <memory>
+
+namespace facebook::hbt::perf_event {
+
+//
+// CRTP extension of CpuEventsGroupBase<>.
+//
+// Read counters from perf_event groups.
+// It relies on perf_events opened on counting mode.
+//
+
+class ThreadCountReaderImpl
+    : public CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting> {
+ public:
+  using TBase = CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting>;
+
+  /// Convenience type definition to create structure to store read values.
+  using ReadValues = GroupReadValues<mode::Counting>;
+
+  ThreadCountReaderImpl(
+      const std::vector<std::string>& ev_names,
+      EventConfs event_confs,
+      pid_t pid = 0)
+      : TBase{0 /*cpu*/, pid, -1 /*cgroup_fd*/, event_confs},
+        event_names_{ev_names} {}
+
+  void enableImpl() {}
+
+  void disableImpl() {}
+
+  void open(bool pinned) {
+    this->open_counting_(0, pinned, true /*thread*/);
+    HBT_THROW_ASSERT_IF(!isOpen());
+  }
+
+  const auto& getEventNames() const noexcept {
+    return event_names_;
+  }
+
+ protected:
+  std::vector<std::string> event_names_;
+};
+
+// A thread level counting mode performance counter
+//  (1) pid argument can be left 0 (default) to measure the current thread
+//      or set to pid/tid of thread you wish to track.
+//  (2) Currently, this will track the thread on all CPUs.
+class ThreadCountReader final : public ThreadCountReaderImpl {
+ public:
+  using TBase = ThreadCountReaderImpl;
+  using ReadValues = ThreadCountReaderImpl::ReadValues;
+
+  ThreadCountReader(
+      std::shared_ptr<const MetricDesc> metric_desc_in,
+      std::shared_ptr<const PmuDeviceManager> pmu_manager_in,
+      pid_t pid = 0)
+      : TBase{
+        metric_desc_in->eventNicknames(pmu_manager_in->cpuInfo.cpu_arch),
+        metric_desc_in->makeNoCpuTopologyConfs(*pmu_manager_in),
+        pid
+      },
+        pmu_manager{pmu_manager_in},
+        metric_desc{metric_desc_in} {
+    HBT_DCHECK(pmu_manager != nullptr);
+    HBT_DCHECK(metric_desc != nullptr);
+  }
+
+  size_t getNumEvents() const {
+    return metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch).value_or(0);
+  }
+
+  /// Utility method to create ReadValues structure of the right size.
+  ReadValues makeReadValues() const {
+    return ReadValues{getNumEvents()};
+  }
+
+  using TBase::read;
+
+  std::optional<ReadValues> read() const {
+    auto rv = makeReadValues();
+    if (TBase::read(rv)) {
+      return std::make_optional(rv);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  const std::shared_ptr<const PmuDeviceManager> pmu_manager;
+  const std::shared_ptr<const MetricDesc> metric_desc;
+};
+
+inline std::ostream& operator<<(
+    std::ostream& os,
+    const ThreadCountReader& reader) {
+  os << "Thread Counter Reader \"" << reader.metric_desc->id;
+  if (reader.isEnabled()) {
+    os << "\" active.\n";
+    auto val = reader.read();
+    if (val.has_value()) {
+      os << *val << "\n";
+    } else {
+      os << " Failed to read\n";
+    }
+  } else {
+    os << "\" inactive.\n";
+  }
+  return os;
+}
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/tests/ThreadCountReaderTest.cpp
+++ b/hbt/src/perf_event/tests/ThreadCountReaderTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "hbt/src/perf_event/ThreadCountReader.h"
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/BuiltinMetrics.h"
+
+#include <gtest/gtest.h>
+#include <sched.h>
+#include <chrono>
+
+using namespace facebook::hbt;
+using namespace facebook::hbt::perf_event;
+
+int64_t myRand() {
+  // seed the generator with the current time
+  static int64_t seed =
+      std::chrono::system_clock::now().time_since_epoch().count() / 1000000;
+
+  // constants for the linear congruential method
+  const int64_t a = 1664525;
+  const int64_t c = 1013904223;
+  const int64_t m = 4294967296; // 2^32
+
+  // calculate the next random number
+  seed = (a * seed + c) % m;
+
+  return seed;
+}
+
+TEST(ThreadCountReader, SmokeTest) {
+  // XXX duplicated in PerCpuGeneratorsTest.cpp, refactor to common file?
+
+  // Create a metric to use in this test.
+  // Alternatively, you can create a Metrics object
+  // with makeAvailableMetrics() and call
+  // Metrics::getMetricDesc(metric_id).
+  // Default metrics are populated in hbt/src/perf_event/BuiltinMetrics.cpp
+  auto m = std::make_shared<MetricDesc>(
+      "ipc",
+      "IPC including user but excluding kernel, and hypervisor.",
+      "Intructions-per-Cycle (IPC) including user but excluding kernel, and hypervisor. ",
+      std::map<TOptCpuArch, EventRefs>{
+          {// We'll use generic events so no need to specify CPU architecture.
+           std::nullopt,
+           EventRefs{
+               EventRef{
+                   .nickname = "inst",
+                   // Using Linux's kernel generic events.
+                   .pmu_type = PmuType::generic_hardware,
+                   // The event-name as defined in PMU of generic events.
+                   .event_id = "retired_instructions",
+                   // Capture user-space only.
+                   // See EventExtraAttr for other convenience factory
+                   // functions. Or create your own EventExtraAttr.
+                   .extra_attr = EventExtraAttr::makeUserOnly()},
+               EventRef{
+                   .nickname = "cycles",
+                   // Using Linux's kernel generic events.
+                   .pmu_type = PmuType::generic_hardware,
+                   // The event-name as defined in PMU of generic events.
+                   .event_id = "cpu_cycles",
+                   // Capture user-space only.
+                   // See EventExtraAttr for other convenience factory
+                   // functions. Or create your own EventExtraAttr.
+                   .extra_attr = EventExtraAttr::makeUserOnly()}}}},
+      0, // 0 sampling_period is ok because we do not require sampling.
+      System::Permissions{}, // No special system permissions required for these
+                             // events.
+      std::vector<std::string>{} // No post-processing dives
+  );
+
+  auto pmu_manager = makePmuDeviceManager();
+  auto cpu_arch = pmu_manager->cpuInfo.cpu_arch;
+
+  HBT_DCHECK(pmu_manager != nullptr);
+
+  // Monitor events for current thread.
+  ThreadCountReader g(m, pmu_manager);
+
+  // Open without pinning the events.
+  g.open(false);
+  g.enable();
+  ASSERT_TRUE(g.isEnabled());
+
+  // Object to store data read from counters.
+  // Definition comes from GroupReadValues<>.
+  auto rv = g.makeReadValues();
+  ASSERT_TRUE(m->getNumEvents(cpu_arch).has_value());
+
+  // Events always keep creation order in EventRefs,
+  // so we could also just use 0 and 1 rather than query the indices.
+  ASSERT_TRUE(m->eventIdxFromNicknames(cpu_arch, "cycles").has_value());
+  auto cycles_ev_idx = m->eventIdxFromNicknames(cpu_arch, "cycles").value();
+  ASSERT_TRUE(m->eventIdxFromNicknames(cpu_arch, "inst").has_value());
+  auto inst_ev_idx = m->eventIdxFromNicknames(cpu_arch, "inst").value();
+  ASSERT_EQ(cycles_ev_idx, 1);
+  ASSERT_EQ(inst_ev_idx, 0);
+
+  // Do some work
+  int iters = 1000;
+  int64_t cur_rand = 0, prev_rand = 0;
+  while (iters--) {
+    prev_rand = cur_rand;
+    cur_rand = myRand();
+  }
+
+  // Random numbers should not be same in a row
+  ASSERT_NE(prev_rand, cur_rand);
+
+  // Read thread level counters.
+  auto v = g.read(rv);
+  ASSERT_TRUE(v);
+  ASSERT_GT(rv.getTimeRunning(), 0);
+  ASSERT_GT(rv.getTimeEnabled(), 0);
+  ASSERT_GT(rv.getCount(inst_ev_idx), 100);
+  ASSERT_GT(rv.getCount(cycles_ev_idx), 100);
+  ASSERT_LE(rv.getTimeEnabled(), rv.getTimeRunning());
+
+  // Easy to use version that always creates a ReadValues objecct.
+  auto rrv = g.read();
+  ASSERT_TRUE(rrv.has_value());
+  ASSERT_EQ(rrv->getNumEvents(), rv.getNumEvents());
+
+  g.disable();
+  g.close();
+}


### PR DESCRIPTION
Summary:
Adds thread level counter for hbt
* Set cpu = -1 to make this thread based perf even
https://man7.org/linux/man-pages/man2/perf_event_open.2.html
* Create Thread counter class specializing `CpuEventGroupBase`
* Avoid verbose prints on PMU sysfs discovery reading?

Differential Revision: D44764690

