### PR TITLE
refactor generated and static CpuArch.h, add ARM family

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "hbt/src/common/Defs.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
+#include "hbt/src/perf_event/CpuArch.h"
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -10,10 +10,10 @@
 #include "hbt/src/intel_pt/IptEventBuilder.h"
 #include "hbt/src/perf_event/AmdEvents.h"
 #include "hbt/src/perf_event/BuiltinMetrics.h"
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/Metrics.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 #ifdef USE_JSON_GENERATED_PERF_EVENTS
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 #endif // USE_JSON_GENERATED_PERF_EVENTS

--- a/hbt/src/perf_event/BuiltinMetrics.h
+++ b/hbt/src/perf_event/BuiltinMetrics.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/Metrics.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -10,6 +10,10 @@ add_subdirectory(tests)
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+add_library(CpuArch CpuArch.h)
+set_target_properties(CpuArch PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(CpuArch PUBLIC CpuArchGen)
+
 add_library(PmuEvent PmuEvent.h PmuEvent.cpp)
 target_link_libraries(PmuEvent PUBLIC System)
 

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Generated file. Do not modify.
+
+#pragma once
+
+#include <sstream>
+
+namespace facebook::hbt::perf_event {
+
+enum class CpuFamily { AMD, INTEL, ARM, UNKNOWN };
+
+inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
+  switch (f) {
+    case CpuFamily::AMD:
+      return os << "AMD";
+    case CpuFamily::INTEL:
+      return os << "INTEL";
+    case CpuFamily::ARM:
+      return os << "ARM";
+    case CpuFamily::UNKNOWN:
+      return os << "UNKNOWN";
+  }
+}
+
+// Create CpuFamily enumeration from integer.
+inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
+#if defined(__x86_64__)
+  switch (cpu_family) {
+    case 6:
+      return CpuFamily::INTEL;
+    case 25:
+      return CpuFamily::AMD;
+    // Not recognized CPU model.
+    default:
+      return CpuFamily::UNKNOWN;
+  }
+#elif defined(__aarch64__)
+  return CpuFamily::ARM;
+#else
+  return CpuFamily::UNKNOWN;
+#endif
+}
+
+} // namespace facebook::hbt::perf_event
+
+#include "hbt/src/perf_event/json_events/generated/CpuArch.h"

--- a/hbt/src/perf_event/Metrics.h
+++ b/hbt/src/perf_event/Metrics.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 #include <map>
 #include <memory>

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 #include <bitset>
 #include <map>

--- a/hbt/src/perf_event/json_events/generated/CMakeLists.txt
+++ b/hbt/src/perf_event/json_events/generated/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-add_library(CpuArch CpuArch.h)
-set_target_properties(CpuArch PROPERTIES LINKER_LANGUAGE CXX)
+add_library(CpuArchGen CpuArch.h)
+set_target_properties(CpuArchGen PROPERTIES LINKER_LANGUAGE CXX)
 
 if(USE_JSON_GENERATED_PERF_EVENTS)
   add_subdirectory(intel)

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -9,32 +9,9 @@
 
 namespace facebook::hbt::perf_event {
 
-enum class CpuFamily { AMD, INTEL, UNKNOWN };
-
-inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
-  switch (f) {
-    case CpuFamily::AMD:
-      return os << "AMD";
-    case CpuFamily::INTEL:
-      return os << "INTEL";
-    case CpuFamily::UNKNOWN:
-      return os << "UNKNOWN";
-  }
-}
-// Create CpuFamily enumeration from integer.
-inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
-  switch (cpu_family) {
-    case 6:
-      return CpuFamily::INTEL;
-    case 25:
-      return CpuFamily::AMD;
-    // Not recognized CPU model.
-    default:
-      return CpuFamily::UNKNOWN;
-  }
-}
-
 enum class CpuArch {
+  // ARM Architectures
+  GRACE,
   // AMD Architectures
   MILAN,
   GENOA,
@@ -62,8 +39,14 @@ enum class CpuArch {
 
 inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
   switch (ev) {
+    case CpuArch::GRACE:
+      return os << "GRACE";
     case CpuArch::MILAN:
       return os << "MILAN";
+    case CpuArch::GENOA:
+      return os << "GENOA";
+    case CpuArch::BERGAMO:
+      return os << "BERGAMO";
     case CpuArch::BDW:
       return os << "BDW";
     case CpuArch::BDW_DE:
@@ -111,6 +94,10 @@ inline CpuArch makeCpuArch(
     switch (cpu_model_num) {
       case 1:
         return CpuArch::MILAN;
+      case 17:
+        return CpuArch::GENOA;
+      case 160:
+        return CpuArch::BERGAMO;
     }
   } else if (cpu_family == CpuFamily::INTEL) {
     switch (cpu_model_num) {


### PR DESCRIPTION
Summary: As above, the CpuArch may have many non generated lines so it is better to split it up into common and generated parts.

Differential Revision: D47304296

