### PR TITLE
Fix issues causing bperf-collection failures

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -29,7 +29,7 @@ namespace facebook::hbt::mon {
 template <class MuxGroupIdType>
 struct ManagedBPerfEventInfo {
   explicit ManagedBPerfEventInfo(MuxGroupIdType muxId)
-      : muxId{std::move(muxId)}, refCount{1} {}
+      : muxId{std::move(muxId)}, refCount{0} {}
   MuxGroupIdType muxId;
   size_t refCount;
 };


### PR DESCRIPTION
Summary:
When either the last task is removed or a config refresh ocurrs, the bperf metrics in hbt are not cleaned up.  When we attempt to  enable the events the follow error occurs:
```
#033[1m[ hbt info pid: 93749 on 2023-07-13 03:33:31.573405
  In open at fbcode/hbt/src/perf_event/BPerfEventsGroup.cpp:161]
 => #033[0mLoading leader program.
ERR 1689244411593 [dyno/cpp/server/TwTaskMonitor.cpp:656:emplaceTaskPerfCountReaders()] "pid: 93749 on 2023-07-13 03:33:31.593667 In emplaceBPerfCountReader at buck-out/v2/gen/fbcode/c3d198f7f21cd8c4/hbt/src/mon/__Monitor__/buck-headers/hbt/src/mon/Monitor.h:376.
#011Expected argument !mux_bperf_event_map_.count(mux_group_id) || mux_bperf_event_map_[mux_group_id] == bperf_eg.get() (0) == true (1). The provided BPerfEventsGroup has been used by another BPerfCountReader under a different mux group id. The same BPerfEventsGroup should have the same mux group id."
ERR 1689244411593 [dyno/cpp/server/TwTaskMonitor.cpp:657:emplaceTaskPerfCountReaders()] failed to construct PerfCountReader for task: tsp_atn/datainfra/bumblebee.atnsparktest2.tt/167 and key: DRAM_access_reads_per_second
```

This prevent collection of bperf metrics on the host and the untracked bperf events result in high multiplexing with perfdril counters.

This was due to:
* Off-by-one error, when the events for the first task are added `ManagedBPerfEventInfo` refCount is inited to 1 and then immediately incremented.
  * With this diff, refCount is inited to 0
* Metrics were erased after the the hbt Monitor was disabled.
  * Metrics are erased before the Monitor is disabled

Differential Revision: D47497843

