### PR TITLE
Dynolog doesn't build from a conda env

### DIFF
--- a/dynolog/src/metric_frame/ExtraTypes.h
+++ b/dynolog/src/metric_frame/ExtraTypes.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 
 namespace facebook::dynolog {

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 
 namespace facebook::hbt::perf_event {


### PR DESCRIPTION
Summary: While trying to compile the opensource version of dynolog using a conda env, it fails with 2 errors about 'cstdint' not being included.

Reviewed By: briancoutinho

Differential Revision: D54302880


