### PR TITLE
define flops events/metrics for AMD Zen4

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -65,6 +65,32 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "L3 Cache misses",
           "L3 Cache misses"),
       std::vector<EventId>({"l3-cache-misses"}));
+
+  // FLOPs events for AMD Zen3/Zen4
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen3/4::fp_ret_x87_fp_ops.all",
+          EventDef::Encoding{.code = amd_msr::kRetiredX87Flops.val},
+          "Retired x87 floating-point ops of all types.",
+          "The number of all x87 floating-point Ops that have retired."),
+      std::vector<EventId>({"zen3/4-ret-x87-fp-ops-all"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen3::fp_ret_sse_avx_ops.all",
+          EventDef::Encoding{.code = amd_msr::kZen3RetiredSseAvxFlops.val},
+          "Retired SSE and AVX floating-point ops of all types.",
+          "The number of all SSE/AVX floating-point Ops that have retired."),
+      std::vector<EventId>({"zen3-ret-sse-avx-fp-ops-all"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen4::fp_ret_sse_avx_ops.all",
+          EventDef::Encoding{.code = amd_msr::kZen4RetiredSseAvxFlops.val},
+          "Retired SSE and AVX floating-point ops of all types.",
+          "The number of all SSE/AVX floating-point Ops that have retired."),
+      std::vector<EventId>({"zen4-ret-sse-avx-fp-ops-all"}));
 }
 } // namespace milan
 

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -143,8 +143,10 @@ constexpr PmuMsr kL1AndL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0xff}};
 // Flops
 constexpr PmuMsr kRetiredX87Flops{.amdCore = {.event = 0x2, .unitMask = 0x7}};
-constexpr PmuMsr kRetiredSseAvxFlops{
+constexpr PmuMsr kZen3RetiredSseAvxFlops{
     .amdCore = {.event = 0x3, .unitMask = 0xf}};
+constexpr PmuMsr kZen4RetiredSseAvxFlops{
+    .amdCore = {.event = 0x3, .unitMask = 0x1f}};
 
 // Branches
 constexpr PmuMsr kRetiredBranchInstructions{.amdCore = {.event = 0xc2}};

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -784,6 +784,112 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
       std::vector<std::string>{}));
 
   metrics->add(std::make_shared<MetricDesc>(
+      "fp_ops_all",
+      "Total floating points operations",
+      "Counts number of floating points operations of single precision type, double precision type, and bfloat types "
+      "executed by the processor. "
+      "For AMD, each event counts the # retired floating point operations. "
+      "For Intel, each event counts the # retired instructions "
+      "Multiply # of instructions by # of operations packed inside an instruction to calculate # operations.",
+      std::map<TOptCpuArch, EventRefs>{
+          {CpuArch::MILAN,
+           EventRefs{
+               EventRef{
+                   "flops_scalar",
+                   PmuType::cpu,
+                   "zen3/4::fp_ret_x87_fp_ops.all",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "flops_vector",
+                   PmuType::cpu,
+                   "zen3::fp_ret_sse_avx_ops.all",
+                   EventExtraAttr{},
+                   {}}}},
+          {CpuArch::BERGAMO,
+           EventRefs{
+               EventRef{
+                   "flops_scalar",
+                   PmuType::cpu,
+                   "zen3/4::fp_ret_x87_fp_ops.all",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "flops_vector",
+                   PmuType::cpu,
+                   "zen4::fp_ret_sse_avx_ops.all",
+                   EventExtraAttr{},
+                   {}}}},
+          {CpuArch::GENOA,
+           EventRefs{
+               EventRef{
+                   "flops_scalar",
+                   PmuType::cpu,
+                   "zen3/4::fp_ret_x87_fp_ops.all",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "flops_vector",
+                   PmuType::cpu,
+                   "zen4::fp_ret_sse_avx_ops.all",
+                   EventExtraAttr{},
+                   {}}}},
+          // Intel by default
+          {std::nullopt,
+           EventRefs{
+               EventRef{
+                   "instr_dp_scalar",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.SCALAR_DOUBLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_dp_128b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_dp_256b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_dp_512b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_sp_scalar",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.SCALAR_SINGLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_sp_128b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_sp_256b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "instr_sp_512b_packed",
+                   PmuType::cpu,
+                   "FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE",
+                   EventExtraAttr{},
+                   {}}}}},
+      100'000'000,
+      System::Permissions{},
+      std::vector<std::string>{}));
+
+  metrics->add(std::make_shared<MetricDesc>(
       "cpu_clock",
       "High-resolution sys and user CPU clock",
       "High-resolution sys and user CPU clock",


### PR DESCRIPTION
Summary:
define two new events `zen4::fp_ret_x87_fp_ops.all` and `zen4::fp_ret_sse_avx_ops.all` to count scalar/vector fp ops. 

also define a new metric `fp_ops_all` that will use two events above on zen4 hosts and fallback to intel events on other hosts.

Differential Revision: D52861377


