### PR TITLE
Fix deprecated this capture in hbt/src/mon/TraceCollector.h

### DIFF
--- a/hbt/src/mon/TraceCollector.h
+++ b/hbt/src/mon/TraceCollector.h
@@ -141,7 +141,7 @@ class TraceCollector {
     HBT_DCHECK(dummy_gen_.isOpen());
     // A functor to call <now>.
     return TimeStampNsConverter::makeFromNow(
-        [=]() { return dummy_gen_.now(); });
+        [=, this]() { return dummy_gen_.now(); });
   }
 
   std::unique_ptr<tagstack::slice::TagStackStatsDump> getTagStackStatsDump()


### PR DESCRIPTION
Summary:
In the future LLVM will require that lambdas capture `this` explicitly. `-Wdeprecated-this-capture` checks for and enforces this now.

This diff adds an explicit `this` capture to a lambda to fix an issue that presents similarly to this:
```
   -> fbcode/path/to/my_file.cpp:66:47: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-
Wdeprecated-this-capture]
   ->           detail::createIOWorkerProvider(evb, requestsRegistry_);
   ->                                               ^
   -> fbcode/path/to/my_file.cpp:61:30: note: add an explicit capture of 'this' to capture '*this' by reference
   ->   evb->runInEventBaseThread([=, self_weak = std::move(self_weak)]() {
   ->                              ^
   ->                               , this
```

Reviewed By: meyering

Differential Revision: D52279219


