### PR TITLE
Add support to identify ARM CPUs

### DIFF
--- a/hbt/src/common/System.cpp
+++ b/hbt/src/common/System.cpp
@@ -8,6 +8,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cinttypes>
+#include <cstdio>
 
 #include <cstring>
 #include <fstream>
@@ -18,6 +20,9 @@
 #include <thread>
 
 namespace facebook::hbt {
+
+constexpr const char* kArmMidrFile =
+    "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
 
 std::string tstampToStr(TimeStamp ts) {
   if (ts == kInvalidTimeStamp) {
@@ -355,11 +360,60 @@ CpuInfo readCpu(std::ifstream& s) {
   return CpuInfo(vendor_id, cpu_family, cpu_model, cpu_step);
 }
 
+CpuInfo readCpuArm() {
+  std::string vendor_id;
+  uint32_t cpu_family = 0, cpu_model = 0, cpu_step = 0;
+
+  // Read ARM MIDR register
+  // NOTE We only detect CPU architecture for one core and assume
+  // it is homogenous, this will not be true for ARM big.LITTLE cases.
+  if (0 != ::access(kArmMidrFile, R_OK)) {
+    HBT_LOG_WARNING() << "Cannot access ARM MIDR file = " << kArmMidrFile;
+    return CpuInfo(vendor_id, cpu_family, cpu_model, cpu_step);
+  }
+
+  std::ifstream s(kArmMidrFile);
+  // MIDR is a 64 bit register-> 16 hex digits
+  std::array<char, 20> midrStr; // some space for 0x and null term
+  s.getline(&midrStr[0], 20);
+
+  HBT_DLOG_INFO() << "ARM MIDR = " << std::string{&midrStr[0]};
+
+  uint64_t midr = 0;
+  uint32_t implementor = 0, variant = 0, revision = 0;
+
+  // SCNx64 is the format specifier for hex 64 bit numbers
+  sscanf(&midrStr[0], "0x%" SCNx64, &midr);
+
+  implementor = (midr >> 24) & 0xff; // Implementor : Bits[31:24]
+  variant = (midr >> 20) & 0xf; // Variant : Bits[23:20]
+  cpu_model = (midr >> 4) & 0xfff; // PartNum : Bits[15:4]
+  revision = midr & 0xf; // Revision : Bits[3:0]
+
+  HBT_DLOG_INFO() << "Implementor = " << implementor
+                  << " cpu_model = " << cpu_model << " step r" << variant << "p"
+                  << revision;
+
+  // ARM saves revisions in rMpN format (example r0p3)
+  // since M and N are only 4 bit unsigned numbers, just merge them
+  cpu_step = (variant << 4) + revision;
+
+  vendor_id = perf_event::armVendorIDFromInt(implementor);
+
+  return CpuInfo(vendor_id, cpu_family, cpu_model, cpu_step, implementor);
+}
+
 CpuInfo CpuInfo::load() {
+  // /proc/cpuinfo format only has reasonable information
+  // on x86 architectures.
+#if defined(__aarch64__)
+  return readCpuArm();
+#else
   std::ifstream s("/proc/cpuinfo");
 
   // Only read CPU 0.
   return readCpu(s);
+#endif
 }
 
 std::ostream& operator<<(std::ostream& os, const CpuInfo& cpu_info) {

--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -290,6 +290,7 @@ struct CpuInfo {
   perf_event::CpuFamily cpu_family;
   perf_event::CpuArch cpu_arch;
 
+  uint32_t vendor_id_int; // only set on ARM platforms
   std::string vendor_id;
   uint32_t cpu_family_num;
   uint32_t cpu_model_num;
@@ -299,12 +300,15 @@ struct CpuInfo {
       const std::string& vendor_id,
       uint32_t cpu_family_num,
       uint32_t cpu_model_num,
-      uint32_t cpu_step_num)
+      uint32_t cpu_step_num,
+      uint32_t vendor_id_int = 0)
       : cpu_family(perf_event::makeCpuFamily(cpu_family_num)),
         cpu_arch(perf_event::makeCpuArch(
+            vendor_id_int,
             cpu_family_num,
             cpu_model_num,
             cpu_step_num)),
+        vendor_id_int(vendor_id_int),
         vendor_id(vendor_id),
         cpu_family_num(cpu_family_num),
         cpu_model_num(cpu_model_num),

--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "hbt/src/common/Defs.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
+#include "hbt/src/perf_event/CpuArch.h"
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>

--- a/hbt/src/common/tests/SystemTest.cpp
+++ b/hbt/src/common/tests/SystemTest.cpp
@@ -280,3 +280,8 @@ TEST(Pow2, log2NextPow2) {
   EXPECT_EQ(log2NextPow2((uint64_t)6), 3);
   EXPECT_EQ(log2NextPow2((uint64_t)8), 3);
 }
+
+TEST(SystemTest, CpuInfoTest) {
+  auto cpu_info = CpuInfo::load();
+  HBT_LOG_INFO() << "CpuInfo = " << cpu_info;
+}

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -10,10 +10,10 @@
 #include "hbt/src/intel_pt/IptEventBuilder.h"
 #include "hbt/src/perf_event/AmdEvents.h"
 #include "hbt/src/perf_event/BuiltinMetrics.h"
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/Metrics.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 #ifdef USE_JSON_GENERATED_PERF_EVENTS
 #include "hbt/src/perf_event/json_events/generated/intel/JsonEvents.h"
 #endif // USE_JSON_GENERATED_PERF_EVENTS

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -465,7 +465,7 @@ std::shared_ptr<PmuDeviceManager> makePmuDeviceManager() {
 
   if (cpu_info.cpu_family == CpuFamily::AMD) {
     addAmdEvents(cpu_info, *pmu_manager);
-  } else {
+  } else if (cpu_info.cpu_family == CpuFamily::INTEL) {
     //
     // Add Intel generated events
     //
@@ -478,6 +478,10 @@ std::shared_ptr<PmuDeviceManager> makePmuDeviceManager() {
                       << e.what() << "\"";
     }
 #endif // USE_JSON_GENERATED_PERF_EVENTS
+  } else if (cpu_info.cpu_family == CpuFamily::ARM) {
+    /* TODO */
+  } else {
+    HBT_LOG_ERROR() << "Unknown CPU family\n";
   }
 
   // Add predefined offcore events

--- a/hbt/src/perf_event/BuiltinMetrics.h
+++ b/hbt/src/perf_event/BuiltinMetrics.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/Metrics.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -10,6 +10,10 @@ add_subdirectory(tests)
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+add_library(CpuArch CpuArch.h)
+set_target_properties(CpuArch PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(CpuArch PUBLIC CpuArchGen)
+
 add_library(PmuEvent PmuEvent.h PmuEvent.cpp)
 target_link_libraries(PmuEvent PUBLIC System)
 

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -45,6 +45,85 @@ inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
 #endif
 }
 
+inline const char* armVendorIDFromInt(uint32_t vid) {
+  switch (vid) {
+    case 0x00:
+      return "Reserved";
+    case 0xC0:
+      return "Ampere Computing";
+    case 0x41:
+      return "Arm Limited";
+    case 0x42:
+      return "Broadcom Corporation";
+    case 0x43:
+      return "Cavium Inc.";
+    case 0x44:
+      return "Digital Equipment Corporation";
+    case 0x46:
+      return "Fujitsu Ltd.";
+    case 0x49:
+      return "Infineon Technologies AG";
+    case 0x4D:
+      return "Motorola or Freescale Semiconductor Inc.";
+    case 0x4E:
+      return "NVIDIA Corporation";
+    case 0x50:
+      return "Applied Micro Circuits Corporation";
+    case 0x51:
+      return "Qualcomm Inc.";
+    case 0x56:
+      return "Marvell International Ltd.";
+    case 0x69:
+      return "Intel Corporation";
+    default:
+      return "Unknown";
+  }
+}
+
 } // namespace facebook::hbt::perf_event
 
 #include "hbt/src/perf_event/json_events/generated/CpuArch.h"
+
+namespace facebook::hbt::perf_event {
+
+inline CpuArch makeCpuArchArm(
+    uint32_t vendor_id,
+    uint32_t /*cpu_family_num*/,
+    uint32_t cpu_model_num,
+    uint32_t /*cpu_step_num*/) {
+  switch (vendor_id) {
+    case 0x41: // ARM Limited
+      switch (cpu_model_num) {
+        case 0xD0C:
+          return CpuArch::NEOVERSE_N1;
+        case 0xD49:
+          return CpuArch::NEOVERSE_N2;
+        case 0xD4F:
+          return CpuArch::NEOVERSE_V2;
+        default:
+          return CpuArch::UNKNOWN;
+      }
+    case 0xC0: // Ampere Computing
+      switch (cpu_model_num) {
+        case 0xAC3:
+          return CpuArch::AMPERE_ONE;
+        default:
+          return CpuArch::UNKNOWN;
+      }
+  }
+  return CpuArch::UNKNOWN;
+}
+
+inline CpuArch makeCpuArch(
+    uint32_t vendor_id,
+    uint32_t cpu_family_num,
+    uint32_t cpu_model_num,
+    uint32_t cpu_step_num) {
+#if defined(__aarch64__)
+  return makeCpuArchArm(vendor_id, cpu_family_num, cpu_model_num, cpu_step_num);
+#else
+  return makeCpuArchX86(vendor_id, cpu_family_num, cpu_model_num, cpu_step_num);
+#endif
+}
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Generated file. Do not modify.
+
+#pragma once
+
+#include <sstream>
+
+namespace facebook::hbt::perf_event {
+
+enum class CpuFamily { AMD, INTEL, ARM, UNKNOWN };
+
+inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
+  switch (f) {
+    case CpuFamily::AMD:
+      return os << "AMD";
+    case CpuFamily::INTEL:
+      return os << "INTEL";
+    case CpuFamily::ARM:
+      return os << "ARM";
+    case CpuFamily::UNKNOWN:
+      return os << "UNKNOWN";
+  }
+}
+
+// Create CpuFamily enumeration from integer.
+inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
+#if defined(__x86_64__)
+  switch (cpu_family) {
+    case 6:
+      return CpuFamily::INTEL;
+    case 25:
+      return CpuFamily::AMD;
+    // Not recognized CPU model.
+    default:
+      return CpuFamily::UNKNOWN;
+  }
+#elif defined(__aarch64__)
+  return CpuFamily::ARM;
+#else
+  return CpuFamily::UNKNOWN;
+#endif
+}
+
+} // namespace facebook::hbt::perf_event
+
+#include "hbt/src/perf_event/json_events/generated/CpuArch.h"

--- a/hbt/src/perf_event/Metrics.h
+++ b/hbt/src/perf_event/Metrics.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 #include <map>
 #include <memory>

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/PmuEvent.h"
-#include "hbt/src/perf_event/json_events/generated/CpuArch.h"
 
 #include <bitset>
 #include <map>

--- a/hbt/src/perf_event/json_events/generated/CMakeLists.txt
+++ b/hbt/src/perf_event/json_events/generated/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-add_library(CpuArch CpuArch.h)
-set_target_properties(CpuArch PROPERTIES LINKER_LANGUAGE CXX)
+add_library(CpuArchGen CpuArch.h)
+set_target_properties(CpuArchGen PROPERTIES LINKER_LANGUAGE CXX)
 
 if(USE_JSON_GENERATED_PERF_EVENTS)
   add_subdirectory(intel)

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -11,7 +11,11 @@ namespace facebook::hbt::perf_event {
 
 enum class CpuArch {
   // ARM Architectures
-  GRACE,
+  NEOVERSE_N1,
+  NEOVERSE_N2,
+  NEOVERSE_V2,
+  AMPERE_ONE,
+
   // AMD Architectures
   MILAN,
   GENOA,
@@ -39,8 +43,14 @@ enum class CpuArch {
 
 inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
   switch (ev) {
-    case CpuArch::GRACE:
-      return os << "GRACE";
+    case CpuArch::NEOVERSE_N1:
+      return os << "NEOVERSE_N1";
+    case CpuArch::NEOVERSE_N2:
+      return os << "NEOVERSE_N2";
+    case CpuArch::NEOVERSE_V2:
+      return os << "NEOVERSE_V2";
+    case CpuArch::AMPERE_ONE:
+      return os << "AMPERE_ONE";
     case CpuArch::MILAN:
       return os << "MILAN";
     case CpuArch::GENOA:
@@ -85,7 +95,8 @@ inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
 }
 
 // Create CpuArch from CPU information in integers.
-inline CpuArch makeCpuArch(
+inline CpuArch makeCpuArchX86(
+    uint32_t /*vendor_id*/,
     uint32_t cpu_family_num,
     uint32_t cpu_model_num,
     uint32_t cpu_step_num) {

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -9,32 +9,9 @@
 
 namespace facebook::hbt::perf_event {
 
-enum class CpuFamily { AMD, INTEL, UNKNOWN };
-
-inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
-  switch (f) {
-    case CpuFamily::AMD:
-      return os << "AMD";
-    case CpuFamily::INTEL:
-      return os << "INTEL";
-    case CpuFamily::UNKNOWN:
-      return os << "UNKNOWN";
-  }
-}
-// Create CpuFamily enumeration from integer.
-inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
-  switch (cpu_family) {
-    case 6:
-      return CpuFamily::INTEL;
-    case 25:
-      return CpuFamily::AMD;
-    // Not recognized CPU model.
-    default:
-      return CpuFamily::UNKNOWN;
-  }
-}
-
 enum class CpuArch {
+  // ARM Architectures
+  GRACE,
   // AMD Architectures
   MILAN,
   GENOA,
@@ -62,8 +39,14 @@ enum class CpuArch {
 
 inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
   switch (ev) {
+    case CpuArch::GRACE:
+      return os << "GRACE";
     case CpuArch::MILAN:
       return os << "MILAN";
+    case CpuArch::GENOA:
+      return os << "GENOA";
+    case CpuArch::BERGAMO:
+      return os << "BERGAMO";
     case CpuArch::BDW:
       return os << "BDW";
     case CpuArch::BDW_DE:
@@ -111,6 +94,10 @@ inline CpuArch makeCpuArch(
     switch (cpu_model_num) {
       case 1:
         return CpuArch::MILAN;
+      case 17:
+        return CpuArch::GENOA;
+      case 160:
+        return CpuArch::BERGAMO;
     }
   } else if (cpu_family == CpuFamily::INTEL) {
     switch (cpu_model_num) {


### PR DESCRIPTION
Summary:
Identify ARM CPUs using ARM MIDR register

https://developer.arm.com/documentation/ddi0601/2020-12/AArch64-Registers/MIDR-EL1--Main-ID-Register

Part numbers identified by public documentation
1. Neoverse N1 - 0xD0C [doc](https://developer.arm.com/documentation/100616/0301/register-descriptions/aarch64-system-registers/midr-el1--main-id-register--el1)
2. Neoverse N2 - 0xD49 [doc](https://developer.arm.com/documentation/102099/0003/AArch64-registers/AArch64-Identification-registers-summary/MIDR-EL1--Main-ID-Register?lang=en)
3. Neoverse V2 - 0xD4F [doc](https://developer.arm.com/documentation/102375/0002)
4. Ampere One - 0xAC3

Differential Revision: D47309750

