### PR TITLE
Remove unused variables in hbt/src/tagstack/Slicer.h

### DIFF
--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -793,7 +793,6 @@ class Slicer {
   }
 
   inline auto eventToTransitionType_(const Event* ev) const {
-    Slice::TransitionType sw_type;
     switch (ev->type) {
       case Event::Type::Start:
       case Event::Type::End:


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: bunnypak, dmm-fb

Differential Revision: D53011660


