### PR TITLE
add an option to only update tw task cgroup rather than all cgroups

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -377,7 +377,8 @@ class Monitor {
       const MuxGroupId& mux_group_id,
       const ElemId& elem_id,
       std::shared_ptr<perf_event::BPerfEventsGroup> bperf_eg,
-      std::shared_ptr<FdWrapper> cgroup_fd_wrapper) {
+      std::shared_ptr<FdWrapper> cgroup_fd_wrapper,
+      int cgroup_update_level) {
     std::lock_guard<std::mutex> lock{mutex_};
     // Check for key before creating new count generator.
     HBT_ARG_CHECK_EQ(bperf_count_readers_.count(elem_id), 0)
@@ -392,7 +393,7 @@ class Monitor {
         << " under a different mux group id. The same BPerfEventsGroup should have the"
         << " same mux group id.";
     auto bperf_cnt_reader = std::make_unique<Monitor::TBPerfCountReader>(
-        std::move(bperf_eg), cgroup_fd_wrapper);
+        std::move(bperf_eg), cgroup_fd_wrapper, cgroup_update_level);
     if (!bperf_cnt_reader->enable()) {
       return nullptr;
     }

--- a/hbt/src/perf_event/BPerfCountReader.cpp
+++ b/hbt/src/perf_event/BPerfCountReader.cpp
@@ -12,9 +12,11 @@ namespace facebook::hbt::perf_event {
 
 BPerfCountReader::BPerfCountReader(
     std::shared_ptr<BPerfEventsGroup> bperf_eg_in,
-    std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
+    std::shared_ptr<FdWrapper> cgroup_fd_wrapper,
+    int cgroup_update_level)
     : bperf_eg_{std::move(bperf_eg_in)},
-      cgroup_fd_wrapper_{std::move(cgroup_fd_wrapper)} {}
+      cgroup_fd_wrapper_{std::move(cgroup_fd_wrapper)},
+      cgroup_update_level_{cgroup_update_level} {}
 
 size_t BPerfCountReader::getNumEvents() const {
   return bperf_eg_->getNumEvents();
@@ -26,7 +28,7 @@ BPerfCountReader::ReadValues BPerfCountReader::makeReadValues() const {
 
 bool BPerfCountReader::enable() {
   if (cgroup_fd_wrapper_) {
-    if (bperf_eg_->addCgroup(cgroup_fd_wrapper_)) {
+    if (bperf_eg_->addCgroup(cgroup_fd_wrapper_, cgroup_update_level_)) {
       cgroup_tracking_ = true;
     }
     return cgroup_tracking_;

--- a/hbt/src/perf_event/BPerfCountReader.h
+++ b/hbt/src/perf_event/BPerfCountReader.h
@@ -24,7 +24,8 @@ class BPerfCountReader {
 
   BPerfCountReader(
       std::shared_ptr<BPerfEventsGroup> bperf_eg_in,
-      std::shared_ptr<FdWrapper> cgroup_fd_wrapper);
+      std::shared_ptr<FdWrapper> cgroup_fd_wrapper,
+      int cgroup_update_level);
 
   size_t getNumEvents() const;
 
@@ -53,6 +54,7 @@ class BPerfCountReader {
   std::shared_ptr<BPerfEventsGroup> bperf_eg_;
 
   std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;
+  int cgroup_update_level_;
 
   bool cgroup_tracking_ = false;
 };

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -54,11 +54,15 @@ class BPerfEventsGroup {
   ///
   ///  - name: Name for eBPF maps.
   ///  - confs: Event Confs for group.
-  BPerfEventsGroup(const std::string& name, const EventConfs& confs);
+  BPerfEventsGroup(
+      const std::string& name,
+      const EventConfs& confs,
+      int cgroup_update_level);
   BPerfEventsGroup(
       const std::string& name,
       const MetricDesc& metric,
-      const PmuDeviceManager& pmu_manager);
+      const PmuDeviceManager& pmu_manager,
+      int cgroup_update_level);
 
   ~BPerfEventsGroup();
   static std::string attrMapPath();
@@ -73,7 +77,7 @@ class BPerfEventsGroup {
     return enabled_;
   }
 
-  bool addCgroup(std::shared_ptr<hbt::FdWrapper> fd);
+  bool addCgroup(std::shared_ptr<hbt::FdWrapper> fd, int cgroup_update_level);
   bool removeCgroup(__u64 id);
 
   // eBPF like interface to read counters from all CPUs and accumulate them.
@@ -102,6 +106,7 @@ class BPerfEventsGroup {
   bool enabled_ = false;
   int cpu_cnt_;
   std::vector<int> pe_fds_;
+  int cgroup_update_level_;
 
   // There could be multiple users of a given metric, e.g., global cycles.
   // To make them work in parallel, the BPF side never stop counting. Each

--- a/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
@@ -48,7 +48,7 @@ TEST(BPerfEventsGroupTest, RunSystemWide) {
   auto ev_conf =
       pmu->makeConf(ev_def->id, EventExtraAttr(), EventValueTransforms());
 
-  auto system = BPerfEventsGroup("cycles", EventConfs({ev_conf}));
+  auto system = BPerfEventsGroup("cycles", EventConfs({ev_conf}), 0);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE];
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
   if (!system.open() || !system.enable()) {
@@ -77,7 +77,7 @@ TEST(BPerfEventsGroupTest, RunCgroup) {
       instructions_def->id, EventExtraAttr(), EventValueTransforms());
   auto cgrpFdPtr = std::make_shared<FdWrapper>("/sys/fs/cgroup/system.slice/");
   auto cgrp =
-      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}));
+      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 1);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE];
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
 
@@ -85,7 +85,7 @@ TEST(BPerfEventsGroupTest, RunCgroup) {
     GTEST_SKIP() << "Skip RunCgroup test, do we have CAP_PERFMON?";
   }
 
-  cgrp.addCgroup(cgrpFdPtr);
+  cgrp.addCgroup(cgrpFdPtr, 1);
 
   cgrp.disable();
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -136,7 +136,7 @@ TEST(BPerfEventsGroupTest, MetricConstructor) {
       std::vector<std::string>{} // No post-processing dives
   );
 
-  auto eg = BPerfEventsGroup("ipc", *m, *pmu_manager);
+  auto eg = BPerfEventsGroup("ipc", *m, *pmu_manager, 0);
   if (!eg.open() || !eg.enable()) {
     GTEST_SKIP() << "Skip RunSystemWide test, do we have CAP_PERFMON?";
   }
@@ -164,7 +164,7 @@ TEST(BPerfEventsGroupTest, EnableDisable) {
   auto instructions_conf = pmu->makeConf(
       instructions_def->id, EventExtraAttr(), EventValueTransforms());
   auto eg =
-      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}));
+      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 0);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE] = {};
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
 
