### PR TITLE
Fix aarch64 build

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -438,9 +438,22 @@ struct Kernel {
   explicit Kernel(std::string release) : release(release) {}
 };
 
-// XXX: Verify that this intrinsic exists in __aarch64__ (ARM).
 inline TimeStamp rdtsc() {
+#if defined(__x86_64__)
   return __rdtsc();
+#elif defined(__aarch64__)
+  uint64_t val;
+
+  /* According to ARM DDI 0487F.c, from Armv8.0 to Armv8.5 inclusive, the
+   * system counter is at least 56 bits wide; from Armv8.6, the counter
+   * must be 64 bits wide.  So the system counter could be less than 64
+   * bits wide and it is attributed with the flag 'cap_user_time_short'
+   * is true.
+   */
+  __asm__ volatile("mrs %0, cntvct_el0" : "=r"(val));
+
+  return val;
+#endif
 }
 
 #if defined(__i386__) || defined(__x86_64__)


### PR DESCRIPTION
Summary: aarch64 does not support __rdtsc()

Reviewed By: dmm-fb

Differential Revision: D44916757

