### PR TITLE
Use `nullptr` in glow/glow/tests/benchmark/ConvBench.cpp

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -247,7 +247,7 @@ int BPerfEventsGroup::syncCpu_(__u32 cpu, int leader_fd) {
   DECLARE_LIBBPF_OPTS(
       bpf_test_run_opts,
       opts,
-      .ctx_in = NULL,
+      .ctx_in = nullptr,
       .ctx_size_in = 0,
       .flags = BPF_F_TEST_RUN_ON_CPU,
       .cpu = cpu,


### PR DESCRIPTION
Summary:
`nullptr` is preferable to `0` or `NULL`. Let's use it everywhere so we can enable `-Wzero-as-null-pointer-constant`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D54835689


