### PR TITLE
Remove unused variables in hbt/src/perf_event/BPerfEventsGroup.cpp

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -18,7 +18,6 @@ namespace facebook::hbt::perf_event {
 
 constexpr auto kAttrMapVersion = 1;
 constexpr auto kAttrMapSize = 16;
-constexpr auto kMaxAttrPerMetric = 8;
 
 static inline __u32 bpf_link_get_id(int fd) {
   struct bpf_link_info link_info = {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52848001


