### PR TITLE
Initial support for running dynolog inside a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
+# CMAKE options
+ARG USE_PROMETHEUS=OFF
+
 FROM --platform=linux/amd64 amd64/ubuntu:20.04 AS ubuntu_build_x86
+ARG USE_PROMETHEUS
+
 # This required to avoid interactive build for tzdata
-ENV DEBIAN_FRONTEND=noninteractive 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
@@ -11,8 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ninja-build \
         tini \
         tree \
-        vim \
-    && rm -rf /var/lib/apt/lists/*
+        vim
+RUN if [ "$USE_PROMETHEUS" = "ON" ]; then apt-get install -y --no-install-recommends zlib1g-dev; fi
+RUN rm -rf /var/lib/apt/lists/*
 # Use Rust nightly with sparse index, https://github.com/rust-lang/cargo/issues/10781
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 ENV PATH /root/.cargo/bin:$PATH
@@ -23,9 +29,11 @@ COPY . .
 # Run the rust build directly
 RUN cd cli && /root/.cargo/bin/cargo +nightly build --release -Z sparse-registry --target-dir build
 
-RUN ./scripts/build.sh 2>&1 | tee build.log
+RUN if [ "$USE_PROMETHEUS" = "ON" ]; then ./scripts/install-prometheus-cpp.sh; fi
+RUN ./scripts/build.sh -DUSE_PROMETHEUS=${USE_PROMETHEUS} 2>&1 | tee build.log
 
 FROM --platform=linux/amd64 rockylinux:9 AS rocky_build_x86
+ARG USE_PROMETHEUS
 RUN yum update -y && \
     yum install -y \
         make \
@@ -40,6 +48,7 @@ RUN yum update -y && \
         systemd-rpm-macros \
         tree \
         vim
+RUN if [ "$USE_PROMETHEUS" = "ON" ]; then yum install -y zlib-devel; fi
 RUN dnf --enablerepo=crb install -y ninja-build
 # Use Rust nightly with sparse index, https://github.com/rust-lang/cargo/issues/10781
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
@@ -51,4 +60,15 @@ COPY . .
 # Run the rust build directly
 RUN cd cli && /root/.cargo/bin/cargo +nightly build --release -Z sparse-registry --target-dir build
 
-RUN ./scripts/build.sh 2>&1 | tee build.log
+RUN if [ "$USE_PROMETHEUS" = "ON" ]; then ./scripts/install-prometheus-cpp.sh;  fi
+RUN ./scripts/build.sh -DUSE_PROMETHEUS=${USE_PROMETHEUS} 2>&1 | tee build.log
+
+# Image for running dynolog daemon
+FROM --platform=linux/amd64 amd64/ubuntu:20.04 AS docker_dynolog
+ARG USE_PROMETHEUS
+RUN apt-get update &&  apt-get install -y --no-install-recommends tini
+COPY --from=ubuntu_build_x86 /workspace/dynolog/build/bin/dynolog /root/dynolog
+ENTRYPOINT ["/usr/bin/tini", "--", "/root/dynolog"]
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  docker-dynolog:
+    container_name: dynolog
+    build:
+      context: ./
+      target: docker_dynolog
+      args:
+        - USE_PROMETHEUS=ON
+    volumes:
+      - /proc:/proc
+
+
+
+
+

--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -25,6 +25,7 @@
 #include <fmt/ranges.h>
 #include <iostream>
 #include <vector>
+#include <utility>
 
 // If this version of linux/perf_event.h does not provide,
 // then add it.

--- a/scripts/install-prometheus-cpp.sh
+++ b/scripts/install-prometheus-cpp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+DOWNLOAD_DIR=$(mktemp -d)
+PROMETHEUS_CPP_VERSION="${PROMETHEUS_CPP_VERSION:-v1.1.0}"
+
+curl "https://github.com/jupp0r/prometheus-cpp/releases/download/${PROMETHEUS_CPP_VERSION}/prometheus-cpp-with-submodules.tar.gz" -o "${DOWNLOAD_DIR}/prometheus-cpp.tar.gz" -L
+tar -xf "${DOWNLOAD_DIR}/prometheus-cpp.tar.gz" -C "${DOWNLOAD_DIR}"
+
+mkdir "${DOWNLOAD_DIR}/prometheus-cpp-with-submodules/build"
+
+pushd "${DOWNLOAD_DIR}/prometheus-cpp-with-submodules/build"
+cmake -DENABLE_PUSH=OFF -DENABLE_TESTING=OFF ..
+cmake --build .
+cmake --install .
+popd


### PR DESCRIPTION
It would be nice to have dynolog run inside a docker and publish metrics to prometheus running in another container. 

- added a docker ARG to specify if dynolog should be compiled with prometheus support
- a script to build and install prometheus-cpp library as this is missing in both ubuntu20.04 and rockylinux9.
- added a docker target for creating a container to run dynolog
- added simple docker-compose file