### PR TITLE
Remove unused exception parameter from files inc graphene/ticket/test/fuzz/GrapheneTicketFromStringFuzzer.cpp

### DIFF
--- a/hbt/src/mon/tests/MonDataTest.cpp
+++ b/hbt/src/mon/tests/MonDataTest.cpp
@@ -24,7 +24,7 @@ class ModuleCollectionTest : public ::testing::Test {
 
     try {
       std::filesystem::create_directory(TEST_MODULES_DIR);
-    } catch (const std::filesystem::filesystem_error& ex) {
+    } catch (const std::filesystem::filesystem_error&) {
       FAIL() << "Unable to create test file directory: " << TEST_MODULES_DIR;
     }
 

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -301,7 +301,7 @@ void PmuDeviceManager::loadSysFsPmus() {
     }
     try {
       parseSysFsPmu_(dentry, *this);
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
       // HBT_LOG_INFO()
       //    << "Ignoring unrecognized /sys/devices entry: \""
       //    << e.what() << "\"";
@@ -354,7 +354,7 @@ PmuDeviceManager::listTracepointEvents(const std::string& category) {
 
       try {
         tp.second = readIntFromFile((dentry.path() / "id").string());
-      } catch (const std::invalid_argument& e) {
+      } catch (const std::invalid_argument&) {
         // HBT_LOG_INFO()
         //    << "Ignoring tracepoint : \""
         //    << dentry.path.string()


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977657


