### PR TITLE
Add network metrics to prometheus

### DIFF
--- a/docs/Metrics.md
+++ b/docs/Metrics.md
@@ -20,10 +20,10 @@ A metric is generally associated with a scope that describes the space/dimension
 | cpu_u, cpu_s | Fraction of total CPU time spent in user and system mode respectively| Activity of the system CPU in user/system mode. | Ratio | - | 60s |
 | cpu_i| Fraction of total CPU time that the CPU was in idle mode.| Overall inactivity of the system CPU. | Ratio | - | 60s |
 | cpu_u/s/n/w/x/y_ms| Total CPU time in milliseconds spent in various modes: user, system, nice, iowait etc. For more details please see man page for [/proc/stat](https://man7.org/linux/man-pages/man5/proc.5.html) | Activity of the system CPU in various modes. | Delta | ms | 60s |
-| rx/tx_bytes_`<devname>` | Total bytes transmitted/received over the specific network device.| Network transfer statistics. | Delta | Bytes | 60s |
-| rx/tx_packets_`<devname>` | Total packets transmitted/received over the specific network device.| Network transfer statistics. | Delta | Packets | 60s |
-| rx/tx_errors_`<devname>` | Total transmit/receive errors on the specific network device.| Network transfer statistics. | Delta | Errors | 60s |
-| rx/tx_drops_`<devname>` | Total transmit/receive packet drops on the specific network device.| Network transfer statistics. | Delta | Packets | 60s |
+| rx/tx_bytes.`<devname>` | Total bytes transmitted/received over the specific network device.| Network transfer statistics. | Delta | Bytes | 60s |
+| rx/tx_packets.`<devname>` | Total packets transmitted/received over the specific network device.| Network transfer statistics. | Delta | Packets | 60s |
+| rx/tx_errors.`<devname>` | Total transmit/receive errors on the specific network device.| Network transfer statistics. | Delta | Errors | 60s |
+| rx/tx_drops.`<devname>` | Total transmit/receive packet drops on the specific network device.| Network transfer statistics. | Delta | Packets | 60s |
 | mips | Number of million instructions executed per second. | Overall rate of instructions per second the CPU executed. | Rate | Million / sec | 60s |
 | mega_cycles_per_second | Number of active CPU clock cycles per second. | Overall rate of the CPU clock cycle. | Rate | MHz | 60s |
 

--- a/dynolog/src/KernelCollector.cpp
+++ b/dynolog/src/KernelCollector.cpp
@@ -68,14 +68,14 @@ void KernelCollector::log(Logger& log) {
   }
 
   for (const auto& [devName, devRxtx] : rxtxDelta_) {
-    log.logUint(fmt::format("rx_bytes_{}", devName), devRxtx.rxBytes);
-    log.logUint(fmt::format("rx_packets_{}", devName), devRxtx.rxPackets);
-    log.logUint(fmt::format("rx_errors_{}", devName), devRxtx.rxErrors);
-    log.logUint(fmt::format("rx_drops_{}", devName), devRxtx.rxDrops);
-    log.logUint(fmt::format("tx_bytes_{}", devName), devRxtx.txBytes);
-    log.logUint(fmt::format("tx_packets_{}", devName), devRxtx.txPackets);
-    log.logUint(fmt::format("tx_errors_{}", devName), devRxtx.txErrors);
-    log.logUint(fmt::format("tx_drops_{}", devName), devRxtx.txDrops);
+    log.logUint(fmt::format("rx_bytes.{}", devName), devRxtx.rxBytes);
+    log.logUint(fmt::format("rx_packets.{}", devName), devRxtx.rxPackets);
+    log.logUint(fmt::format("rx_errors.{}", devName), devRxtx.rxErrors);
+    log.logUint(fmt::format("rx_drops.{}", devName), devRxtx.rxDrops);
+    log.logUint(fmt::format("tx_bytes.{}", devName), devRxtx.txBytes);
+    log.logUint(fmt::format("tx_packets.{}", devName), devRxtx.txPackets);
+    log.logUint(fmt::format("tx_errors.{}", devName), devRxtx.txErrors);
+    log.logUint(fmt::format("tx_drops.{}", devName), devRxtx.txDrops);
   }
 
   log.setTimestamp();

--- a/dynolog/src/Logger.cpp
+++ b/dynolog/src/Logger.cpp
@@ -57,4 +57,18 @@ void JsonLogger::finalize() {
   json_.clear();
 }
 
+KeyParts splitKey(const std::string& full_key) {
+  // Splits "metric.entity"
+  KeyParts ret;
+  size_t pos = full_key.find('.');
+  if (pos == std::string::npos) {
+    ret.metric = full_key;
+    return ret;
+  }
+
+  ret.metric = full_key.substr(0, pos);
+  ret.entity = full_key.substr(pos + 1);
+  return ret;
+}
+
 } // namespace dynolog

