### PR TITLE
Add reducer function to metrics

### DIFF
--- a/hbt/src/common/Defs.h
+++ b/hbt/src/common/Defs.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -35,6 +36,13 @@ inline pid_t getpid() noexcept {
 }
 
 #endif
+
+// A metric could define a function to reduce multiple event values.
+// ReducerFunc type is used as the reducer functor for these values.
+// - note that events will always be uint64_t as that is the type
+//   used by the kernel perf_event system call.
+using ReducerFunc =
+    std::function<std::optional<double>(const std::vector<uint64_t>&)>;
 
 // Branch hint macros. C++20 will include them as part of language.
 #define __hbt_likely(x) __builtin_expect(!!(x), 1)

--- a/hbt/src/perf_event/BuiltinMetrics.h
+++ b/hbt/src/perf_event/BuiltinMetrics.h
@@ -20,4 +20,6 @@ struct HwCacheEventInfo {
       : id(id), description(descrption) {}
 };
 
+const ReducerFunc& getAddReducer();
+const ReducerFunc& getRateReducer();
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -480,6 +480,18 @@ struct GroupReadValues {
     return v;
   }
 
+  /// Apply a reduction on the counts
+  std::optional<double> getReducedCount(const ReducerFunc& reducer) const {
+    const auto vals = this->getCounts();
+    if (vals.size() == 1) {
+      return vals[0];
+    }
+    if (!reducer) {
+      return std::nullopt;
+    }
+    return reducer(vals);
+  }
+
   /// The fraction of time enabled that this counter has been running.
   /// It can be less than one due to Hardware Performance Counter multiplexing.
   float getRunningRatio() const {

--- a/hbt/src/perf_event/Metrics.cpp
+++ b/hbt/src/perf_event/Metrics.cpp
@@ -48,6 +48,11 @@ std::ostream& operator<<(std::ostream& os, const MetricDesc& desc) {
     }
     os << "]";
   }
+  if (desc.reducer) {
+    os << "\n has reducer";
+  } else {
+    os << "\n does not have reducer";
+  }
   return os << "\n";
 }
 

--- a/hbt/src/perf_event/Metrics.h
+++ b/hbt/src/perf_event/Metrics.h
@@ -50,6 +50,7 @@ struct MetricDesc {
   uint64_t default_sampling_period;
   System::Permissions req_permissions;
   std::vector<std::string> dives;
+  ReducerFunc reducer;
 
   MetricDesc(
       MetricId id,
@@ -58,14 +59,16 @@ struct MetricDesc {
       const std::map<TOptCpuArch, EventRefs>& event_refs_by_arch,
       uint64_t default_sampling_period,
       const System::Permissions& req_permissions,
-      const std::vector<std::string> dives)
+      const std::vector<std::string>& dives,
+      ReducerFunc reducer = nullptr)
       : id{id},
         brief_desc{brief_desc},
         full_desc{full_desc},
         event_refs_by_arch{event_refs_by_arch},
         default_sampling_period{default_sampling_period},
         req_permissions{req_permissions},
-        dives{dives} {
+        dives{dives},
+        reducer{reducer} {
     HBT_ARG_CHECK_GT(id.size(), 0);
     HBT_ARG_CHECK_GT(brief_desc.size(), 0);
     HBT_ARG_CHECK_GT(full_desc.size(), 0);


### PR DESCRIPTION
Summary:
## About
We can define hbt metrics in terms of a multiple events. However, we lack a way to specify the formula to combine these events,
today that is done manually outside in code or by the user directly.
We add an optional "reducer" functor to our metric definition that helps identify how to reduce performance events..

Included
* Reducer functor type definition and adding it to Metric class (Metric.h/.cpp.
* Perf ReadValues leverages the reducer functor to combine multiple events (CpuEventsGroup.h).
* Include a simple addition and rate reducer (BuiltinMetrics.h).
* Use the rate reducer in instructions/cycle.

Differential Revision: D45092289

