### PR TITLE
Fix indirect include that breaks with gcc 12

### DIFF
--- a/hbt/src/perf_event/CpuEventsGroup.h
+++ b/hbt/src/perf_event/CpuEventsGroup.h
@@ -24,6 +24,7 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 // If this version of linux/perf_event.h does not provide,


### PR DESCRIPTION
Summary:
When testing the open source build, an error was found when building with GCC 12. This error stems from an indirect header inclusion that works in GCC 11, but is no longer available in GCC 12. The build error in GCC 12 is:

```
FAILED: hbt/src/perf_event/tests/CMakeFiles/CpuEventsGroupTest.dir/CpuEventsGroupTest.cpp.o
...
hbt/src/perf_event/CpuEventsGroup.h:407:16: error: ‘exchange’ is not a member of ‘std’
  407 |       : t(std::exchange(other.t, nullptr)) {
      |                ^~~~~~~~
```

This diff fixes the issue by directly including the `<utility>` header for the usage of `std::exchange` in the `CpuEventsGroup.h` file.

Differential Revision: D48089821

