### PR TITLE
Remove extraneous semicolon from hbt/src/tagstack/Stream.h

### DIFF
--- a/hbt/src/tagstack/Stream.h
+++ b/hbt/src/tagstack/Stream.h
@@ -87,7 +87,6 @@ class RingBufferStream : protected ringbuffer::Consumer<TExtraData> {
     HBT_THROW_SYSTEM_CODE_IF(0 > ret, toErrorCode(-ret))
         << "RingBuffer read failed due to unexpected causes: "
         << toErrorCode(-ret).message();
-    ;
     HBT_THROW_ASSERT_IF(event == nullptr);
     HBT_THROW_ASSERT_IF(
         next_event_ != nullptr && event->happenedBefore(*next_event_));


### PR DESCRIPTION
Summary:
Extraneous semicolons are a code smell and can mask more serious problems. `-Wextra-semi-stmt` finds them.

This diff removes an extraneous semicolon or adjusts a macro so that a semicolon is required after the macro (making it look like a standard function).

This file is drawn from a heavy-hitting list, so fixing this problem will allow *many* other files to take advantage of the safety `-Wextra-semi-stmt` offers.

This should be a low-risk diff: if it compiles, it works.

Reviewed By: meyering

Differential Revision: D51631145


