### PR TITLE
Implement per-CPU event collection in hbt.

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -233,6 +233,20 @@ class Monitor {
   }
 
   /// Read counts for all events opened in counting mode
+  /// in all PerCpuCountReaders.
+  std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>>
+  readAllCountsPerCpu() const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>> rvs;
+
+    for (auto& [k, cr] : count_readers_) {
+      HBT_THROW_ASSERT_IF(cr == nullptr);
+      rvs.emplace(k, cr->readPerCpu());
+    }
+    return rvs;
+  }
+
+  /// Read counts for all events opened in counting mode
   /// in PerCpuCountReader given by elem_id.
   std::optional<TCountReader::ReadValues> readCounts(
       const ElemId& elem_id) const {

--- a/hbt/src/perf_event/PerCpuBase.h
+++ b/hbt/src/perf_event/PerCpuBase.h
@@ -118,6 +118,26 @@ class PerCpuBase {
     return true;
   }
 
+  // Read all events from all monitored CPUs.
+  // The indexes of the vector does not correspond to actual CPU ids.
+  template <class T = typename TCpuBase::TMode>
+  mode::enable_if_counting_or_sampling<T, bool> readPerCpu(
+      std::vector<GroupReadValues<T>>& rv,
+      size_t numEvents) const {
+    if (!isOpen()) {
+      return false;
+    }
+    rv.reserve(this->getMonCpus().numCpus());
+    GroupReadValues<T> aux(numEvents);
+    for_each_cpu(cpu, this->getMonCpus()) {
+      if (!this->getCpuGenerator(cpu).read(aux)) {
+        return false;
+      }
+      rv.push_back(aux);
+    }
+    return true;
+  }
+
  protected:
   CpuSet mon_cpus_;
   std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;

--- a/hbt/src/perf_event/PerCpuCountReader.h
+++ b/hbt/src/perf_event/PerCpuCountReader.h
@@ -11,6 +11,7 @@
 #include "hbt/src/perf_event/PerCpuBase.h"
 
 #include <memory>
+#include <vector>
 
 namespace facebook::hbt::perf_event {
 
@@ -113,6 +114,15 @@ class PerCpuCountReader : public PerCpuBase<CpuCountReader> {
   std::optional<ReadValues> read() const {
     auto rv = makeReadValues();
     if (TBase::read(rv)) {
+      return std::make_optional(rv);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  std::optional<std::vector<ReadValues>> readPerCpu() const {
+    std::vector<ReadValues> rv;
+    if (TBase::readPerCpu(rv, getNumEvents())) {
       return std::make_optional(rv);
     } else {
       return std::nullopt;

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <sched.h>
 #include <chrono>
+#include <optional>
 
 using namespace facebook::hbt;
 using namespace facebook::hbt::perf_event;
@@ -207,6 +208,19 @@ TEST(PerCpuCountReader, SmokeTest) {
   ASSERT_GT(rv.getCount(cycles_ev_idx), total_count_cycles);
   ASSERT_GT(rv.getTimeRunning(), total_time_running);
   ASSERT_GT(rv.getTimeEnabled(), total_time_enabled);
+
+  // Read per CPUs
+  auto rv_percpu = g.readPerCpu();
+  ASSERT_NE(rv_percpu, std::nullopt);
+  for (auto& grv : *rv_percpu) {
+    if (grv.getTimeRunning() == 0) {
+      continue;
+    }
+    ASSERT_GT(grv.getCount(inst_ev_idx), 0);
+    ASSERT_GT(grv.getCount(cycles_ev_idx), 0);
+    ASSERT_GT(grv.getTimeRunning(), 0);
+    ASSERT_GT(grv.getTimeEnabled(), 0);
+  }
 
   // Reducer computes the ratio of instructions per cycle
   auto ipc = rv.getReducedCount(m->reducer);


### PR DESCRIPTION
Summary:
Hbt currently accumulates per CPU values in https://www.internalfb.com/code/fbsource/[79387c81c3b7]/fbcode/hbt/src/perf_event/PerCpuBase.h?lines=116.

We want to be able to return per-CPU values as well.

Differential Revision: D47485376

