### PR TITLE
Fix shadowed variable in hbt/src/perf_event/PmuEvent.h

### DIFF
--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -357,7 +357,7 @@ struct EventDef {
   /// Create perf_event_attr config field,
   /// as done in kernel's
   /// linux/arch/x86/include/asm/perf_event.h macro X86_RAW_EVENT_MASK.
-  EventConfigs makeConfigs(uint32_t new_pmu_type) const {
+  EventConfigs makeConfigs(uint32_t new_pmu_type_2) const {
     uint64_t config = (encoding.cmask << 24) |
         (((uint64_t)encoding.inv) << 23) | (((uint64_t)encoding.any) << 21) |
         (((uint64_t)encoding.edge) << 18) | (encoding.umask << 8u) |
@@ -376,7 +376,7 @@ struct EventDef {
       }
     }
     return EventConfigs{
-        .type = new_pmu_type,
+        .type = new_pmu_type_2,
         .config = config,
         .config1 = config1,
         .config2 = config2};


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582917


