### PR TITLE
Fix compilation error in CpuArc

### DIFF
--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -27,7 +27,13 @@ inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
 }
 
 // Create CpuFamily enumeration from integer.
-inline CpuFamily makeCpuFamily(uint32_t cpu_family) {
+inline CpuFamily makeCpuFamily(
+#if defined(__x86_64__)
+    uint32_t cpu_family
+#else
+    uint32_t /* cpu_family */
+#endif
+) {
 #if defined(__x86_64__)
   switch (cpu_family) {
     case 6:


### PR DESCRIPTION
Summary:
Noticed some build failures when `-Werror,-Wunused-parameter` is used:
```
 buck-out/v2/gen/fbcode/d9c9d105b3705280/hbt/src/perf_event/__CpuArch__/buck-headers/hbt/src/perf_event/CpuArch.h:30:41: error: unused parameter 'cpu_family' [-Werror,-Wunused-parameter]
```

Reviewed By: nslingerland

Differential Revision: D47472700

