### PR TITLE
Remove unused variables in dynolog/src/gpumon/DcgmGroupInfo.cpp

### DIFF
--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -30,7 +30,6 @@ constexpr double maxKeepAgeSec = 2;
 constexpr int maxKeepSamples = 2;
 const std::string groupName = "DcgmGroupInfo";
 const std::string fieldGroupName = "DcgmFieldGroup";
-constexpr int kDcgmBlankValueError = 2;
 
 // fieldId -> metricName in metric cache
 std::unordered_map<unsigned short, std::string> FieldIdToName{


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52847970


