### PR TITLE
refactor to use MetricFrame to store task netns counters

### DIFF
--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -8,6 +8,8 @@
 
 #include <stdexcept>
 
+#include <iostream>
+
 namespace facebook::dynolog {
 
 MetricFrameMap::MetricFrameMap(

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -95,6 +95,9 @@ class MetricSeriesSlice {
         series_.begin() + range_.start.offset,
         series_.begin() + range_.end.offset + 1);
   }
+  T last() const {
+    return series_.last();
+  }
 
  protected:
   MetricSeriesSlice(

--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -230,6 +230,10 @@ class MetricSeries final {
     return *(end_ - 1) - *begin_;
   }
 
+  T last() const {
+    return *(end() - 1);
+  }
+
  private:
   template <typename R>
   static R rate(

--- a/dynolog/tests/metric_frame/MetricFrameTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTest.cpp
@@ -176,12 +176,14 @@ TEST(MetricSeriesSliceTest, metricFrameVectorSmokeTest) {
   EXPECT_NEAR(seriesSlice1->rate<double>(1s), 0.01667, 1e-3);
   EXPECT_EQ(seriesSlice1->rate<int>(1min), 1);
   EXPECT_EQ(seriesSlice1->diff(), 5);
+  EXPECT_EQ(seriesSlice1->last(), 52);
 
   EXPECT_NEAR(seriesSlice2->avg<double>(), 28.4, 1e-3);
   EXPECT_NEAR(seriesSlice2->percentile(0.4), 27.9, 1e-3);
   EXPECT_NEAR(seriesSlice2->rate<double>(1s), 0.01667, 1e-3);
   EXPECT_EQ(seriesSlice2->rate<int>(1min), 1);
   EXPECT_NEAR(seriesSlice2->diff(), 5, 1e-3);
+  EXPECT_NEAR(seriesSlice2->last(), 33.9, 1e-3);
 }
 
 TEST(MetricSeriesSliceTest, perfReadValuesCompabilityTest) {

--- a/dynolog/tests/metric_frame/MetricSeriesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricSeriesTest.cpp
@@ -117,3 +117,14 @@ TEST(MetricSeriesTest, testDiff) {
   EXPECT_EQ(t.diff(t.begin(), t.end() - 1), 12);
   EXPECT_EQ(t.diff(t.begin() + 1, t.end()), -4);
 }
+
+TEST(MetricSeriesTest, testLast) {
+  MetricSeries<int> t(3, "test_metric", "this is a test metric in unittest");
+  t.addSample(0);
+  EXPECT_EQ(t.last(), 0);
+  t.addSample(12);
+  EXPECT_EQ(t.last(), 12);
+  t.addSample(8);
+  t.addSample(7);
+  EXPECT_EQ(t.last(), 7);
+}


### PR DESCRIPTION
Summary:
use MetricFrame to store last 60 seconds history of tupperware task netns counters and change the collection granularity of netns counters to 1 sample per second.

In this way, we will be able to still report netns metrics of last 1 minute reporting window.

Differential Revision: D45803407

