### PR TITLE
fix empty cgroup path and cgroup output map cleanup issues

### DIFF
--- a/hbt/src/perf_event/BPerfCountReader.cpp
+++ b/hbt/src/perf_event/BPerfCountReader.cpp
@@ -97,6 +97,7 @@ BPerfEventsGroup* BPerfCountReader::getBPerfEventsGroup() const {
 }
 
 BPerfCountReader::~BPerfCountReader() {
+  disable();
   HBT_DCHECK(bperf_eg_ != nullptr);
 }
 


### PR DESCRIPTION
Summary:
1) ignore tw tasks without a cgroup v2 path to avoid TwTaskMonitor opening bperf counters for a invalid cgroup

2) call disable() when BperfCountReader is destroyed so it can remove its inode key from the shared cgroup output map.

Differential Revision: D48657930

