### PR TITLE
Remove extra semi colon from dyno/cpp/server/parsing/util.h

### DIFF
--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -72,7 +72,7 @@ bool MetricFrameMap::incFromLastSample(
 
 size_t MetricFrameMap::width() const {
   return series_.size();
-};
+}
 
 std::optional<MetricSeriesVar> MetricFrameMap::series(
     const std::string& name) const {

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -30,7 +30,7 @@ std::optional<TimePoint> MetricFrameTsUnitFixInterval::firstSampleTime() const {
     return std::nullopt;
   }
   return lastSampleTime_ - (sampleCount_ - 1) * interval_;
-};
+}
 
 std::optional<TimePoint> MetricFrameTsUnitFixInterval::lastSampleTime() const {
   if (sampleCount_ == 0) {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995090


