### PR TITLE
Fix compiler warning issues in dynolog/src/metric_frame/MetricSeries.h

### DIFF
--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -198,8 +198,6 @@ class MetricSeries final {
       std::chrono::steady_clock::duration duration,
       std::optional<Iterator> beginMaybe = std::nullopt,
       std::optional<Iterator> endMaybe = std::nullopt) const {
-    auto begin_ = beginMaybe.value_or(begin());
-    auto end_ = endMaybe.value_or(end());
     auto value = diff(beginMaybe, endMaybe);
     return rate<R>(value, period, duration);
   }


### PR DESCRIPTION
Summary:
This diff fixes issues identified by one or more of these compiler warning flags:
* `-Wpessimizing-move`
* `-Wmissing-braces `
* `-Wself-assign`
* `-Wunused-lambda-capture `
* `-Wheader-hygiene`
* `-Wunused-variable`

If the code compiles, it should work.

Differential Revision: D51571581


