### PR TITLE
text table for simple visualization of data in MetricFrame

### DIFF
--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(extra_types STATIC ExtraTypes.h ExtraTypes.cpp)
+add_library(text_table STATIC TextTable.h TextTable.cpp)
 add_library(metric_series STATIC MetricSeries.h)
 set_target_properties(metric_series PROPERTIES LINKER_LANGUAGE CXX)
 add_library(metric_values STATIC MetricValues.h)
@@ -8,4 +9,4 @@ add_library(metric_frame_ts_unit STATIC
 add_library(metric_frame STATIC
     MetricFrame.h MetricFrame.cpp MetricFrameBase.h MetricFrameBase.cpp)
 target_link_libraries(metric_frame
-    metric_series metric_frame_ts_unit extra_types)
+    metric_series metric_frame_ts_unit extra_types text_table)

--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -87,6 +87,19 @@ std::optional<MetricSeriesVar> MetricFrameMap::series(const int) const {
   return std::nullopt;
 }
 
+void MetricFrameMap::show(std::ostream& s) const {
+  std::vector<MetricSeriesVar> series;
+  std::transform(
+      series_.begin(),
+      series_.end(),
+      std::back_inserter(series),
+      [](const auto& kv) { return kv.second; });
+  s << name() << std::endl;
+  s << description() << std::endl;
+  MetricFrameBase::show<decltype(series.begin())>(
+      series.begin(), series.end(), *ts_, s);
+}
+
 MetricFrameVector::MetricFrameVector(
     VectorSeriesDefList defs,
     std::string name,
@@ -139,6 +152,13 @@ std::optional<MetricSeriesVar> MetricFrameVector::series(int idx) const {
     return std::nullopt;
   }
   return series_[idx];
+}
+
+void MetricFrameVector::show(std::ostream& s) const {
+  s << name() << std::endl;
+  s << description() << std::endl;
+  MetricFrameBase::show<decltype(series_.begin())>(
+      series_.begin(), series_.end(), *ts_, s);
 }
 
 } // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/MetricFrame.h
