### PR TITLE
Added two missing raw counters that we need to calculate backend and frontend stall ratios

### DIFF
--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -156,6 +156,8 @@ constexpr PmuMsr kDTlbMisses{.amdCore = {.event = 0x45, .unitMask = 0xf0}};
 constexpr PmuMsr kDTlbAccesses{.amdCore = {.event = 0x45, .unitMask = 0xff}};
 constexpr PmuMsr kITlbMisses{.amdCore = {.event = 0x85, .unitMask = 0xf}};
 constexpr PmuMsr kITlbAccesses{.amdCore = {.event = 0x84}};
+constexpr PmuMsr kLoadPlusStoreDtlbMisses{
+    .amdCore = {.event = 0x45, .unitMask = 0x0f}};
 
 // Stall cycles
 // Found in kernel perf_events


### PR DESCRIPTION
Summary: Added two missing raw counters that we need to calculate backend and frontend stall ratios.

Differential Revision: D46402616

