### PR TITLE
Remove extraneous semicolon from hbt/src/ringbuffer/PerCpuRingBuffer.h

### DIFF
--- a/hbt/src/ringbuffer/PerCpuRingBuffer.h
+++ b/hbt/src/ringbuffer/PerCpuRingBuffer.h
@@ -159,7 +159,6 @@ class PerCpuRingBuffer final {
 
   size_t usedSizeWeak(CpuId cpu) const {
     return this->getCpuRingBuffer(cpu)->usedSizeWeak();
-    ;
   }
 
   auto getHeader() {


### PR DESCRIPTION
Summary:
Extraneous semicolons are a code smell and can mask more serious problems. `-Wextra-semi-stmt` finds them.

This diff removes an extraneous semicolon or adjusts a macro so that a semicolon is required after the macro (making it look like a standard function).

This file is drawn from a heavy-hitting list, so fixing this problem will allow *many* other files to take advantage of the safety `-Wextra-semi-stmt` offers.

This should be a low-risk diff: if it compiles, it works.

Reviewed By: meyering

Differential Revision: D51631126


