### PR TITLE
Fix hostname read to correctly truncate on large hostnames

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -569,9 +569,11 @@ inline int readIntFromFile(std::string filepath) {
 
 /// Wrapper for gethostname
 inline std::string getHostName() {
-  char b[HOST_NAME_MAX];
-  int ret = ::gethostname(b, HOST_NAME_MAX);
+  char b[HOST_NAME_MAX + 1];
+  int ret = ::gethostname(b, HOST_NAME_MAX + 1);
   HBT_THROW_SYSTEM_IF(0 > ret, errno);
+  // null terminate to truncate the name if required
+  b[HOST_NAME_MAX] = '\0';
   return std::string{b};
 }
 

--- a/hbt/src/common/tests/SystemTest.cpp
+++ b/hbt/src/common/tests/SystemTest.cpp
@@ -285,3 +285,9 @@ TEST(SystemTest, CpuInfoTest) {
   auto cpu_info = CpuInfo::load();
   HBT_LOG_INFO() << "CpuInfo = " << cpu_info;
 }
+
+TEST(SystemTest, GetHostNameTest) {
+  auto hostname = getHostName();
+  EXPECT_GT(hostname.size(), 0);
+  HBT_LOG_INFO() << "hostname = " << hostname;
+}


### PR DESCRIPTION
Summary: As above

Reviewed By: haowangludx

Differential Revision: D48854710

