### PR TITLE
Implement additional options for gputrace, refactor into a config structs/enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Cargo.lock
+build/
+*.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-merge-conflict
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+        args: ['--manifest-path', 'cli/Cargo.toml']
+        pass_filenames: false
+    -   id: cargo-check
+        args: ['--manifest-path', 'cli/Cargo.toml']

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 amd64/ubuntu:20.04 AS ubuntu_build_x86
 # This required to avoid interactive build for tzdata
-ENV DEBIAN_FRONTEND=noninteractive 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         libssl-dev \
+        python3-pip \
         ninja-build \
         tini \
         tree \

--- a/hbt/src/mon/tests/parse_procfs/1234/maps
+++ b/hbt/src/mon/tests/parse_procfs/1234/maps
@@ -1,29 +1,29 @@
 00200000-01eaf000 r--p 00000000 00:1c 268353812                          /tmp/module_collection_test/lib0
 01eaf000-09e97000 r-xp 01caf000 00:1c 268353812                          /tmp/module_collection_test/lib0
 09e97000-09ea0000 r--p 09c97000 00:1c 268353812                          /tmp/module_collection_test/lib0
-09ea0000-09ea1000 r--p 00000000 00:00 0 
+09ea0000-09ea1000 r--p 00000000 00:00 0
 09ea1000-09ef7000 rw-p 09ca0000 00:1c 268353812                          /tmp/module_collection_test/lib0
 09ef7000-0a368000 rw-p 00000000 00:00 0                                  [heap]
-7fe7d48c8000-7fe7d48c9000 ---p 00000000 00:00 0 
-7fe7d48c9000-7fe7d50c9000 rwxp 00000000 00:00 0 
+7fe7d48c8000-7fe7d48c9000 ---p 00000000 00:00 0
+7fe7d48c9000-7fe7d50c9000 rwxp 00000000 00:00 0
 7fe7ee291000-7fe7ee2b2000 rw-s 00000000 00:0c 14368                      anon_inode:[perf_event]
 7fe828c1a000-7fe828c1b000 r--s 00000000 00:0c 14368                      anon_inode:bpf-map
-7fe828f6a000-7fe828f6c000 rw-p 00000000 00:00 0 
+7fe828f6a000-7fe828f6c000 rw-p 00000000 00:00 0
 7fe828f6c000-7fe829002000 r--p 00000000 00:1c 240656293                  /tmp/module_collection_test/lib1
 7fe829002000-7fe829110000 r-xp 00096000 00:1c 240656293                  /tmp/module_collection_test/lib1
 7fe829110000-7fe829150000 r--p 001a4000 00:1c 240656293                  /tmp/module_collection_test/lib1
 7fe829150000-7fe82915b000 r--p 001e3000 00:1c 240656293                  /tmp/module_collection_test/lib1
 7fe82915b000-7fe82915e000 rw-p 001ee000 00:1c 240656293                  /tmp/module_collection_test/lib1
-7fe829bfb000-7fe829bfd000 rw-p 00000000 00:00 0 
+7fe829bfb000-7fe829bfd000 rw-p 00000000 00:00 0
 7fe829bfd000-7fe829bfe000 r--p 00000000 00:1c 240656152                  /tmp/module_collection_test/lib2
 7fe829bfe000-7fe829c1f000 r-xp 00001000 00:1c 240656152                  /tmp/module_collection_test/lib2
 7fe829c1f000-7fe829c26000 r--p 00022000 00:1c 240656152                  /tmp/module_collection_test/lib2
-7fe829c26000-7fe829c27000 r--p 00000000 00:00 0 
+7fe829c26000-7fe829c27000 r--p 00000000 00:00 0
 7fe829c27000-7fe829c28000 r--p 00029000 00:1c 240656152                  /tmp/module_collection_test/lib2
 7fe829c28000-7fe829c29000 rw-p 0002a000 00:1c 240656152                  /tmp/module_collection_test/lib2
-7fe829c29000-7fe829c2a000 rw-p 00000000 00:00 0 
+7fe829c29000-7fe829c2a000 rw-p 00000000 00:00 0
 7ffccb80f000-7ffccb872000 rwxp 00000000 00:00 0                          [stack]
-7ffccb872000-7ffccb873000 rw-p 00000000 00:00 0 
+7ffccb872000-7ffccb873000 rw-p 00000000 00:00 0
 7ffccb8ae000-7ffccb8b2000 r--p 00000000 00:00 0                          [vvar]
 7ffccb8b2000-7ffccb8b4000 r-xp 00000000 00:00 0                          [vdso]
 ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]

