### PR TITLE
refactor CpuBase to potentially support non-core device

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -234,10 +234,11 @@ class Monitor {
 
   /// Read counts for all events opened in counting mode
   /// in all PerCpuCountReaders.
-  std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>>
+  std::map<ElemId, std::optional<std::map<int, TCountReader::ReadValues>>>
   readAllCountsPerCpu() const {
     std::lock_guard<std::mutex> lock{mutex_};
-    std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>> rvs;
+    std::map<ElemId, std::optional<std::map<int, TCountReader::ReadValues>>>
+        rvs;
 
     for (auto& [k, cr] : count_readers_) {
       HBT_THROW_ASSERT_IF(cr == nullptr);

--- a/hbt/src/perf_event/BPerfCountReader.cpp
+++ b/hbt/src/perf_event/BPerfCountReader.cpp
@@ -5,8 +5,8 @@
 
 #include "hbt/src/perf_event/BPerfCountReader.h"
 #include "hbt/src/perf_event/BPerfEventsGroup.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/BPerfCountReader.h
+++ b/hbt/src/perf_event/BPerfCountReader.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -9,8 +9,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
 #include "hbt/src/perf_event/bpf/bperf.h"

--- a/hbt/src/perf_event/PerCpuBase.h
+++ b/hbt/src/perf_event/PerCpuBase.h
@@ -5,144 +5,54 @@
 
 #pragma once
 
-#include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
-
-#include <map>
-#include <memory>
+#include "hbt/src/perf_event/PerPerfEventsGroupBase.h"
 
 namespace facebook::hbt::perf_event {
 
-// Base class to make a per-CPU generator (multiple CPUs)
-// from a type defined for a single CPU.
-template <class TCpuBase>
-class PerCpuBase {
+template <class TPerfEventGroupGenBase>
+class PerCpuBase : public PerPerfEventsGroupBase<TPerfEventGroupGenBase> {
  public:
+  using TBase = PerPerfEventsGroupBase<TPerfEventGroupGenBase>;
   PerCpuBase(
       const CpuSet& mon_cpus,
       std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
-      : mon_cpus_{mon_cpus}, cgroup_fd_wrapper_{cgroup_fd_wrapper} {
-    // Base class must initialize <cpu_generators_> entries.
-    cpu_generators_.resize(mon_cpus.max_cpu_id + 1);
-  }
-
-  void close() {
-    for_each_cpu(cpu, mon_cpus_) {
-      getCpuGenerator(cpu).close();
+      : TBase(cgroup_fd_wrapper), mon_cpus_{mon_cpus} {
+    for_each_cpu(cpu, mon_cpus) {
+      TBase::generators_.insert(std::make_pair(static_cast<int>(cpu), nullptr));
     }
   }
-
-  void enable() {
-    try {
-      for_each_cpu(cpu, mon_cpus_) {
-        getCpuGenerator(cpu).enable();
-      }
-    } catch (std::exception& /*e*/) {
-      for_each_cpu(cpu, mon_cpus_) {
-        auto& cg = getCpuGenerator(cpu);
-        if (cg.isEnabled()) {
-          cg.disable();
-        }
-      }
-      throw;
-    }
-  }
-
-  bool isEnabled() const {
-    // It should be all enabled or none.
-    bool enabled = getCpuGenerator(mon_cpus_.cpu_first_set()).isEnabled();
-    for_each_cpu(cpu, mon_cpus_) {
-      HBT_THROW_ASSERT_IF(enabled != getCpuGenerator(cpu).isEnabled())
-          << "CPU : " << cpu << " is not enabled while others are.";
-    }
-    return enabled;
-  }
-
-  void disable() {
-    for_each_cpu(cpu, mon_cpus_) {
-      getCpuGenerator(cpu).disable();
-    }
-  }
-
-  bool isOpen() const {
-    // It should be all open or none.
-    bool is_open = getCpuGenerator(mon_cpus_.cpu_first_set()).isOpen();
-    for_each_cpu(cpu, mon_cpus_) {
-      HBT_THROW_ASSERT_IF(is_open != getCpuGenerator(cpu).isOpen())
-          << "CPU : " << cpu << " is not open while others are.";
-    }
-    return is_open;
-  }
-
-  const TCpuBase& getCpuGenerator(CpuId cpu) const {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    HBT_ARG_CHECK(cpu_generators_.at(cpu) != nullptr)
-        << "No generator in CPU " << cpu;
-    return *cpu_generators_.at(cpu);
-  }
-
-  TCpuBase& getCpuGenerator(CpuId cpu) {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    return *cpu_generators_.at(cpu);
-  }
-
-  auto getCpuGeneratorPtr(CpuId cpu) {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    return cpu_generators_.at(cpu);
-  }
-
   auto getMonCpus() const {
     return mon_cpus_;
   }
-
-  template <class T = typename TCpuBase::TMode>
-  mode::enable_if_counting_or_sampling<T, bool> read(
-      GroupReadValues<T>& rv) const {
-    if (!isOpen()) {
-      return false;
-    }
-    rv.zero();
-    GroupReadValues<T> aux(rv.getNumEvents());
-    for_each_cpu(cpu, this->getMonCpus()) {
-      if (!this->getCpuGenerator(cpu).read(aux)) {
-        return false;
-      }
-      rv.accum(aux);
-    }
-    return true;
+  const TPerfEventGroupGenBase& getCpuGenerator(CpuId cpu) const {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return *TBase::generators_.at(key);
   }
 
-  // Read all events from all monitored CPUs.
-  // The indexes of the vector does not correspond to actual CPU ids.
-  template <class T = typename TCpuBase::TMode>
-  mode::enable_if_counting_or_sampling<T, bool> readPerCpu(
-      std::vector<GroupReadValues<T>>& rv,
-      size_t numEvents) const {
-    if (!isOpen()) {
-      return false;
-    }
-    rv.reserve(this->getMonCpus().numCpus());
-    GroupReadValues<T> aux(numEvents);
-    for_each_cpu(cpu, this->getMonCpus()) {
-      if (!this->getCpuGenerator(cpu).read(aux)) {
-        return false;
-      }
-      rv.push_back(aux);
-    }
-    return true;
+  TPerfEventGroupGenBase& getCpuGenerator(CpuId cpu) {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return *TBase::generators_.at(key);
+  }
+
+  auto getCpuGeneratorPtr(CpuId cpu) {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return TBase::generators_.at(key);
   }
 
  protected:
   CpuSet mon_cpus_;
-  std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;
-  // Must be initialized by base class.
-  std::vector<std::shared_ptr<TCpuBase>> cpu_generators_;
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PerPerfEventsGroupBase.h
+++ b/hbt/src/perf_event/PerPerfEventsGroupBase.h
@@ -1,0 +1,145 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
+
+#include <map>
+#include <memory>
+
+namespace facebook::hbt::perf_event {
+
+// Base class to manage a list of perf events group generators with the same
+// config.
+template <class TPerfEventGroupGenBase>
+class PerPerfEventsGroupBase {
+ public:
+  PerPerfEventsGroupBase(std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
+      : cgroup_fd_wrapper_{cgroup_fd_wrapper} {}
+
+  void close() {
+    for (auto& [_, gen] : generators_) {
+      gen->close();
+    }
+  }
+
+  void enable() {
+    try {
+      for (auto& [_, gen] : generators_) {
+        gen->enable();
+      }
+    } catch (std::exception& /*e*/) {
+      for (auto& [_, gen] : generators_) {
+        if (gen->isEnabled()) {
+          gen->disable();
+        }
+      }
+      throw;
+    }
+  }
+
+  bool isEnabled() const {
+    HBT_THROW_ASSERT_IF(generators_.empty())
+        << "PerPerfEventsGroupBase should always contain at least one generator.";
+    // It should be all enabled or none.
+    bool enabled = getFirstGenerator().isEnabled();
+    for (const auto& [key, gen] : generators_) {
+      HBT_THROW_ASSERT_IF(enabled != gen->isEnabled())
+          << "Generator with key=" << key
+          << " has a different isEnabled() status comparing to some other generators.";
+    }
+    return enabled;
+  }
+
+  void disable() {
+    for (auto& [_, gen] : generators_) {
+      gen->disable();
+    }
+  }
+
+  bool isOpen() const {
+    HBT_THROW_ASSERT_IF(generators_.empty())
+        << "PerPerfEventsGroupBase should always contain at least one generator.";
+    // It should be all open or none.
+    bool is_open = getFirstGenerator().isOpen();
+    for (const auto& [key, gen] : generators_) {
+      HBT_THROW_ASSERT_IF(is_open != gen->isOpen())
+          << "Generator with key=" << key
+          << " has a different isOpen() status comparing to some other generators.";
+    }
+    return is_open;
+  }
+
+  const TPerfEventGroupGenBase& getFirstGenerator() const {
+    HBT_ARG_CHECK(!generators_.empty()) << "No generator exists";
+    return *generators_.begin()->second;
+  }
+
+  TPerfEventGroupGenBase& getFirstGenerator() {
+    HBT_ARG_CHECK(!generators_.empty()) << "No generator exists";
+    return *generators_.begin()->second;
+  }
+
+  const TPerfEventGroupGenBase& getGenerator(int key) const {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return *generators_.at(key);
+  }
+
+  TPerfEventGroupGenBase& getGenerator(int key) {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return *generators_.at(key);
+  }
+
+  auto getGeneratorPtr(int key) {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return generators_.at(key);
+  }
+
+  template <class T = typename TPerfEventGroupGenBase::TMode>
+  mode::enable_if_counting_or_sampling<T, bool> read(
+      GroupReadValues<T>& rv) const {
+    if (!isOpen()) {
+      return false;
+    }
+    rv.zero();
+    GroupReadValues<T> aux(rv.getNumEvents());
+    for (const auto& [_, gen] : generators_) {
+      if (!gen->read(aux)) {
+        return false;
+      }
+      rv.accum(aux);
+    }
+    return true;
+  }
+
+  // Read all events from all monitored perf events group.
+  template <class T = typename TPerfEventGroupGenBase::TMode>
+  mode::enable_if_counting_or_sampling<T, bool> readPerPerfEventsGroup(
+      std::map<int, GroupReadValues<T>>& rv,
+      size_t numEvents) const {
+    if (!isOpen()) {
+      return false;
+    }
+    GroupReadValues<T> aux(numEvents);
+    for (const auto& [key, gen] : generators_) {
+      if (!gen->read(aux)) {
+        return false;
+      }
+      rv.insert(std::make_pair(key, aux));
+    }
+    return true;
+  }
+
+ protected:
+  std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;
+  // a hashmap contains per perf event group generators.
+  // definition of the key depends on the implementation of the class inherite
+  // from this class.
+  std::map<int, std::shared_ptr<TPerfEventGroupGenBase>> generators_;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PerfEventsGroup.h
+++ b/hbt/src/perf_event/PerfEventsGroup.h
@@ -586,21 +586,21 @@ static_assert(std::is_pod_v<GroupReadValues<mode::Sampling>::T>);
 /// Must implement a handleRecord* for each record type support in <TMode>.
 
 template <class TImpl, class TMode_>
-class CpuEventsGroupBase {
+class PerfEventsGroupBase {
  public:
   using TMode = TMode_;
 
   static constexpr size_t kPerfEventAttrSize = sizeof(perf_event_attr);
 
-  CpuEventsGroupBase(const CpuEventsGroupBase&) = delete;
+  PerfEventsGroupBase(const PerfEventsGroupBase&) = delete;
 
-  CpuEventsGroupBase(
+  PerfEventsGroupBase(
       CpuId cpu,
       pid_t pid,
       int cgroup_fd,
       const EventConfs& confs);
 
-  virtual ~CpuEventsGroupBase();
+  virtual ~PerfEventsGroupBase();
 
   void close();
 
@@ -681,7 +681,7 @@ class CpuEventsGroupBase {
 /// Must implement a handleRecord* for each record type support in <TMode>.
 
 template <class TImpl, class TMode_>
-class CpuEventsGroup : public CpuEventsGroupBase<TImpl, TMode_> {
+class PerfEventsGroup : public PerfEventsGroupBase<TImpl, TMode_> {
  public:
   using TMode = TMode_;
   using TSampleId = typename TMode::sample_id_t;
@@ -697,11 +697,11 @@ class CpuEventsGroup : public CpuEventsGroupBase<TImpl, TMode_> {
 
   static constexpr size_t kPerfEventAttrSize = sizeof(perf_event_attr);
 
-  CpuEventsGroup(const CpuEventsGroup&) = delete;
+  PerfEventsGroup(const PerfEventsGroup&) = delete;
 
-  using CpuEventsGroupBase<TImpl, TMode_>::CpuEventsGroupBase;
+  using PerfEventsGroupBase<TImpl, TMode_>::PerfEventsGroupBase;
 
-  virtual ~CpuEventsGroup() {}
+  virtual ~PerfEventsGroup() {}
 
   void close();
 
@@ -892,7 +892,7 @@ inline void writeDataTail(
 }
 
 template <class TImpl, class TMode>
-CpuEventsGroupBase<TImpl, TMode>::CpuEventsGroupBase(
+PerfEventsGroupBase<TImpl, TMode>::PerfEventsGroupBase(
     CpuId cpu,
     pid_t pid,
     int cgroup_fd,
@@ -906,14 +906,14 @@ CpuEventsGroupBase<TImpl, TMode>::CpuEventsGroupBase(
 }
 
 template <class TImpl, class TMode>
-CpuEventsGroupBase<TImpl, TMode>::~CpuEventsGroupBase() {
+PerfEventsGroupBase<TImpl, TMode>::~PerfEventsGroupBase() {
   if (isOpen()) {
     close();
   }
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
+void PerfEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
     const EventConfs& confs,
     uint64_t sample_period,
     struct perf_event_attr* attrs,
@@ -992,7 +992,7 @@ void CpuEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
 /// head page info, such as clocks.
 ///
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::open_counting_(
+void PerfEventsGroupBase<TImpl, TMode>::open_counting_(
     uint64_t sample_period,
     bool pinned,
     bool thread) {
@@ -1087,7 +1087,7 @@ void CpuEventsGroupBase<TImpl, TMode>::open_counting_(
 /// head page info, such as clocks.
 ///
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::open_(
+void PerfEventsGroup<TImpl, TMode>::open_(
     size_t num_data_pages,
     uint64_t sample_period,
     bool pinned,
@@ -1143,7 +1143,7 @@ void CpuEventsGroup<TImpl, TMode>::open_(
 }
 
 template <class TImpl, class TMode>
-int CpuEventsGroup<TImpl, TMode>::mmap_(int fd) {
+int PerfEventsGroup<TImpl, TMode>::mmap_(int fd) {
   HBT_DCHECK_GT(fd, 0);
   // Mmap sampling buffer for leader event.
   size_t mmap_size = page_size_ * (1 + num_data_pages_);
@@ -1202,7 +1202,7 @@ int CpuEventsGroup<TImpl, TMode>::mmap_(int fd) {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::closeEvents_() {
+void PerfEventsGroupBase<TImpl, TMode>::closeEvents_() {
   HBT_THROW_ASSERT_IF(!isOpen());
 
   // Reverse order to delete leader last.
@@ -1221,7 +1221,7 @@ void CpuEventsGroupBase<TImpl, TMode>::closeEvents_() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::close() {
+void PerfEventsGroupBase<TImpl, TMode>::close() {
   if (!isOpen()) {
     return;
   }
@@ -1232,7 +1232,7 @@ void CpuEventsGroupBase<TImpl, TMode>::close() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::close() {
+void PerfEventsGroup<TImpl, TMode>::close() {
   if (!this->isOpen()) {
     return;
   }
@@ -1274,7 +1274,7 @@ void CpuEventsGroup<TImpl, TMode>::close() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::enable(bool reset) {
+void PerfEventsGroupBase<TImpl, TMode>::enable(bool reset) {
   HBT_ARG_CHECK(isOpen()) << "Cannot enable events that are not open";
 
   if (enabled_) {
@@ -1318,7 +1318,7 @@ void CpuEventsGroupBase<TImpl, TMode>::enable(bool reset) {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::disable() {
+void PerfEventsGroupBase<TImpl, TMode>::disable() {
   HBT_ARG_CHECK(isOpen()) << "Cannot disable events that are not open";
 
   if (!enabled_)
@@ -1332,7 +1332,7 @@ void CpuEventsGroupBase<TImpl, TMode>::disable() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::changeSamplePeriod(
+void PerfEventsGroup<TImpl, TMode>::changeSamplePeriod(
     uint64_t new_sample_period) {
   if (this->sample_period_ == new_sample_period)
     return;
@@ -1345,7 +1345,7 @@ void CpuEventsGroup<TImpl, TMode>::changeSamplePeriod(
 }
 
 template <class TImpl, class TMode>
-void* CpuEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
+void* PerfEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
   if (aux_buffer_.size < size) {
     aux_buffer_.base = ::realloc(aux_buffer_.base, size);
     aux_buffer_.size = size;
@@ -1362,9 +1362,9 @@ void* CpuEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
 /// of actually collected events. If an error, it will return a
 /// negative value with error number.
 template <class TImpl, class TMode>
-ssize_t CpuEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
+ssize_t PerfEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
   HBT_ARG_CHECK(this->isOpen())
-      << "CpuEventsGroup must be open for events to be consumed "
+      << "PerfEventsGroup must be open for events to be consumed "
       << " (event fd must be valid). Did you mean to only disable it?";
 
   ssize_t err = 0;
@@ -1548,7 +1548,7 @@ ssize_t CpuEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
 
 exit:
   HBT_DCHECK_GE(max_num_records, num_records);
-  // HBT_LOG_INFO() << "CpuEventsGroup::consume err: " << err
+  // HBT_LOG_INFO() << "PerfEventsGroup::consume err: " << err
   //    << " data_head: " << data_head << " data_tail: " << data_tail
   //    << " num_records: " << num_records
   //    << " max_num_records: " << max_num_records;
@@ -1560,11 +1560,11 @@ exit:
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
+void PerfEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
     OnRbReadCallback callback,
     bool consume) {
   HBT_ARG_CHECK(this->isOpen())
-      << "CpuEventsGroup must be open for events to be consumed "
+      << "PerfEventsGroup must be open for events to be consumed "
       << " (event fd must be valid). Did you mean to only disable it?";
 
   auto mmap_header =
@@ -1613,10 +1613,10 @@ void CpuEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
 
 /// Convert TSC to kernel time (reference bus-cycles to nanoseconds since boot).
 template <class TImpl, class TMode>
-uint64_t CpuEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
+uint64_t PerfEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
     uint64_t tsc_cycles) const {
   HBT_DCHECK(mmap_base_ != nullptr)
-      << "Cannot call kernelTimeFromTsc in closed CpuEventsGroup "
+      << "Cannot call kernelTimeFromTsc in closed PerfEventsGroup "
       << "because perf_event mmap page is not available";
   auto mmap_header =
       static_cast<volatile struct perf_event_mmap_page*>(mmap_base_);
@@ -1630,9 +1630,10 @@ uint64_t CpuEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
 
 /// Convert kernel time to TSC (nanoseconds since boot to reference bus-cycles).
 template <class TImpl, class TMode>
-uint64_t CpuEventsGroup<TImpl, TMode>::tscFromKernelTime(uint64_t ktime) const {
+uint64_t PerfEventsGroup<TImpl, TMode>::tscFromKernelTime(
+    uint64_t ktime) const {
   HBT_THROW_ASSERT_IF(mmap_base_ == nullptr)
-      << "Cannot call tscFromKernelTimec in closed CpuEventsGroup "
+      << "Cannot call tscFromKernelTimec in closed PerfEventsGroup "
          "because perf_event mmap page is not available";
 
   // XXX: It's likely that time_mult is usually a hardware division friendly

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -71,13 +71,15 @@ class PmuDevice {
       std::optional<unsigned> pmu_device_enumeration,
       uint32_t perf_pmu_id,
       const std::string& desc,
-      bool in_sysfs)
+      bool in_sysfs,
+      std::optional<cpu_set_t> cpu_mask = std::nullopt)
       : pmu_name_{pmu_name},
         pmu_type_{pmu_type},
         pmu_device_enumeration_{pmu_device_enumeration},
         perf_pmu_id_{perf_pmu_id},
         desc_{desc},
-        in_sysfs_{in_sysfs} {}
+        in_sysfs_{in_sysfs},
+        cpu_mask_{cpu_mask} {}
 
   PmuDevice(const PmuDevice&) = delete;
   PmuDevice(PmuDevice&&) = delete;

--- a/hbt/src/perf_event/ThreadCountReader.h
+++ b/hbt/src/perf_event/ThreadCountReader.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 #include <memory>
 
@@ -21,9 +21,9 @@ namespace facebook::hbt::perf_event {
 //
 
 class ThreadCountReaderImpl
-    : public CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting> {
+    : public PerfEventsGroupBase<ThreadCountReaderImpl, mode::Counting> {
  public:
-  using TBase = CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting>;
+  using TBase = PerfEventsGroupBase<ThreadCountReaderImpl, mode::Counting>;
 
   /// Convenience type definition to create structure to store read values.
   using ReadValues = GroupReadValues<mode::Counting>;

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -212,7 +212,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Read per CPUs
   auto rv_percpu = g.readPerCpu();
   ASSERT_NE(rv_percpu, std::nullopt);
-  for (auto& grv : *rv_percpu) {
+  for (auto& [_, grv] : *rv_percpu) {
     if (grv.getTimeRunning() == 0) {
       continue;
     }

--- a/hbt/src/perf_event/tests/PerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/PerfEventsGroupTest.cpp
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 #include <gtest/gtest.h>
 #include <filesystem>
@@ -55,9 +55,9 @@ EventConfs constructIntelPTEventConfs() {
 }
 
 // Create a CRTP implementation for test purposes.
-class SamplingEvents : public CpuEventsGroup<SamplingEvents, mode::Sampling> {
+class SamplingEvents : public PerfEventsGroup<SamplingEvents, mode::Sampling> {
  public:
-  using TBase = CpuEventsGroup<SamplingEvents, mode::Sampling>;
+  using TBase = PerfEventsGroup<SamplingEvents, mode::Sampling>;
   using TMode = TBase::TMode;
 
   SamplingEvents(CpuId cpu, const EventConfs& confs)
@@ -89,9 +89,9 @@ class SamplingEvents : public CpuEventsGroup<SamplingEvents, mode::Sampling> {
 
 // Create a CRTP implementation for test purposes.
 class ContextSwitchEvents
-    : public CpuEventsGroup<ContextSwitchEvents, mode::ContextSwitch> {
+    : public PerfEventsGroup<ContextSwitchEvents, mode::ContextSwitch> {
  public:
-  using TBase = CpuEventsGroup<ContextSwitchEvents, mode::ContextSwitch>;
+  using TBase = PerfEventsGroup<ContextSwitchEvents, mode::ContextSwitch>;
   using TMode = TBase::TMode;
 
   ContextSwitchEvents(CpuId cpu, const EventConfs& confs)
@@ -131,9 +131,9 @@ class ContextSwitchEvents
   }
 };
 
-class IntelPTEvents : public CpuEventsGroup<IntelPTEvents, mode::AUXSpace> {
+class IntelPTEvents : public PerfEventsGroup<IntelPTEvents, mode::AUXSpace> {
  public:
-  using TBase = CpuEventsGroup<IntelPTEvents, mode::AUXSpace>;
+  using TBase = PerfEventsGroup<IntelPTEvents, mode::AUXSpace>;
   using TMode = TBase::TMode;
 
   IntelPTEvents(CpuId cpu, pid_t pid, const EventConfs& confs)
@@ -339,7 +339,7 @@ TEST(IntelPTEvents, SmokeTest_IntelPT) {
 TEST(ContextSwitchEvents, SmokeTest_IntelPTSpecificProcess) {
   /*
    * XXX: Temporarily comment because this test requires
-   * IntelPT availablity that is not always available in SandCastle.
+   * IntelPT availability that is not always available in SandCastle.
   // Fork a new process for testing
   auto pid = fork();
   ASSERT_NE(pid, -1);

--- a/hbt/src/tagstack/PerfEventStream.h
+++ b/hbt/src/tagstack/PerfEventStream.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/ringbuffer/Consumer.h"
 #include "hbt/src/tagstack/Event.h"
 


### PR DESCRIPTION
Summary: refactor PerCpuBase to PerPerfEventsGroupBase so it can handle perf events that are not one per core

Differential Revision: D50585192


