### PR TITLE
Remove extra semi colon from hbt/src/tagstack/tests/SlicerTest.cpp

### DIFF
--- a/hbt/src/tagstack/tests/SlicerTest.cpp
+++ b/hbt/src/tagstack/tests/SlicerTest.cpp
@@ -47,7 +47,7 @@ void expectExistsEqual(
   EXPECT_EQ(it->first, exp_stack);
   EXPECT_EQ(it->second.stats.stack, exp_stack);
   EXPECT_EQ(it->second.stats.stack_id, stack_id) << "stack: " << exp_stack;
-};
+}
 
 TEST(SliceMapTest, Lifetime) {
   SlicesMap m;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: rahku

Differential Revision: D55087324


