### PR TITLE
cmake: add USE_SYSTEM_* options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,22 +4,23 @@ cmake_minimum_required(VERSION 3.16)
 project(Dynolog VERSION 1.0)
 option(BUILD_TESTS "Build the unit tests" ON)
 option(USE_ODS_GRAPH_API "Enable logger to Meta ODS using public Graph API."
-OFF)
+  OFF)
 option(USE_JSON_GENERATED_PERF_EVENTS "Add performance events generated using
 Intel json spec, see hbt/src/perf_event/json_events/intel"
-OFF)
-option(USE_PROMETHEUS "Enable logging to prometheus, this requires
-prometheus-cpp to be installed on the system"
-OFF)
-
-if(USE_PROMETHEUS)
-  find_package(prometheus-cpp CONFIG REQUIRED)
-endif()
+  OFF)
+option(USE_SYSTEM_LIBS "Use system libraries" OFF)
+option(USE_SYSTEM_GOOGLETEST "Use system-provided Google Test" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_GLOG "Use system-provided glog" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_GFLAGS "Use system-provided gflags" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_JSON "Use system-provided json" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_PFS "Use system-provided pfs" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_FMT "Use system-provided fmt" ${USE_SYSTEM_LIBS})
+option(USE_SYSTEM_CPR "Use system-provided cpr" ${USE_SYSTEM_LIBS})
 
 file(READ "version.txt" DYNOLOG_VERSION)
 string(STRIP ${DYNOLOG_VERSION} DYNOLOG_VERSION)
 
-execute_process (
+execute_process(
   COMMAND git rev-parse --short HEAD
   OUTPUT_VARIABLE DYNOLOG_GIT_REV
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -41,12 +42,18 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
 
 if(BUILD_TESTS)
   enable_testing()
-  add_subdirectory("third_party/googletest" "third_party/googletest")
+
+  if(USE_SYSTEM_GOOGLETEST)
+    find_package(GTest REQUIRED)
+  else()
+    add_subdirectory(third_party/googletest)
+  endif()
 endif()
 
 include_directories(".")
 add_subdirectory(dynolog)
 add_subdirectory(cli)
+
 # The following dummy depdendency ensures the cli is built
 add_dependencies(dynolog_lib dyno)
 add_subdirectory(hbt)
@@ -59,26 +66,59 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
 
 set(BUILD_TESTING OFF CACHE BOOL "")
 set(WITH_GFLAGS OFF CACHE BOOL "")
-add_subdirectory(third_party/glog)
+
+if(USE_SYSTEM_GLOG)
+  find_package(glog REQUIRED)
+else()
+  add_subdirectory(third_party/glog)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC glog::glog)
 
 set(GFLAGS_BUILD_TESTING OFF CACHE BOOL "")
-add_subdirectory(third_party/gflags)
+
+if(USE_SYSTEM_GFLAGS)
+  find_package(gflags REQUIRED)
+else()
+  add_subdirectory(third_party/gflags)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC gflags::gflags)
 
 # https://github.com/nlohmann/json#cmake
 set(JSON_BuildTests OFF CACHE INTERNAL "")
-add_subdirectory(third_party/json)
+
+if(USE_SYSTEM_JSON)
+  find_package(nlohmann_json REQUIRED)
+else()
+  add_subdirectory(third_party/json)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC nlohmann_json::nlohmann_json)
 
-add_subdirectory(third_party/pfs)
-target_include_directories(dynolog_lib PUBLIC third_party/pfs/include)
+if(USE_SYSTEM_PFS)
+  find_package(pfs REQUIRED)
+else()
+  add_subdirectory(third_party/pfs)
+  target_include_directories(dynolog_lib PUBLIC third_party/pfs/include)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC pfs)
 
-add_subdirectory(third_party/fmt)
+if(USE_SYSTEM_FMT)
+  find_package(fmt REQUIRED)
+else()
+  add_subdirectory(third_party/fmt)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC fmt::fmt)
 
 if(USE_ODS_GRAPH_API)
-  add_subdirectory(third_party/cpr)
+  if(USE_SYSTEM_CPR)
+    find_package(cpr REQUIRED)
+  else()
+    add_subdirectory(third_party/cpr)
+  endif()
+
   target_link_libraries(dynolog_lib PUBLIC cpr::cpr)
 endif()

--- a/dynolog/src/gpumon/CMakeLists.txt
+++ b/dynolog/src/gpumon/CMakeLists.txt
@@ -14,8 +14,10 @@ add_library(dynolog_dcgm_lib
 target_include_directories(dynolog_dcgm_lib
     INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
 )
-target_include_directories(dynolog_dcgm_lib PUBLIC
+if(NOT USE_SYSTEM_PFS)
+    target_include_directories(dynolog_dcgm_lib PUBLIC
                             ${PROJECT_SOURCE_DIR}/third_party/pfs/include)
+endif()
 target_link_libraries(dynolog_dcgm_lib PUBLIC gflags::gflags)
 target_link_libraries(dynolog_dcgm_lib PUBLIC glog::glog)
 target_link_libraries(dynolog_dcgm_lib PUBLIC nlohmann_json::nlohmann_json)

--- a/hbt/src/CMakeLists.txt
+++ b/hbt/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 cmake_minimum_required(VERSION 3.16)
 
-include_directories(${PROJECT_SOURCE_DIR}/third_party/pfs/include)
+if(NOT USE_SYSTEM_PFS)
+  include_directories(${PROJECT_SOURCE_DIR}/third_party/pfs/include)
+endif()
 
 add_subdirectory(common)
 add_subdirectory(intel_pt)

--- a/hbt/src/perf_event/tests/CMakeLists.txt
+++ b/hbt/src/perf_event/tests/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 add_compile_options("-Wconversion")
 
-include_directories(${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include)
+if(NOT USE_SYSTEM_GOOGLETEST)
+  include_directories(${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include)
+endif()
 
 add_executable(CpuEventsGroupTest CpuEventsGroupTest.cpp)
 target_link_libraries(CpuEventsGroupTest PRIVATE gtest gmock gtest_main)


### PR DESCRIPTION
Similar to the work done in https://github.com/pytorch/pytorch/pull/37137, this adds the following CMake options:

- `USE_SYSTEM_LIBS`
- `USE_SYSTEM_GOOGLETEST`
- `USE_SYSTEM_GLOG`
- `USE_SYSTEM_GFLAGS`
- `USE_SYSTEM_JSON`
- `USE_SYSTEM_PFS`
- `USE_SYSTEM_FMT`
- `USE_SYSTEM_CPR`

This is particularly useful in the context of Nix, where we can build these libraries once and then re-use them elsewhere to avoid rebuilding vendors dependencies.