--- a/dynolog/src/Logger.h
+++ b/dynolog/src/Logger.h
@@ -44,6 +44,12 @@ class Logger {
   virtual void finalize() = 0;
 };
 
+struct KeyParts {
+  std::string metric;
+  std::string entity;
+};
+KeyParts splitKey(const std::string& full_key);
+
 class JsonLogger : public Logger {
  public:
   void setTimestamp(Timestamp ts) override {

--- a/dynolog/src/Metrics.cpp
+++ b/dynolog/src/Metrics.cpp
@@ -59,4 +59,41 @@ const std::vector<MetricDesc> getAllMetrics() {
   return metrics;
 }
 
+// These metrics are dynamic per network drive
+const std::vector<MetricDesc> getNetworkMetrics() {
+  static std::vector<MetricDesc> metrics_ = {
+      {.name = "tx_bytes",
+       .type = MetricType::Delta,
+       .desc =
+           "Total bytes transmitted/received over the specific network device."},
+      {.name = "rx_bytes",
+       .type = MetricType::Delta,
+       .desc =
+           "Total bytes transmitted/received over the specific network device."},
+      {.name = "tx_packets",
+       .type = MetricType::Delta,
+       .desc =
+           "Total packets transmitted/received over the specific network device."},
+      {.name = "rx_packets",
+       .type = MetricType::Delta,
+       .desc =
+           "Total packets transmitted/received over the specific network device."},
+      {.name = "tx_errors",
+       .type = MetricType::Delta,
+       .desc = "Total transmit/receive errors on the specific network device."},
+      {.name = "rx_errors",
+       .type = MetricType::Delta,
+       .desc = "Total transmit/receive errors on the specific network device."},
+      {.name = "tx_drops",
+       .type = MetricType::Delta,
+       .desc =
+           "Total transmit/receive packet drops on the specific network device."},
+      {.name = "rx_drops",
+       .type = MetricType::Delta,
+       .desc =
+           "Total transmit/receive packet drops on the specific network device."},
+  };
+  return metrics_;
+}
+
 } // namespace dynolog

--- a/dynolog/src/Metrics.h
+++ b/dynolog/src/Metrics.h
@@ -25,4 +25,6 @@ struct MetricDesc {
 
 const std::vector<MetricDesc> getAllMetrics();
 
+const std::vector<MetricDesc> getNetworkMetrics();
+
 } // namespace dynolog

--- a/dynolog/src/PrometheusLogger.h
+++ b/dynolog/src/PrometheusLogger.h
@@ -33,6 +33,10 @@ class PrometheusManager {
 
   PrometheusManager();
 
+  // Add dynamic metrics if required
+  // returns true if a key was added
+  bool ensureDynamicKey(const std::string& key);
+
   // Note that this method is not thread-safe and so
   // should only be used with the LoggingGuard in scope
   void log(const std::string& key, double val);
@@ -40,6 +44,7 @@ class PrometheusManager {
   static LoggingGuard singleton();
 
  private:
+  using GaugeFamily = prometheus::Family<prometheus::Gauge>;
   std::lock_guard<std::mutex> lock() {
     return std::lock_guard{mutex_};
   }
@@ -50,6 +55,9 @@ class PrometheusManager {
 
   // only store a reference to Gauge because copying is not allowed
   std::unordered_map<std::string, prometheus::Gauge*> gauges_;
+
+  // metric families that need dynamic dimensions
+  std::unordered_map<std::string, GaugeFamily*> dynamic_metrics_;
 
   // Should match googletest/include/gtest/gtest_prod.h
   // friend class test_case_name##_##test_name##_Test


### PR DESCRIPTION
Summary:
Add network monitoring metrics to prometheus
* We need to enable adding a new dimension - "net" to the Prometheus metrics
* Implement adding dynamic prometheus metrics. The changes also include a new function in PrometheusLogger.cpp to ensure dynamic keys are added to the registry.
* Network metrics renamed to use a '.' as separator.

*TODO* remove the LOG(INFO) adding new series

Differential Revision: D53553477


