### PR TITLE
Remove unused variables in dynolog/src/ODSJsonLogger.cpp

### DIFF
--- a/dynolog/src/ODSJsonLogger.cpp
+++ b/dynolog/src/ODSJsonLogger.cpp
@@ -18,7 +18,10 @@ DEFINE_string(category_id, "", "The category id of the ODS endpoint");
 DEFINE_string(ods_entity_prefix, "", "The prefix for ODS entity name");
 
 namespace dynolog {
+
+#ifdef USE_GRAPH_ENDPOINT
 constexpr char kODSUrl[] = "https://graph.facebook.com/v2.2/ods_metrics";
+#endif
 
 ODSJsonLogger::ODSJsonLogger() : hostname_(facebook::hbt::getHostName()) {}
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52848030


