### PR TITLE
break down group events to single event (#154)

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -52,7 +52,6 @@ class BPerfEventsGroup {
   ///
   ///  - name: Name for eBPF maps.
   ///  - confs: Event Confs for group.
-
   BPerfEventsGroup(const std::string& name, const EventConfs& confs);
   BPerfEventsGroup(
       const std::string& name,


### PR DESCRIPTION
Summary:

break down group events. TwTaskMonitor will create one MetricFrame per <TwTask, Event>.

add a second parameter `PerfMetricReducerFunc` to `readTaskPerfCounters()` function so user can provide a custom callback to calculate final metric value from multiple events.

Reviewed By: bigzachattack

Differential Revision: D46748433


