### PR TITLE
Fix systemd lint issues

### DIFF
--- a/scripts/dynolog.service
+++ b/scripts/dynolog.service
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=Dynolog performance monitoring daemon
-Documentation=Dynolog provides system observability for heterogenous platforms. Please find the output logs in /var/logs/dynolog.log
+Documentation=https://github.com/facebookincubator/dynolog
 
 [Service]
 ExecStartPre=/usr/bin/touch /etc/dynolog.gflags


### PR DESCRIPTION
Summary:
Fix systemd lint issues

Per systemd documentation (https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Documentation=), the `Documentation` section option requires a space separated list of URIs

Differential Revision: D54525515


