### PR TITLE
Remove unused exception parameter from files inc dynolog/src/rpc/SimpleJsonServerInl.h

### DIFF
--- a/dynolog/src/rpc/SimpleJsonServerInl.h
+++ b/dynolog/src/rpc/SimpleJsonServerInl.h
@@ -38,7 +38,7 @@ nlohmann::json toJson(const std::string& message) {
   }
   try {
     result = json::parse(message);
-  } catch (json::parse_error& ex) {
+  } catch (json::parse_error&) {
     LOG(ERROR) << "Error parsing message = " << message;
     return result;
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977808


