### PR TITLE
musl: __u64 not defined

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -51,7 +51,7 @@ struct FdWrapper {
     close_on_destruction = true;
   }
 
-  __u64 getInode() {
+  ino_t getInode() {
     struct stat s = {};
     int err = ::fstat(fd, &s);
     HBT_THROW_SYSTEM_IF(0 != err, errno)

--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -90,10 +90,10 @@ BPerfEventsGroup::BPerfEventsGroup(
           name,
           metric.makeNoCpuTopologyConfs(pmu_manager),
           cgroup_update_level) {}
-inline auto mapFdWrapperPtrIntoInode(
+inline ino_t mapFdWrapperPtrIntoInode(
     const std::shared_ptr<FdWrapper>& fd_wrapper) {
   if (fd_wrapper == nullptr) {
-    return 0ull;
+    return (ino_t)0;
   }
   return fd_wrapper->getInode();
 }


### PR DESCRIPTION
https://bugs.gentoo.org/925905

struct stat field is defined as a ino_t, at least looking at man 3type stat