### PR TITLE
fix flops metrics defintion

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -722,19 +722,19 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                EventRef{
                    "instr_sp_128b_packed",
                    PmuType::cpu,
-                   "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
+                   "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
                    EventExtraAttr{},
                    {}},
                EventRef{
                    "instr_sp_256b_packed",
                    PmuType::cpu,
-                   "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
+                   "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
                    EventExtraAttr{},
                    {}},
                EventRef{
                    "instr_sp_512b_packed",
                    PmuType::cpu,
-                   "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
+                   "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
                    EventExtraAttr{},
                    {}}}}},
       100'000'000,
@@ -772,7 +772,7 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                EventRef{
                    "instr_dp_512b_packed",
                    PmuType::cpu,
-                   "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
+                   "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
                    EventExtraAttr{},
                    {}}}}},
       100'000'000,

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
@@ -4119,7 +4119,7 @@ Note: Writeback pending FIFO has six entries.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -4132,7 +4132,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -4178,7 +4177,7 @@ Note: Writeback pending FIFO has six entries.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -4191,7 +4190,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
@@ -4118,7 +4118,7 @@ Note: Writeback pending FIFO has six entries.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -4131,7 +4131,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -4177,7 +4176,7 @@ Note: Writeback pending FIFO has six entries.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -4190,7 +4189,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
@@ -4118,7 +4118,7 @@ Note: Writeback pending FIFO has six entries.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -4131,7 +4131,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -4177,7 +4176,7 @@ Note: Writeback pending FIFO has six entries.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -4190,7 +4189,6 @@ Note: Writeback pending FIFO has six entries.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/cascadelakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/cascadelakex_core.cpp
@@ -3658,7 +3658,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -3671,7 +3671,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3717,7 +3716,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -3730,9 +3729,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
@@ -3745,9 +3743,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
@@ -3760,7 +3757,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/icelake_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/icelake_core.cpp
@@ -3130,7 +3130,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -3143,7 +3143,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3174,7 +3173,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -3187,9 +3186,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
@@ -3202,7 +3200,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3219,7 +3216,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
@@ -3232,7 +3229,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
@@ -3415,7 +3415,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -3428,7 +3428,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3459,7 +3458,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -3472,9 +3471,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
@@ -3487,7 +3485,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3504,7 +3501,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
@@ -3517,7 +3514,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
@@ -3616,7 +3616,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -3629,7 +3629,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3660,7 +3659,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -3673,7 +3672,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
@@ -3686,7 +3686,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
@@ -3699,7 +3699,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
   // Event FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -3745,7 +3744,7 @@ Note: Invoking MITE requires two or three cycles delay.)",
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
@@ -3758,9 +3757,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
@@ -3773,9 +3771,8 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
@@ -3788,7 +3785,6 @@ Note: Invoking MITE requires two or three cycles delay.)",
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(


### PR DESCRIPTION
Summary:
- fix the incorrect single/double flops instructions definitions in BuiltinMetrics
- regenerate events import function because some new events are now used in BuiltinMetrics

Differential Revision: D46827650

