### PR TITLE
Replace memcmp with checked_memcmp

### DIFF
--- a/dynolog/src/tracing/IPCMonitor.cpp
+++ b/dynolog/src/tracing/IPCMonitor.cpp
@@ -46,9 +46,18 @@ void IPCMonitor::processMsg(std::unique_ptr<ipcfabric::Message> msg) {
     LOG(ERROR) << "Fabric Manager not initialized";
     return;
   }
-  if (memcmp(msg->metadata.type, kLibkinetoContext.c_str(), 4) == 0) {
+  // sizeof(msg->metadata.type) = 32, well above the size of the constant
+  // strings we are comparing against. memcmp is safe
+  if (memcmp( // NOLINT(facebook-security-vulnerable-memcmp)
+          msg->metadata.type,
+          kLibkinetoContext.data(),
+          kLibkinetoContext.size()) == 0) {
     registerLibkinetoContext(std::move(msg));
-  } else if (memcmp(msg->metadata.type, kLibkinetoRequest.c_str(), 3) == 0) {
+  } else if (
+      memcmp( // NOLINT(facebook-security-vulnerable-memcmp)
+          msg->metadata.type,
+          kLibkinetoRequest.data(),
+          kLibkinetoRequest.size()) == 0) {
     getLibkinetoOnDemandRequest(std::move(msg));
   } else {
     LOG(ERROR) << "TYPE UNKOWN: " << msg->metadata.type;

--- a/dynolog/src/tracing/IPCMonitor.h
+++ b/dynolog/src/tracing/IPCMonitor.h
@@ -15,7 +15,7 @@ class IPCMonitor {
  public:
   using FabricManager = dynolog::ipcfabric::FabricManager;
   IPCMonitor(const std::string& ipc_fabric_name = "dynolog");
-  virtual ~IPCMonitor(){};
+  virtual ~IPCMonitor() {}
 
   void loop();
 


### PR DESCRIPTION
Summary: No behavior change expected other than: A out-of-cound buffer access is now an abort. Looking at the code this should not have been a possibility, but a future change in the type names, or the type buffer size could have exposed an issue.

Differential Revision: D44138204


