### PR TITLE
Remove extra semi colon from hbt/src/mon/TraceCollector.cpp

### DIFF
--- a/hbt/src/mon/TraceCollector.cpp
+++ b/hbt/src/mon/TraceCollector.cpp
@@ -39,7 +39,7 @@ void TraceCollector::emplaceThreadGenerator(
           nullptr,
           TraceCollector::kTidLevel,
           params.thread_switch_aux_rb_min_num_events));
-};
+}
 
 void TraceCollector::emplaceTagStackGeneratorFromRbs(
     std::shared_ptr<TPhasesPerCpuRingBuffer> phases_per_cpu_rb,

--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -488,7 +488,7 @@ class Slicer {
       stats->emplace(ss.stats.stack_id, ss.stats);
     }
     return stats;
-  };
+  }
 
   auto getStats() const {
     return stats_;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995016