--- a/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwell_core.cpp
@@ -26,8 +26,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x00, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Instructions retired from execution.)",
-      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers. 
-Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event. 
+      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers.
+Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event.
 Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as retired instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -76,7 +76,7 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       EventDef::Encoding{
           .code = 0x00, .umask = 0x03, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the core is not in halt state.)",
-      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. 
+      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events.
 Note: On all current platforms this event stops counting during 'throttling (TM)' states duty off periods the processor is 'halted'.  This event is clocked by base clock (100 Mhz) on Sandy Bridge. The counter update is done at a lower clock rate then the core clock the overflow status bit for this counter may appear 'sticky'.  After the counter has overflowed and software clears the overflow status bit and resets the counter to less than MAX. The reset value to the counter is not clocked immediately so the overflow status bit will flip 'high (1)' and generate another PMI (if enabled) after which the reset value gets clocked into the counter. Therefore, software will get the interrupt, read the overflow status bit '1 for bit 34 while the counter value is less than MAX. Software should ignore this case.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -2362,7 +2362,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       R"(Uops not delivered to Resource Allocation Table (RAT) per thread when backend of the machine is not stalled)",
       R"(This event counts the number of uops not delivered to Resource Allocation Table (RAT) per thread adding 4  x when Resource Allocation Table (RAT) is not stalled and Instruction Decode Queue (IDQ) delivers x uops to Resource Allocation Table (RAT) (where x belongs to {0,1,2,3}). Counting does not cover cases when:
  a. IDQ-Resource Allocation Table (RAT) pipe serves the other thread;
- b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions); 
+ b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions);
  c. Instruction Decode Queue (IDQ) delivers four uops.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -3175,7 +3175,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       EventDef::Encoding{
           .code = 0xAB, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles.)",
-      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop. 
+      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop.
 MM is placed before Instruction Decode Queue (IDQ) to merge uops being fed from the MITE and Decode Stream Buffer (DSB) paths. Decode Stream Buffer (DSB) inserts the Sync-indication whenever a Decode Stream Buffer (DSB)-to-MITE switch occurs.
 Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DSB) miss can cost up to six cycles in which no uops are delivered to the IDQ. Most often, such switches from the Decode Stream Buffer (DSB) to the legacy pipeline cost 02 cycles.)",
       2000003,

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellde_core.cpp
@@ -25,8 +25,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x00, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Instructions retired from execution.)",
-      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers. 
-Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event. 
+      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers.
+Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event.
 Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as retired instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -75,7 +75,7 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       EventDef::Encoding{
           .code = 0x00, .umask = 0x03, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the core is not in halt state.)",
-      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. 
+      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events.
 Note: On all current platforms this event stops counting during 'throttling (TM)' states duty off periods the processor is 'halted'.  This event is clocked by base clock (100 Mhz) on Sandy Bridge. The counter update is done at a lower clock rate then the core clock the overflow status bit for this counter may appear 'sticky'.  After the counter has overflowed and software clears the overflow status bit and resets the counter to less than MAX. The reset value to the counter is not clocked immediately so the overflow status bit will flip 'high (1)' and generate another PMI (if enabled) after which the reset value gets clocked into the counter. Therefore, software will get the interrupt, read the overflow status bit '1 for bit 34 while the counter value is less than MAX. Software should ignore this case.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -2361,7 +2361,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       R"(Uops not delivered to Resource Allocation Table (RAT) per thread when backend of the machine is not stalled)",
       R"(This event counts the number of uops not delivered to Resource Allocation Table (RAT) per thread adding 4  x when Resource Allocation Table (RAT) is not stalled and Instruction Decode Queue (IDQ) delivers x uops to Resource Allocation Table (RAT) (where x belongs to {0,1,2,3}). Counting does not cover cases when:
  a. IDQ-Resource Allocation Table (RAT) pipe serves the other thread;
- b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions); 
+ b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions);
  c. Instruction Decode Queue (IDQ) delivers four uops.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -3174,7 +3174,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       EventDef::Encoding{
           .code = 0xAB, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles.)",
-      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop. 
+      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop.
 MM is placed before Instruction Decode Queue (IDQ) to merge uops being fed from the MITE and Decode Stream Buffer (DSB) paths. Decode Stream Buffer (DSB) inserts the Sync-indication whenever a Decode Stream Buffer (DSB)-to-MITE switch occurs.
 Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DSB) miss can cost up to six cycles in which no uops are delivered to the IDQ. Most often, such switches from the Decode Stream Buffer (DSB) to the legacy pipeline cost 02 cycles.)",
       2000003,

