### PR TITLE
Remove extraneous semicolon from hbt/src/tagstack/Slicer.h

### DIFF
--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -400,7 +400,6 @@ class Slicer {
       //
 
       Slice::TransitionType sw_type = eventToTransitionType_(ev);
-      ;
       // HBT_LOG_INFO() << "sw_type: " << sw_type;
 
       auto* last_state = active_states_[group_idx];
@@ -871,7 +870,6 @@ class Slicer {
       resetState_();
       ++stats_.num_processed;
       return true;
-      ;
       // XXX: Keeps stats of failures like these.
     }
     return false;


### PR DESCRIPTION
Summary:
Extraneous semicolons are a code smell and can mask more serious problems. `-Wextra-semi-stmt` finds them.

This diff removes an extraneous semicolon or adjusts a macro so that a semicolon is required after the macro (making it look like a standard function).

This file is drawn from a heavy-hitting list, so fixing this problem will allow *many* other files to take advantage of the safety `-Wextra-semi-stmt` offers.

This should be a low-risk diff: if it compiles, it works.

Reviewed By: meyering

Differential Revision: D51631119


