### PR TITLE
[hbt][perf_event] Rename parameter in `facebook::hbt::perf_event::makeConfigs` for clarity

### DIFF
--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -357,7 +357,7 @@ struct EventDef {
   /// Create perf_event_attr config field,
   /// as done in kernel's
   /// linux/arch/x86/include/asm/perf_event.h macro X86_RAW_EVENT_MASK.
-  EventConfigs makeConfigs(uint32_t new_pmu_type_2) const {
+  EventConfigs makeConfigs(uint32_t new_pmu_type) const {
     uint64_t config = (encoding.cmask << 24) |
         (((uint64_t)encoding.inv) << 23) | (((uint64_t)encoding.any) << 21) |
         (((uint64_t)encoding.edge) << 18) | (encoding.umask << 8u) |
@@ -376,7 +376,7 @@ struct EventDef {
       }
     }
     return EventConfigs{
-        .type = new_pmu_type_2,
+        .type = new_pmu_type,
         .config = config,
         .config1 = config1,
         .config2 = config2};


### PR DESCRIPTION
Summary:
Following up on this comment:
https://www.internalfb.com/diff/D52582917?dst_version_fbid=695145869487697&transaction_fbid=1088578665513728

r-barnes:
It doesn't seem this change was necessary -- can we revert? Thanks!

Reviewed By: r-barnes

Differential Revision: D53273260


