### PR TITLE
Remove extraneous semicolon from hbt/src/perf_event/PmuDevices.cpp

### DIFF
--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -88,7 +88,7 @@ std::string PmuTypeToStr(PmuType pmu_type) {
     CASE_PMU_TYPE(uncore_mchbm);
 
     CASE_PMU_TYPE(armv8_pmuv3);
-  };
+  }
 }
 
 /// Macro to generate "if" statements for PMU string names.


### PR DESCRIPTION
Summary:
Extraneous semicolons are a code smell and can mask more serious problems. `-Wextra-semi-stmt` finds them.

This diff removes an extraneous semicolon or adjusts a macro so that a semicolon is required after the macro (making it look like a standard function).

This file is drawn from a heavy-hitting list, so fixing this problem will allow *many* other files to take advantage of the safety `-Wextra-semi-stmt` offers.

This should be a low-risk diff: if it compiles, it works.

Reviewed By: meyering

Differential Revision: D51631141