+++ b/dynolog/src/metric_frame/MetricFrame.h
@@ -35,6 +35,7 @@ class MetricFrameMap : public MetricFrameBase {
   size_t width() const override;
   std::optional<MetricSeriesVar> series(const std::string& name) const override;
   std::optional<MetricSeriesVar> series(int name) const override;
+  void show(std::ostream& s) const override;
 
  protected:
   std::map<std::string, MetricSeriesVar> series_;
@@ -55,6 +56,7 @@ class MetricFrameVector : public MetricFrameBase {
   size_t width() const override;
   std::optional<MetricSeriesVar> series(const std::string& name) const override;
   std::optional<MetricSeriesVar> series(int name) const override;
+  void show(std::ostream& s) const override;
 
  protected:
   VectorSeriesDefList series_;

--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -95,6 +95,11 @@ void MetricFrameBase::incFromLastSample(
       seriesVar);
 }
 
+std::ostream& operator<<(std::ostream& s, const MetricFrameBase& frame) {
+  frame.show(s);
+  return s;
+}
+
 MetricFrameSlice::MetricFrameSlice(
     const MetricFrameBase& frame,
     MetricFrameRange range)

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -39,6 +39,14 @@ std::optional<TimePoint> MetricFrameTsUnitFixInterval::lastSampleTime() const {
   return lastSampleTime_;
 }
 
+std::vector<TimePoint> MetricFrameTsUnitFixInterval::getTimeVector() const {
+  std::vector<TimePoint> res(length());
+  for (size_t i = 0; i < length(); i++) {
+    res[i] = lastSampleTime_ - (length() - i - 1) * interval_;
+  }
+  return res;
+}
+
 size_t MetricFrameTsUnitFixInterval::length() const {
   return sampleCount_;
 }

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.h
@@ -19,6 +19,7 @@ class MetricFrameTsUnitFixInterval : public MetricFrameTsUnitInterface {
   virtual void addSample(TimePoint time) override;
   virtual std::optional<TimePoint> firstSampleTime() const override;
   virtual std::optional<TimePoint> lastSampleTime() const override;
+  virtual std::vector<TimePoint> getTimeVector() const override;
   virtual size_t length() const override;
   virtual size_t maxLength() const override;
   virtual std::optional<MetricFrameRange> getRange(

--- a/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <optional>
+#include <vector>
 
 namespace facebook::dynolog {
 
@@ -35,6 +36,7 @@ class MetricFrameTsUnitInterface {
   virtual void addSample(TimePoint time) = 0;
   virtual std::optional<TimePoint> firstSampleTime() const = 0;
   virtual std::optional<TimePoint> lastSampleTime() const = 0;
+  virtual std::vector<TimePoint> getTimeVector() const = 0;
   virtual size_t length() const = 0;
   virtual size_t maxLength() const = 0;
   virtual std::optional<MetricFrameRange> getRange(

--- a/dynolog/src/metric_frame/TextTable.cpp
+++ b/dynolog/src/metric_frame/TextTable.cpp
@@ -1,0 +1,70 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "dynolog/src/metric_frame/TextTable.h"
+
+namespace facebook::dynolog {
+
+TextTable::TextTable(std::vector<std::vector<std::string>>&& data)
+    : data_{std::move(data)} {}
+
+std::ostream& TextTable::show(std::ostream& s) {
+  updateCachedWidth();
+  for (size_t row = 0; row < height(); row++) {
+    writeLine(s);
+    writeRow(row, s);
+  }
+  writeLine(s);
+  return s;
+}
+
+size_t TextTable::width() const {
+  return data_.empty() ? 0 : data_[0].size();
+}
+
+size_t TextTable::height() const {
+  return data_.size();
+}
+
+void TextTable::updateCachedWidth() {
+  colWidthCache_.resize(width());
+  for (size_t col = 0; col < width(); col++) {
+    colWidthCache_[col] = getColWidth(col);
+  }
+}
+
+[[nodiscard]] size_t TextTable::getColWidth(size_t col) const {
+  size_t width = 0;
+  for (const auto& row : data_) {
+    width = std::max(width, row[col].size());
+  }
+  return width;
+}
+
+void TextTable::writeRow(size_t row, std::ostream& s) const {
+  for (size_t col = 0; col < width(); col++) {
+    size_t cellWidth = colWidthCache_[col] + extraPad_;
+    size_t textWidth = data_[row][col].size();
+    size_t lPad = (cellWidth - textWidth) / 2;
+    size_t rPad = cellWidth - textWidth - lPad;
+    s << '|';
+    for (int i = 0; i < lPad; i++) {
+      s << ' ';
+    }
+    s << data_[row][col];
+    for (int i = 0; i < rPad; i++) {
+      s << ' ';
+    }
+  }
+  s << '|' << std::endl;
+}
+
+void TextTable::writeLine(std::ostream& s) const {
+  for (auto cellWidth : colWidthCache_) {
+    for (int i = 0; i < cellWidth + 1 + extraPad_; i++) {
+      s << '-';
+    }
+  }
+  s << '-' << std::endl;
+}
+
+} // namespace facebook::dynolog

--- a/dynolog/src/metric_frame/TextTable.h
+++ b/dynolog/src/metric_frame/TextTable.h
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace facebook::dynolog {
+
+// for basic visualizaion of a MetricFrame
+// print a text table like below
+/*
+-------------------------------
+|         |  t1   | t2  | t3  |
+-------------------------------
+| metric1 |  12   | 21  | 38  |
+-------------------------------
+| metric2 | 17423 | 992 | 157 |
+-------------------------------
+*/
+
+class TextTable {
+ public:
+  explicit TextTable(std::vector<std::vector<std::string>>&& data);
+  std::ostream& show(std::ostream& s);
+
+ private:
+  size_t width() const;
+  size_t height() const;
+  void updateCachedWidth();
+  [[nodiscard]] size_t getColWidth(size_t col) const;
+  void writeRow(size_t row, std::ostream& s) const;
+  void writeLine(std::ostream& s) const;
+
+  std::vector<std::vector<std::string>> data_;
+  std::vector<size_t> colWidthCache_;
+  const size_t extraPad_ = 2;
+};
+
+} // namespace facebook::dynolog

--- a/dynolog/tests/metric_frame/CMakeLists.txt
+++ b/dynolog/tests/metric_frame/CMakeLists.txt
@@ -1,4 +1,7 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+dynolog_add_test(TextTableTest TextTableTest.cpp)
+target_link_libraries(TextTableTest PRIVATE text_table)
+
 dynolog_add_test(MetricSeriesTest MetricSeriesTest.cpp)
 target_link_libraries(MetricSeriesTest PRIVATE metric_series)
 

--- a/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
@@ -42,6 +42,12 @@ TEST(MetricFrameTsUnitTest, smokeTest) {
   EXPECT_EQ(res.start.time, now - 120s);
   EXPECT_EQ(res.end.offset, 2);
   EXPECT_EQ(res.end.time, now);
+
+  auto timeVector = i.getTimeVector();
+  EXPECT_EQ(timeVector.size(), 3);
+  EXPECT_EQ(timeVector[0], now - 120s);
+  EXPECT_EQ(timeVector[1], now - 60s);
+  EXPECT_EQ(timeVector[2], now);
 }
 
 TEST(MetricFrameTsUnitTest, emptyFrame) {

--- a/dynolog/tests/metric_frame/TextTableTest.cpp
+++ b/dynolog/tests/metric_frame/TextTableTest.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "dynolog/src/metric_frame/TextTable.h"
+
+using namespace ::testing;
+using namespace ::facebook::dynolog;
+
+/*
+-------------------------------
+|         |    t1 |  t2 |  t3 |
+--------------------------
+| metric1 |    12 |  21 |  38 |
+--------------------------
+| metric2 | 17423 | 992 | 157 |
+-------------------------------
+*/
+
+TEST(TextTableTest, checkOutputHasRightShape) {
+  std::vector<std::vector<std::string>> data = {
+      {"", "t1", "t2", "t3"},
+      {"metric1", "12", "21", "38"},
+      {"metric2", "17423", "992", "157"}};
+
+  TextTable t(std::move(data));
+  std::stringstream s;
+
+  t.show(s);
+  size_t nLine = 0;
+  auto output = s.str();
+  int lastLineWidth = -1;
+  while (true) {
+    auto nl = output.find('\n');
+    if (nl == std::string::npos) {
+      break;
+    }
+    nLine++;
+    EXPECT_TRUE(lastLineWidth == -1 || lastLineWidth == nl);
+    lastLineWidth = nl;
+    output = output.substr(nl + 1, output.size() - nl - 1);
+  }
+  EXPECT_EQ(nLine, 7);
+}


### PR DESCRIPTION
Summary: add show() function which print a text table of MetricFrame

Differential Revision: D45939982

