### PR TITLE
Add docker image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 project(Dynolog VERSION 1.0)
 option(BUILD_TESTS "Build the unit tests" ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM --platform=linux/amd64 amd64/ubuntu:20.04 AS ubuntu_build_x86
+# This required to avoid interactive build for tzdata
+ENV DEBIAN_FRONTEND=noninteractive 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        libssl-dev \
+        ninja-build \
+        tini \
+        tree \
+        vim \
+    && rm -rf /var/lib/apt/lists/*
+# Use Rust nightly with sparse index, https://github.com/rust-lang/cargo/issues/10781
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+ENV PATH /root/.cargo/bin:$PATH
+
+WORKDIR /workspace/dynolog
+COPY . .
+
+# Run the rust build directly
+RUN cd cli && /root/.cargo/bin/cargo +nightly build --release -Z sparse-registry --target-dir build
+
+RUN ./scripts/build.sh 2>&1 | tee build.log
+
+FROM --platform=linux/amd64 rockylinux:9 AS rocky_build_x86
+RUN yum update -y && \
+    yum install -y \
+        make \
+        git \
+        cmake \
+        openssl-devel \
+        libstdc++ \
+        gcc \
+        gcc-c++ \
+        rpmdevtools.noarch \
+        rpmlint.noarch \
+        systemd-rpm-macros \
+        tree \
+        vim
+RUN dnf --enablerepo=crb install -y ninja-build
+# Use Rust nightly with sparse index, https://github.com/rust-lang/cargo/issues/10781
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+ENV PATH /root/.cargo/bin:$PATH
+
+WORKDIR /workspace/dynolog
+COPY . .
+
+# Run the rust build directly
+RUN cd cli && /root/.cargo/bin/cargo +nightly build --release -Z sparse-registry --target-dir build
+
+RUN ./scripts/build.sh 2>&1 | tee build.log

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,4 +7,60 @@
    [branch_name]`
 6. Create a new release on [this
   page](https://github.com/facebookincubator/dynolog/releases) on Github.
-7. Add the rpm/debian package by running `./scripts/rpm/make_rpm.sh`/`./scripts/debian/make_deb.sh`  and adding it to the release by dropping from the [release page](https://github.com/facebookincubator/dynolog/releases) or by running the [gh cli](https://cli.github.com/manual/gh_release_upload)
+7. Build rpm and debian packages. You can use Docker for this, details provided below.
+7. Upload the rpm and debian packages to the [release page](https://github.com/facebookincubator/dynolog/releases) or by running [gh cli](https://cli.github.com/manual/gh_release_upload)
+
+# Building Release Packages using Docker
+
+## About
+Docker is a container technology that can emulate any OS and and HW platform. It provides a simpler flow to control and version the release environment. It also eliminates the need to have machines with the specific Linux OS versions; instead you can build packages on a Mac/Windows/Linux laptop, all the same.
+
+## 1) Install Docker Desktop
+Follow the instructions [here](https://docs.docker.com/get-docker/).
+
+## 2) Build Docker images
+We include a `Dockerfile` in the repo to make release generation easy.
+Run the following commands for building debian (Ubuntu based) and rpm (Rocky/CentOS based)packages
+```
+# For debian package
+docker build . -t dyno_build:ubuntu20.04 --target ubuntu_build_x86
+# For rpm package
+docker build . -t dyno_build:rocky9_build_x86 --target rocky_build_x86
+```
+
+Note, this step may take a while if you are using an ARM based laptop/machine and building the x86 packages.
+
+## 3) Generate Packages
+
+The docker images should have already run majority of the build process. We only need to run the final packaging step by spinning up the container.
+
+Below are commands for Ubuntu/debian package build
+```
+docker run -it dyno_build:ubuntu20.04 /bin/bash
+
+root@05d28f436d2b:/workspace/dynolog# ./scripts/debian/make_deb.sh
+```
+
+Similarly, run `./scripts/rpm/make_rpm.sh` in the rocky9 image for rpm package build.
+```
+docker run -it dyno_build:rocky9_build_x86 /bin/bash
+
+root@05d28f436d2b:/workspace/dynolog# ./scripts/rpm/make_rpm.sh
+```
+
+## 4) Copy packages
+You can copy files from your docker container. Make sure the container is still running while you do this.
+
+Each docker container should have a unique ID; you can run `docker ps` to get a list of all running containers. Please replace '05d28f436d2b' below to the docker container ID.
+```
+mkdir -p build_packages
+docker cp 05d28f436d2b:/workspace/dynolog/dynolog_0.2.2-0-amd64.deb build_packages
+
+# similarly for rpm in container 01382d91b91b
+docker cp 01382d91b91b:/root/rpmbuild/RPMS/x86_64/dynolog-0.2.2-1.el9.x86_64.rpm build_packages
+```
+
+## Notes
+Currently, the docker file fixes the platform for deployment to 'linux/amd64'. We can also build packages for ARM or other architectures, the build scripts do hard-code the package file names as amd64 and that needs to be fixed.
+
+Also, anupamb has shared a great [cheatsheet](https://gist.github.com/anupambhatnagar/07ebff374bc45e4b63eb42893cca7e87) for docker commands.

--- a/dynolog/CMakeLists.txt
+++ b/dynolog/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(src)
 

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 add_definitions(-DDYNOLOG_VERSION=${DYNOLOG_VERSION} -DDYNOLOG_GIT_REV=${DYNOLOG_GIT_REV})
 
 # our build script will first create a src/ dir where all source code will exist

--- a/hbt/CMakeLists.txt
+++ b/hbt/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(src)

--- a/hbt/src/CMakeLists.txt
+++ b/hbt/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 include_directories(${PROJECT_SOURCE_DIR}/third_party/pfs/include)
 

--- a/scripts/dynolog.service
+++ b/scripts/dynolog.service
@@ -24,6 +24,12 @@ CPUQuota=100%
 # Limit Memory usage to 1 GB, beyond that the process will be OOM killed
 MemoryMax=1G
 
+# Limit CPU usage to 1 CPU core
+CPUQuota=100%
+
+# Limit Memory usage to 1 GB, beyond that the process will be OOM killed
+MemoryMax=1G
+
 Restart=always
 
 [Install]

--- a/scripts/rpm/make_rpm.sh
+++ b/scripts/rpm/make_rpm.sh
@@ -74,13 +74,14 @@ rpmbuild -bb SPECS/dynolog.spec
 
 # Test results
 tree .
-rpm -qi "RPMS/x86_64/dynolog-${VERSION}-1.el8.x86_64.rpm"
+rpmfile=$(ls "$RPMDIR/RPMS/x86_64/dynolog"-*rpm)
+rpm -qi "$rpmfile"
 
 {
 echo
 echo "---------------------------------------------------------------"
-echo "RPM generated at $RPMDIR/RPMS/x86_64/dynolog-${VERSION}-1.el8.x86_64.rpm"
+echo "RPM generated at $rpmfile"
 echo "To install you can use --nodeps flag "
-echo "rpm -i $RPMDIR/RPMS/x86_64/dynolog-${VERSION}-1.el8.x86_64.rpm"
+echo "rpm -i $rpmfile"
 echo "---------------------------------------------------------------"
 } 2> /dev/null


### PR DESCRIPTION
Use docker images as an easy way to build release RPMs and debian packages