### PR TITLE
Remove extra semi colon from hbt/src/tagstack/Slicer.h

### DIFF
--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -489,7 +489,7 @@ class Slicer {
       stats->emplace(ss.stats.stack_id, ss.stats);
     }
     return stats;
-  };
+  }
 
   auto getStats() const {
     return stats_;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777963


