### PR TITLE
Remove unused exception parameter from files inc dyno/cpp/server/DynoUtil.cpp

### DIFF
--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -107,7 +107,7 @@ std::shared_ptr<DcgmGroupInfo> DcgmGroupInfo::factory(
     unsigned short field_id;
     try {
       field_id = (unsigned short)std::stoi(field);
-    } catch (std::invalid_argument& e) {
+    } catch (std::invalid_argument&) {
       LOG(ERROR) << "Field id must be number, instead got: " << field;
       continue;
     }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977834


