### PR TITLE
Update pytorch_profiler.md to include information about older PyTorch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,6 @@ We have tested dynolog works with the following versions of C++ and Rust toolcha
    <td>Rust 1.58.1 (1.56+ required for clap dependency)
    </td>
   </tr>
-  <tr>
-   <td>PyTorch
-   </td>
-   <td>2.0+
-   </td>
-  </tr>
 </table>
 
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ We have tested dynolog works with the following versions of C++ and Rust toolcha
    <td>Rust 1.58.1 (1.56+ required for clap dependency)
    </td>
   </tr>
+  <tr>
+   <td>PyTorch
+   </td>
+   <td>2.0+
+   </td>
+  </tr>
 </table>
 
 

--- a/docs/pytorch_profiler.md
+++ b/docs/pytorch_profiler.md
@@ -16,6 +16,7 @@ The following instructions walk through:
 > Note that these instructions continue to evolve as we add more features to PyTorch profiler and Dynolog.
 
 Please use the latest [PyTorch 2.0 release](https://pytorch.org/get-started/pytorch-2.0/). For more information on obtaining PyTorch nightly see [here](https://pytorch.org/get-started/locally/).
+Older versions of PyTorch (< 2.0) are currently not supported.
 
 ## On-demand tracing locally
 On a local machine you can run Dynolog and use the command line tool to trace your application.


### PR DESCRIPTION
Summary:
- Updates `pytorch_profiler.md` to include information about older PyTorch versions.

Based on [this thread](https://github.com/pytorch/kineto/issues/770), versions below PyTorch 2.0 do not work with the on-demand remote tracing feature in Dynolog.  

It would be fruitful to mention this in the README  - currently, we only mention that the latest PyTorch 2.0 release is recommended, and nothing about the older versions.

Since using Dynolog with an older PyTorch version does not result in any kind of error or warning, it may be confusing to the users as to why they don't see the expected functionality. Thus, we can include this in the README since many still use older torch versions.