### PR TITLE
Add perf_event read value diff function, reset as optional on enable, update AMD Events for L2 misses

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -33,6 +33,33 @@ void addEvents(PmuDeviceManager& pmu_manager) {
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
           PmuType::cpu,
+          "l2_cache_misses_no_prefetcher",
+          EventDef::Encoding{.code = amd_msr::kL2Misses.val},
+          "L2 cache misses excluding L2 prefetcher",
+          "L2 Data and Instruction cache misses excluding L2 prefetcher."),
+      std::vector<EventId>({"l2-cache-misses-no-prefetcher"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l1_l2_pf_hit_in_l3",
+          EventDef::Encoding{.code = amd_msr::kL1AndL2PrefetcherHitsInL3.val},
+          "L1 and L2 prefetch hits in L3",
+          "L1 and L2 prefetcher requests that hit in L3."),
+      std::vector<EventId>({"l2-pf-hit-in-l3"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l1_l2_pf_miss_in_l3",
+          EventDef::Encoding{.code = amd_msr::kL1AndL2PrefetcherMissesInL3.val},
+          "L1 and L2 prefetch misses in L3",
+          "L1 and L2 prefetcher requests that miss in L3"),
+      std::vector<EventId>({"l2-pf-miss-in-l3"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
           "l3_cache_misses",
           EventDef::Encoding{.code = amd_msr::kL3CacheMisses.val},
           "L3 Cache misses",

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -136,6 +136,11 @@ constexpr PmuMsr kL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0x1f}};
 constexpr PmuMsr kL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0x1f}};
+// L2 and L1 Prefetcher misses
+constexpr PmuMsr kL1AndL2PrefetcherHitsInL3{
+    .amdCore = {.event = 0x71, .unitMask = 0xff}};
+constexpr PmuMsr kL1AndL2PrefetcherMissesInL3{
+    .amdCore = {.event = 0x72, .unitMask = 0xff}};
 // Flops
 constexpr PmuMsr kRetiredX87Flops{.amdCore = {.event = 0x2, .unitMask = 0x7}};
 constexpr PmuMsr kRetiredSseAvxFlops{


### PR DESCRIPTION
Summary:
## Updates to hbt perf_events
* Add a diff() function to Read value datastructure, to find difference of two reads from perf_event.
* enabling perf_event counters should not always reset the counter, making optional.
* minor

## Amd Counter updates
* While counting prefetch hits and misses in L3, add mask to include both L1 and L2 prefetcher, previously the event only enabled L2 prefetcher.
* The above two counters cover cache misses to L2 cache due to L1 and L2 prefetchers.

Differential Revision: D45171647