--- a/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/broadwellx_core.cpp
@@ -25,8 +25,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::Encoding{
           .code = 0x00, .umask = 0x01, .cmask = 0, .msr_values = {0}},
       R"(Instructions retired from execution.)",
-      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers. 
-Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event. 
+      R"(This event counts the number of instructions retired from execution. For instructions that consist of multiple micro-ops, this event counts the retirement of the last micro-op of the instruction. Counting continues during hardware interrupts, traps, and inside interrupt handlers.
+Notes: INST_RETIRED.ANY is counted by a designated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. INST_RETIRED.ANY_P is counted by a programmable counter and it is an architectural performance event.
 Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as retired instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -75,7 +75,7 @@ Counting: Faulting executions of GETSEC/VM entry/VM Exit/MWait will not count as
       EventDef::Encoding{
           .code = 0x00, .umask = 0x03, .cmask = 0, .msr_values = {0}},
       R"(Reference cycles when the core is not in halt state.)",
-      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events. 
+      R"(This event counts the number of reference cycles when the core is not in a halt state. The core enters the halt state when it is running the HLT instruction or the MWAIT instruction. This event is not affected by core frequency changes (for example, P states, TM2 transitions) but has the same incrementing frequency as the time stamp counter. This event can approximate elapsed time while the core was not in a halt state. This event has a constant ratio with the CPU_CLK_UNHALTED.REF_XCLK event. It is counted on a dedicated fixed counter, leaving the four (eight when Hyperthreading is disabled) programmable counters available for other events.
 Note: On all current platforms this event stops counting during 'throttling (TM)' states duty off periods the processor is 'halted'.  This event is clocked by base clock (100 Mhz) on Sandy Bridge. The counter update is done at a lower clock rate then the core clock the overflow status bit for this counter may appear 'sticky'.  After the counter has overflowed and software clears the overflow status bit and resets the counter to less than MAX. The reset value to the counter is not clocked immediately so the overflow status bit will flip 'high (1)' and generate another PMI (if enabled) after which the reset value gets clocked into the counter. Therefore, software will get the interrupt, read the overflow status bit '1 for bit 34 while the counter value is less than MAX. Software should ignore this case.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -2361,7 +2361,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       R"(Uops not delivered to Resource Allocation Table (RAT) per thread when backend of the machine is not stalled)",
       R"(This event counts the number of uops not delivered to Resource Allocation Table (RAT) per thread adding 4  x when Resource Allocation Table (RAT) is not stalled and Instruction Decode Queue (IDQ) delivers x uops to Resource Allocation Table (RAT) (where x belongs to {0,1,2,3}). Counting does not cover cases when:
  a. IDQ-Resource Allocation Table (RAT) pipe serves the other thread;
- b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions); 
+ b. Resource Allocation Table (RAT) is stalled for the thread (including uop drops and clear BE conditions);
  c. Instruction Decode Queue (IDQ) delivers four uops.)",
       2000003,
       std::nullopt, // ScaleUnit
@@ -3174,7 +3174,7 @@ Note: A prefetch promoted to Demand is counted from the promotion point.)",
       EventDef::Encoding{
           .code = 0xAB, .umask = 0x02, .cmask = 0, .msr_values = {0}},
       R"(Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles.)",
-      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop. 
+      R"(This event counts Decode Stream Buffer (DSB)-to-MITE switch true penalty cycles. These cycles do not include uops routed through because of the switch itself, for example, when Instruction Decode Queue (IDQ) pre-allocation is unavailable, or Instruction Decode Queue (IDQ) is full. SBD-to-MITE switch true penalty cycles happen after the merge mux (MM) receives Decode Stream Buffer (DSB) Sync-indication until receiving the first MITE uop.
 MM is placed before Instruction Decode Queue (IDQ) to merge uops being fed from the MITE and Decode Stream Buffer (DSB) paths. Decode Stream Buffer (DSB) inserts the Sync-indication whenever a Decode Stream Buffer (DSB)-to-MITE switch occurs.
 Penalty: A Decode Stream Buffer (DSB) hit followed by a Decode Stream Buffer (DSB) miss can cost up to six cycles in which no uops are delivered to the IDQ. Most often, such switches from the Decode Stream Buffer (DSB) to the legacy pipeline cost 02 cycles.)",
       2000003,


### PR DESCRIPTION
Additional options for gputrace to setup pytorch profiler, issue #155 
```
dyno gputrace --record_shapes  --profile_memory --with_stacks --with_flops --with_modules
```
## Details
- Refactor gputrace config logic using structs/enums.
- Additional options
- Test to check gputrace config
- Setup pre-commit file