### PR TITLE
Fix shadowed variable in hbt/src/ringbuffer/tests/RingBufferTest.cpp

### DIFF
--- a/hbt/src/ringbuffer/tests/RingBufferTest.cpp
+++ b/hbt/src/ringbuffer/tests/RingBufferTest.cpp
@@ -637,8 +637,8 @@ TEST(RingBuffer, InTx) {
   }
 
   {
-    auto [size, d_ptr] = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(size, 4u);
+    auto [size_2, d_ptr] = c.readInTxWithSize<uint8_t>();
+    EXPECT_EQ(size_2, 4u);
     EXPECT_TRUE(memcmp(d_ptr, "hola", 4u) == 0);
   }
 
@@ -675,8 +675,8 @@ TEST(RingBuffer, InTx) {
   }
 
   {
-    auto [size, d_ptr] = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(size, 4u);
+    auto [size_2, d_ptr] = c.readInTxWithSize<uint8_t>();
+    EXPECT_EQ(size_2, 4u);
     EXPECT_TRUE(memcmp(d_ptr, "hola", 4u) == 0);
   }
 
@@ -687,23 +687,23 @@ TEST(RingBuffer, InTx) {
   }
 
   {
-    auto [ret, d_ptr] = c.readInTx<uint16_t>();
-    EXPECT_EQ(ret, 2);
+    auto [ret_2, d_ptr] = c.readInTx<uint16_t>();
+    EXPECT_EQ(ret_2, 2);
     EXPECT_EQ(*d_ptr, 8u);
   }
   {
-    auto [ret, d_ptr] = c.readInTx<uint16_t>();
-    EXPECT_EQ(ret, 2);
+    auto [ret_2, d_ptr] = c.readInTx<uint16_t>();
+    EXPECT_EQ(ret_2, 2);
     EXPECT_EQ(*d_ptr, 9u);
   }
   {
-    auto [ret, d_ptr] = c.readInTx<uint16_t>();
-    EXPECT_EQ(ret, 2);
+    auto [ret_2, d_ptr] = c.readInTx<uint16_t>();
+    EXPECT_EQ(ret_2, 2);
     EXPECT_EQ(*d_ptr, 9u);
   }
   {
-    auto [ret, d_ptr] = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(ret, -ENODATA);
+    auto [ret_2, d_ptr] = c.readInTxWithSize<uint8_t>();
+    EXPECT_EQ(ret_2, -ENODATA);
   }
 
   ret = c.commitTx();


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52959133


