### PR TITLE
revise retired SSE/AVX flops events def for AMD Zen4

### DIFF
--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -143,8 +143,10 @@ constexpr PmuMsr kL1AndL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0xff}};
 // Flops
 constexpr PmuMsr kRetiredX87Flops{.amdCore = {.event = 0x2, .unitMask = 0x7}};
-constexpr PmuMsr kRetiredSseAvxFlops{
+constexpr PmuMsr kZen3RetiredSseAvxFlops{
     .amdCore = {.event = 0x3, .unitMask = 0xf}};
+constexpr PmuMsr kZen4RetiredSseAvxFlops{
+    .amdCore = {.event = 0x3, .unitMask = 0x1f}};
 
 // Branches
 constexpr PmuMsr kRetiredBranchInstructions{.amdCore = {.event = 0xc2}};


### PR DESCRIPTION
Summary:
sse/avx flops event config in linux perf tool is different from the one defined in hbt
perf tool fp_ret_sse_avx_ops.all uses umask 0x1f, while hbt uses umask 0x0f

according to AMD manual:

 {F1325336882} 

bit 4 is used to determine if bfloat mac should be counted as 2 ops. this should be true to provide consistent behavior

so this diff make Zen3 and Zen4 machines use different event to monitor SSE/AVX FLOPs

Differential Revision: D52861397