@@ -183,4 +183,30 @@ TEST(BPerfEventsGroupTest, EnableDisable) {
   EXPECT_EQ(prev[0].counter, val[0].counter);
   EXPECT_EQ(prev[0].enabled, val[0].enabled);
   EXPECT_EQ(prev[0].running, val[0].running);
+}
+
+TEST(BPerfEventsGroupTest, cgroup_update_level) {
+  auto pmu_manager = makePmuDeviceManager();
+  auto pmu = pmu_manager->findPmuDeviceByName("generic_hardware");
+  auto cycles_def = pmu_manager->findEventDef("cycles");
+  auto instructions_def = pmu_manager->findEventDef("instructions");
+  if (!cycles_def || !instructions_def) {
+    GTEST_SKIP() << "Cannot find event cycles/instructions";
+  }
+  auto cycles_conf =
+      pmu->makeConf(cycles_def->id, EventExtraAttr(), EventValueTransforms());
+  auto instructions_conf = pmu->makeConf(
+      instructions_def->id, EventExtraAttr(), EventValueTransforms());
+  auto cgrpFdPtr = std::make_shared<FdWrapper>("/sys/fs/cgroup/system.slice/");
+  auto cgrp =
+      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 2);
+  struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE];
+  struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
+
+  if (!cgrp.open() || !cgrp.enable()) {
+    GTEST_SKIP() << "Skip RunCgroup test, do we have CAP_PERFMON?";
+  }
+
+  EXPECT_FALSE(cgrp.addCgroup(cgrpFdPtr, 1))
+      << "BPerfEvents should only be able to track cgroup at level 3";
 }

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -286,14 +286,14 @@ TEST(BPerfCountReader, SmokeTest) {
   auto cgroup_path = "/sys/fs/cgroup/user.slice";
 
   auto eg =
-      std::make_shared<BPerfEventsGroup>("myperfunittest", *m, *pmu_manager);
+      std::make_shared<BPerfEventsGroup>("myperfunittest", *m, *pmu_manager, 1);
   if (!eg->open() || !eg->enable()) {
     GTEST_SKIP()
         << "Failed to open global perf events. Something is wrong with BPerfEventsGroup"
         << "or we don't have do we have CAP_PERFMON cap";
   }
   HBT_LOG_INFO() << cgroup_path;
-  BPerfCountReader g(eg, std::make_unique<FdWrapper>(cgroup_path));
+  BPerfCountReader g(eg, std::make_unique<FdWrapper>(cgroup_path), 1);
   g.enable();
   ASSERT_TRUE(g.isEnabled());
 


### PR DESCRIPTION
Summary: potentially just update tw task cgroup. we only care about those cgroups if we only want to count per tupperware task usage.

Differential Revision: D51875942


