### PR TITLE
Remove unused variables in dynolog/src/ScubaLogger.cpp

### DIFF
--- a/dynolog/src/ScubaLogger.cpp
+++ b/dynolog/src/ScubaLogger.cpp
@@ -17,8 +17,10 @@
 #include <chrono>
 
 namespace dynolog {
-constexpr int HOSTNAME_MAX = 50;
+#ifdef USE_GRAPH_ENDPOINT
 constexpr char kScubaUrl[] = "http://graph.facebook.com/v2.2/scribe_logs";
+#endif
+
 DEFINE_string(
     scribe_category,
     "perfpipe_fair_cluster_gpu_stats",


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52848049


