### PR TITLE
Remove extra semi colon from dynolog/src/metric_frame/MetricFrame.cpp

### DIFF
--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -72,7 +72,7 @@ bool MetricFrameMap::incFromLastSample(
 
 size_t MetricFrameMap::width() const {
   return series_.size();
-};
+}
 
 std::optional<MetricSeriesVar> MetricFrameMap::series(
     const std::string& name) const {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777992


