### PR TITLE
bperf: Use tp_btf instead of raw_tp event

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -41,6 +41,8 @@ struct bperf_attr_map_elem {
   __u32 global_output_map_id;
   __u32 cgroup_output_map_id;
 
+  __u32 trigger_prog_id;
+
   void loadFromSkelLink(
       struct bperf_leader_cgroup* skel,
       struct bpf_link* link);
@@ -92,6 +94,7 @@ class BPerfEventsGroup {
   std::vector<struct perf_event_attr> attrs_;
   int leader_link_fd_ = -1;
   int leader_prog_fd_ = -1;
+  int trigger_prog_fd_ = -1;
   int global_output_fd_ = -1;
   int cgroup_output_fd_ = -1;
 


### PR DESCRIPTION
Summary:
This will make the context switch a little faster.
Note that we cannot use BPF_PROG_TEST_RUN on tp_btf program. To
do the BPF_PROG_TEST_RUN (gather running data to bpf maps on read),
we need another raw_tp program, which is not attached, but only used
for BPF_PROG_TEST_RUN.

Also, rename the programs as bperf_on_sched_switch and
bperf_read_trigger to be more clear that these program belongs to bperf.

Differential Revision: D51870606


