### PR TITLE
Remove extra semi colon from dynolog/src/metric_frame/MetricFrameTsUnit.cpp

### DIFF
--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -30,7 +30,7 @@ std::optional<TimePoint> MetricFrameTsUnitFixInterval::firstSampleTime() const {
     return std::nullopt;
   }
   return lastSampleTime_ - (sampleCount_ - 1) * interval_;
-};
+}
 
 std::optional<TimePoint> MetricFrameTsUnitFixInterval::lastSampleTime() const {
   if (sampleCount_ == 0) {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777990


