### PR TITLE
Remove unused variables in hbt/src/perf_event/PmuDevices.cpp

### DIFF
--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -420,7 +420,7 @@ void PmuDevice::addAliases(
     const EventId& ev_id,
     const std::vector<EventId>& aliases) {
   for (const auto& alias : aliases) {
-    auto [_, added] = aliases_.emplace(alias, ev_id);
+    aliases_.emplace(alias, ev_id);
   }
 }
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: bunnypak, dmm-fb

Differential Revision: D53011652


