### PR TITLE
ignore rather than crash when uncore device has empty cpu_mask

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -234,10 +234,11 @@ class Monitor {
 
   /// Read counts for all events opened in counting mode
   /// in all PerCpuCountReaders.
-  std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>>
+  std::map<ElemId, std::optional<std::map<int, TCountReader::ReadValues>>>
   readAllCountsPerCpu() const {
     std::lock_guard<std::mutex> lock{mutex_};
-    std::map<ElemId, std::optional<std::vector<TCountReader::ReadValues>>> rvs;
+    std::map<ElemId, std::optional<std::map<int, TCountReader::ReadValues>>>
+        rvs;
 
     for (auto& [k, cr] : count_readers_) {
       HBT_THROW_ASSERT_IF(cr == nullptr);

--- a/hbt/src/perf_event/BPerfCountReader.cpp
+++ b/hbt/src/perf_event/BPerfCountReader.cpp
@@ -5,8 +5,8 @@
 
 #include "hbt/src/perf_event/BPerfCountReader.h"
 #include "hbt/src/perf_event/BPerfEventsGroup.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
-#include "hbt/src/perf_event/Metrics.h"
+
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/BPerfCountReader.h
+++ b/hbt/src/perf_event/BPerfCountReader.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 namespace facebook::hbt::perf_event {
 

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -9,8 +9,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/perf_event/PmuDevices.h"
 #include "hbt/src/perf_event/PmuEvent.h"
 #include "hbt/src/perf_event/bpf/bperf.h"

--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -20,12 +20,12 @@ target_link_libraries(PmuEvent PUBLIC System)
 add_library(AmdEvents AmdEvents.h AmdEvents.cpp)
 target_link_libraries(AmdEvents PUBLIC PmuDevices)
 
-add_library(CpuEventsGroup CpuEventsGroup.h)
-target_link_libraries(CpuEventsGroup PUBLIC System)
-target_link_libraries(CpuEventsGroup PUBLIC PmuEvent)
+add_library(PerfEventsGroup PerfEventsGroup.h)
+target_link_libraries(PerfEventsGroup PUBLIC System)
+target_link_libraries(PerfEventsGroup PUBLIC PmuEvent)
 
 add_library(PmuDevices PmuDevices.h PmuDevices.cpp)
-target_link_libraries(PmuDevices PUBLIC CpuEventsGroup)
+target_link_libraries(PmuDevices PUBLIC PerfEventsGroup)
 target_link_libraries(PmuDevices PUBLIC stdc++fs)
 target_link_libraries(PmuDevices PUBLIC PmuEvent)
 target_link_libraries(PmuDevices PUBLIC CpuArch)
@@ -46,15 +46,18 @@ if(USE_JSON_GENERATED_PERF_EVENTS)
   target_link_libraries(BuiltinMetrics PUBLIC JsonEvents)
 endif()
 
+add_library(PerPerfEventsGroupBase PerPerfEventsGroupBase.h)
+target_link_libraries(PerPerfEventsGroupBase PUBLIC PerfEventsGroup)
+target_link_libraries(PerPerfEventsGroupBase PUBLIC Metrics)
+
 add_library(PerCpuBase PerCpuBase.h)
-target_link_libraries(PerCpuBase PUBLIC CpuEventsGroup)
-target_link_libraries(PerCpuBase PUBLIC Metrics)
+target_link_libraries(PerCpuBase PerPerfEventsGroupBase)
 
 add_library(PerCpuCountReader PerCpuCountReader.h)
 target_link_libraries(PerCpuCountReader PUBLIC PerCpuBase)
 
 add_library(ThreadCountReader ThreadCountReader.h)
-target_link_libraries(ThreadCountReader PUBLIC CpuEventsGroup)
+target_link_libraries(ThreadCountReader PUBLIC PerfEventsGroup)
 target_link_libraries(ThreadCountReader PUBLIC Metrics)
 
 add_library(PerCpuSampleGeneratorBase PerCpuSampleGeneratorBase.h)

--- a/hbt/src/perf_event/Metrics.h
+++ b/hbt/src/perf_event/Metrics.h
@@ -121,6 +121,29 @@ struct MetricDesc {
     return per_cpu_confs;
   }
 
+  /// Make EventConfs for each uncore PMU device given a scope
+  PerUncoreEventConfs makePerUncoreConfs(
+      uncore_scope::Scope scope,
+      const PmuDeviceManager& pmu_manager) const {
+    PerUncoreEventConfs per_uncore_confs;
+
+    const auto& event_refs = getEventRefs(pmu_manager.cpuInfo.cpu_arch);
+    HBT_ARG_CHECK(event_refs.has_value())
+        << "No EventRefs for CPU " << pmu_manager.cpuInfo.cpu_arch
+        << " in metric: " << id;
+
+    for (const auto& ev_ref : *event_refs) {
+      pmu_manager.makePerUncoreConfs(
+          ev_ref.pmu_type,
+          ev_ref.event_id,
+          ev_ref.extra_attr,
+          ev_ref.transforms,
+          scope,
+          per_uncore_confs);
+    }
+    return per_uncore_confs;
+  }
+
   // List nicknames for all events for the provided CPU architecture.
   auto eventNicknames(TOptCpuArch cpu_arch) const {
     const auto& event_refs = getEventRefs(cpu_arch);

--- a/hbt/src/perf_event/PerCpuBase.h
+++ b/hbt/src/perf_event/PerCpuBase.h
@@ -5,144 +5,54 @@
 
 #pragma once
 
-#include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
-
-#include <map>
-#include <memory>
+#include "hbt/src/perf_event/PerPerfEventsGroupBase.h"
 
 namespace facebook::hbt::perf_event {
 
-// Base class to make a per-CPU generator (multiple CPUs)
-// from a type defined for a single CPU.
-template <class TCpuBase>
-class PerCpuBase {
+template <class TPerfEventGroupGenBase>
+class PerCpuBase : public PerPerfEventsGroupBase<TPerfEventGroupGenBase> {
  public:
+  using TBase = PerPerfEventsGroupBase<TPerfEventGroupGenBase>;
   PerCpuBase(
       const CpuSet& mon_cpus,
       std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
-      : mon_cpus_{mon_cpus}, cgroup_fd_wrapper_{cgroup_fd_wrapper} {
-    // Base class must initialize <cpu_generators_> entries.
-    cpu_generators_.resize(mon_cpus.max_cpu_id + 1);
-  }
-
-  void close() {
-    for_each_cpu(cpu, mon_cpus_) {
-      getCpuGenerator(cpu).close();
+      : TBase(cgroup_fd_wrapper), mon_cpus_{mon_cpus} {
+    for_each_cpu(cpu, mon_cpus) {
+      TBase::generators_.insert(std::make_pair(static_cast<int>(cpu), nullptr));
     }
   }
-
-  void enable() {
-    try {
-      for_each_cpu(cpu, mon_cpus_) {
-        getCpuGenerator(cpu).enable();
-      }
-    } catch (std::exception& /*e*/) {
-      for_each_cpu(cpu, mon_cpus_) {
-        auto& cg = getCpuGenerator(cpu);
-        if (cg.isEnabled()) {
-          cg.disable();
-        }
-      }
-      throw;
-    }
-  }
-
-  bool isEnabled() const {
-    // It should be all enabled or none.
-    bool enabled = getCpuGenerator(mon_cpus_.cpu_first_set()).isEnabled();
-    for_each_cpu(cpu, mon_cpus_) {
-      HBT_THROW_ASSERT_IF(enabled != getCpuGenerator(cpu).isEnabled())
-          << "CPU : " << cpu << " is not enabled while others are.";
-    }
-    return enabled;
-  }
-
-  void disable() {
-    for_each_cpu(cpu, mon_cpus_) {
-      getCpuGenerator(cpu).disable();
-    }
-  }
-
-  bool isOpen() const {
-    // It should be all open or none.
-    bool is_open = getCpuGenerator(mon_cpus_.cpu_first_set()).isOpen();
-    for_each_cpu(cpu, mon_cpus_) {
-      HBT_THROW_ASSERT_IF(is_open != getCpuGenerator(cpu).isOpen())
-          << "CPU : " << cpu << " is not open while others are.";
-    }
-    return is_open;
-  }
-
-  const TCpuBase& getCpuGenerator(CpuId cpu) const {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    HBT_ARG_CHECK(cpu_generators_.at(cpu) != nullptr)
-        << "No generator in CPU " << cpu;
-    return *cpu_generators_.at(cpu);
-  }
-
-  TCpuBase& getCpuGenerator(CpuId cpu) {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    return *cpu_generators_.at(cpu);
-  }
-
-  auto getCpuGeneratorPtr(CpuId cpu) {
-    HBT_ARG_CHECK(
-        cpu < cpu_generators_.size() && cpu_generators_.at(cpu) != nullptr)
-        << "CPU " + std::to_string(cpu) + " not monitored";
-    return cpu_generators_.at(cpu);
-  }
-
   auto getMonCpus() const {
     return mon_cpus_;
   }
-
-  template <class T = typename TCpuBase::TMode>
-  mode::enable_if_counting_or_sampling<T, bool> read(
-      GroupReadValues<T>& rv) const {
-    if (!isOpen()) {
-      return false;
-    }
-    rv.zero();
-    GroupReadValues<T> aux(rv.getNumEvents());
-    for_each_cpu(cpu, this->getMonCpus()) {
-      if (!this->getCpuGenerator(cpu).read(aux)) {
-        return false;
-      }
-      rv.accum(aux);
-    }
-    return true;
+  const TPerfEventGroupGenBase& getCpuGenerator(CpuId cpu) const {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return *TBase::generators_.at(key);
   }
 
-  // Read all events from all monitored CPUs.
-  // The indexes of the vector does not correspond to actual CPU ids.
-  template <class T = typename TCpuBase::TMode>
-  mode::enable_if_counting_or_sampling<T, bool> readPerCpu(
-      std::vector<GroupReadValues<T>>& rv,
-      size_t numEvents) const {
-    if (!isOpen()) {
-      return false;
-    }
-    rv.reserve(this->getMonCpus().numCpus());
-    GroupReadValues<T> aux(numEvents);
-    for_each_cpu(cpu, this->getMonCpus()) {
-      if (!this->getCpuGenerator(cpu).read(aux)) {
-        return false;
-      }
-      rv.push_back(aux);
-    }
-    return true;
+  TPerfEventGroupGenBase& getCpuGenerator(CpuId cpu) {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return *TBase::generators_.at(key);
+  }
+
+  auto getCpuGeneratorPtr(CpuId cpu) {
+    auto key = static_cast<int>(cpu);
+    HBT_ARG_CHECK(TBase::generators_.count(key))
+        << "CPU " << std::to_string(key) + " not monitored";
+    HBT_ARG_CHECK(TBase::generators_.at(key) != nullptr)
+        << "No generator in CPU " << key;
+    return TBase::generators_.at(key);
   }
 
  protected:
   CpuSet mon_cpus_;
-  std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;
-  // Must be initialized by base class.
-  std::vector<std::shared_ptr<TCpuBase>> cpu_generators_;
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PerCpuDummyGenerator.h
+++ b/hbt/src/perf_event/PerCpuDummyGenerator.h
@@ -6,9 +6,9 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
 #include "hbt/src/perf_event/PerCpuSampleGeneratorBase.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 #include <functional>
 #include <memory>
@@ -24,9 +24,9 @@ namespace facebook::hbt::perf_event {
 // in perf_event mmap page.
 //
 class CpuDummyGenerator final
-    : public CpuEventsGroup<CpuDummyGenerator, mode::Dummy> {
+    : public PerfEventsGroup<CpuDummyGenerator, mode::Dummy> {
  public:
-  using TBase = CpuEventsGroup<CpuDummyGenerator, mode::Dummy>;
+  using TBase = PerfEventsGroup<CpuDummyGenerator, mode::Dummy>;
 
   inline static const EventConfs event_confs = {EventConf{
       .id = "sw_dummy",
@@ -54,16 +54,17 @@ using TBasePerCpuDummyGenerator = PerCpuSampleGeneratorBase<CpuDummyGenerator>;
 // Wrap many instances of CpuDummyGenerator, one per CPU.
 class PerCpuDummyGenerator : public TBasePerCpuDummyGenerator {
  public:
-  PerCpuDummyGenerator(const CpuSet& mon_cpus)
+  explicit PerCpuDummyGenerator(const CpuSet& mon_cpus)
       : TBasePerCpuDummyGenerator{mon_cpus, nullptr} {
     for_each_cpu(cpu, mon_cpus) {
-      this->cpu_generators_[cpu] = std::make_shared<CpuDummyGenerator>(cpu);
+      this->generators_[static_cast<int>(cpu)] =
+          std::make_shared<CpuDummyGenerator>(cpu);
     }
   }
 
   void open() {
-    for_each_cpu(cpu, this->getMonCpus()) {
-      this->getCpuGenerator(cpu).open();
+    for (const auto& [_, gen] : this->generators_) {
+      gen->open();
     }
   }
 };

--- a/hbt/src/perf_event/PerPerfEventsGroupBase.h
+++ b/hbt/src/perf_event/PerPerfEventsGroupBase.h
@@ -1,0 +1,145 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
+
+#include <map>
+#include <memory>
+
+namespace facebook::hbt::perf_event {
+
+// Base class to manage a list of perf events group generators with the same
+// config.
+template <class TPerfEventGroupGenBase>
+class PerPerfEventsGroupBase {
+ public:
+  explicit PerPerfEventsGroupBase(std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
+      : cgroup_fd_wrapper_{cgroup_fd_wrapper} {}
+
+  void close() {
+    for (auto& [_, gen] : generators_) {
+      gen->close();
+    }
+  }
+
+  void enable() {
+    try {
+      for (auto& [_, gen] : generators_) {
+        gen->enable();
+      }
+    } catch (std::exception& /*e*/) {
+      for (auto& [_, gen] : generators_) {
+        if (gen->isEnabled()) {
+          gen->disable();
+        }
+      }
+      throw;
+    }
+  }
+
+  bool isEnabled() const {
+    HBT_THROW_ASSERT_IF(generators_.empty())
+        << "PerPerfEventsGroupBase should always contain at least one generator.";
+    // It should be all enabled or none.
+    bool enabled = getFirstGenerator().isEnabled();
+    for (const auto& [key, gen] : generators_) {
+      HBT_THROW_ASSERT_IF(enabled != gen->isEnabled())
+          << "Generator with key=" << key
+          << " has a different isEnabled() status comparing to some other generators.";
+    }
+    return enabled;
+  }
+
+  void disable() {
+    for (auto& [_, gen] : generators_) {
+      gen->disable();
+    }
+  }
+
+  bool isOpen() const {
+    HBT_THROW_ASSERT_IF(generators_.empty())
+        << "PerPerfEventsGroupBase should always contain at least one generator.";
+    // It should be all open or none.
+    bool is_open = getFirstGenerator().isOpen();
+    for (const auto& [key, gen] : generators_) {
+      HBT_THROW_ASSERT_IF(is_open != gen->isOpen())
+          << "Generator with key=" << key
+          << " has a different isOpen() status comparing to some other generators.";
+    }
+    return is_open;
+  }
+
+  const TPerfEventGroupGenBase& getFirstGenerator() const {
+    HBT_ARG_CHECK(!generators_.empty()) << "No generator exists";
+    return *generators_.begin()->second;
+  }
+
+  TPerfEventGroupGenBase& getFirstGenerator() {
+    HBT_ARG_CHECK(!generators_.empty()) << "No generator exists";
+    return *generators_.begin()->second;
+  }
+
+  const TPerfEventGroupGenBase& getGenerator(int key) const {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return *generators_.at(key);
+  }
+
+  TPerfEventGroupGenBase& getGenerator(int key) {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return *generators_.at(key);
+  }
+
+  auto getGeneratorPtr(int key) {
+    HBT_ARG_CHECK(generators_.count(key)) << "No generator with key " << key;
+    return generators_.at(key);
+  }
+
+  template <class T = typename TPerfEventGroupGenBase::TMode>
+  mode::enable_if_counting_or_sampling<T, bool> read(
+      GroupReadValues<T>& rv) const {
+    if (!isOpen()) {
+      return false;
+    }
+    rv.zero();
+    GroupReadValues<T> aux(rv.getNumEvents());
+    for (const auto& [_, gen] : generators_) {
+      if (!gen->read(aux)) {
+        return false;
+      }
+      rv.accum(aux);
+    }
+    return true;
+  }
+
+  // Read all events from all monitored perf events group.
+  template <class T = typename TPerfEventGroupGenBase::TMode>
+  mode::enable_if_counting_or_sampling<T, bool> readPerPerfEventsGroup(
+      std::map<int, GroupReadValues<T>>& rv,
+      size_t numEvents) const {
+    if (!isOpen()) {
+      return false;
+    }
+    GroupReadValues<T> aux(numEvents);
+    for (const auto& [key, gen] : generators_) {
+      if (!gen->read(aux)) {
+        return false;
+      }
+      rv.insert(std::make_pair(key, aux));
+    }
+    return true;
+  }
+
+ protected:
+  std::shared_ptr<FdWrapper> cgroup_fd_wrapper_;
+  // a hashmap contains per perf event group generators.
+  // definition of the key depends on the implementation of the class inherite
+  // from this class.
+  std::map<int, std::shared_ptr<TPerfEventGroupGenBase>> generators_;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PerUncoreCountReader.h
+++ b/hbt/src/perf_event/PerUncoreCountReader.h
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerPerfEventsGroupBase.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
+
+#include <memory>
+#include <vector>
+
+namespace facebook::hbt::perf_event {
+
+//
+// CRTP extension of CpuEventsGroupBase<>.
+//
+// Read counters from perf_event groups.
+// It relies on perf_events opened on counting mode.
+//
+class UncoreCountReader final
+    : public PerfEventsGroupBase<UncoreCountReader, mode::Counting> {
+ public:
+  using TBase = PerfEventsGroupBase<UncoreCountReader, mode::Counting>;
+
+  /// Convenience type definition to create structure to store read values.
+  using ReadValues = GroupReadValues<mode::Counting>;
+
+  UncoreCountReader(
+      const std::vector<std::string>& ev_names,
+      CpuId cpu,
+      EventConfs event_confs)
+      : TBase{cpu, -1, -1, event_confs}, event_names_{ev_names} {}
+
+  void enableImpl() {}
+
+  void disableImpl() {}
+
+  void open(bool pinned) {
+    this->open_counting_(0, pinned);
+    HBT_THROW_ASSERT_IF(!isOpen());
+  }
+
+  const auto& getEventNames() const noexcept {
+    return event_names_;
+  }
+
+ protected:
+  std::vector<std::string> event_names_;
+};
+
+class PerUncoreCountReader : public PerPerfEventsGroupBase<UncoreCountReader> {
+ public:
+  using TBase = PerPerfEventsGroupBase<UncoreCountReader>;
+  using ReadValues = UncoreCountReader::ReadValues;
+
+  static int32_t generateEventsGroupId(uint32_t pmu_id, CpuId cpu) {
+    HBT_ARG_CHECK(
+        pmu_id <= std::numeric_limits<uint16_t>::max() &&
+        cpu <= std::numeric_limits<uint16_t>::max())
+        << "pmu id or cpu must be equal to or smaller than 2^16-1";
+    return static_cast<uint16_t>(pmu_id) << 16 | static_cast<uint16_t>(cpu);
+  }
+
+  PerUncoreCountReader(
+      uncore_scope::Scope scope,
+      std::shared_ptr<const MetricDesc> metric_desc_in,
+      std::shared_ptr<const PmuDeviceManager> pmu_manager_in)
+      : TBase{nullptr},
+        pmu_manager{pmu_manager_in},
+        metric_desc{metric_desc_in} {
+    HBT_DCHECK(pmu_manager != nullptr);
+    HBT_DCHECK(metric_desc != nullptr);
+
+    // theoritically, uncore events are often not belonged to a certain CPU.
+    // however, linux perf system uses CPU as a part of the identifier to
+    // identify a certain uncore PMU device.
+    auto per_uncore_event_confs =
+        metric_desc->makePerUncoreConfs(scope, *pmu_manager);
+
+    for (const auto& [perf_pmu, conf] : per_uncore_event_confs) {
+      const auto& [cpu, pmu] = perf_pmu;
+      auto id = generateEventsGroupId(pmu->getPmuId(), cpu);
+      this->generators_[id] = std::make_shared<UncoreCountReader>(
+          metric_desc->eventNicknames(pmu_manager->cpuInfo.cpu_arch),
+          cpu,
+          conf);
+    }
+  }
+
+  void open(bool pinned = false) {
+    try {
+      for (const auto& [cpu, gen] : this->generators_) {
+        gen->open(pinned);
+      }
+    } catch (...) {
+      close();
+      throw;
+    }
+  }
+
+  size_t getNumEvents() const {
+    return this->metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch)
+        .value_or(0);
+  }
+
+  /// Utility method to create ReadValues structure of the right size.
+  ReadValues makeReadValues() const {
+    return ReadValues{getNumEvents()};
+  }
+
+  using TBase::read;
+
+  std::optional<ReadValues> read() const {
+    auto rv = makeReadValues();
+    if (TBase::read(rv)) {
+      return std::make_optional(rv);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  const std::shared_ptr<const PmuDeviceManager> pmu_manager;
+  const std::shared_ptr<const MetricDesc> metric_desc;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PerfEventsGroup.h
+++ b/hbt/src/perf_event/PerfEventsGroup.h
@@ -586,21 +586,21 @@ static_assert(std::is_pod_v<GroupReadValues<mode::Sampling>::T>);
 /// Must implement a handleRecord* for each record type support in <TMode>.
 
 template <class TImpl, class TMode_>
-class CpuEventsGroupBase {
+class PerfEventsGroupBase {
  public:
   using TMode = TMode_;
 
   static constexpr size_t kPerfEventAttrSize = sizeof(perf_event_attr);
 
-  CpuEventsGroupBase(const CpuEventsGroupBase&) = delete;
+  PerfEventsGroupBase(const PerfEventsGroupBase&) = delete;
 
-  CpuEventsGroupBase(
+  PerfEventsGroupBase(
       CpuId cpu,
       pid_t pid,
       int cgroup_fd,
       const EventConfs& confs);
 
-  virtual ~CpuEventsGroupBase();
+  virtual ~PerfEventsGroupBase();
 
   void close();
 
@@ -681,7 +681,7 @@ class CpuEventsGroupBase {
 /// Must implement a handleRecord* for each record type support in <TMode>.
 
 template <class TImpl, class TMode_>
-class CpuEventsGroup : public CpuEventsGroupBase<TImpl, TMode_> {
+class PerfEventsGroup : public PerfEventsGroupBase<TImpl, TMode_> {
  public:
   using TMode = TMode_;
   using TSampleId = typename TMode::sample_id_t;
@@ -697,11 +697,11 @@ class CpuEventsGroup : public CpuEventsGroupBase<TImpl, TMode_> {
 
   static constexpr size_t kPerfEventAttrSize = sizeof(perf_event_attr);
 
-  CpuEventsGroup(const CpuEventsGroup&) = delete;
+  PerfEventsGroup(const PerfEventsGroup&) = delete;
 
-  using CpuEventsGroupBase<TImpl, TMode_>::CpuEventsGroupBase;
+  using PerfEventsGroupBase<TImpl, TMode_>::PerfEventsGroupBase;
 
-  virtual ~CpuEventsGroup() {}
+  virtual ~PerfEventsGroup() {}
 
   void close();
 
@@ -892,7 +892,7 @@ inline void writeDataTail(
 }
 
 template <class TImpl, class TMode>
-CpuEventsGroupBase<TImpl, TMode>::CpuEventsGroupBase(
+PerfEventsGroupBase<TImpl, TMode>::PerfEventsGroupBase(
     CpuId cpu,
     pid_t pid,
     int cgroup_fd,
@@ -906,14 +906,14 @@ CpuEventsGroupBase<TImpl, TMode>::CpuEventsGroupBase(
 }
 
 template <class TImpl, class TMode>
-CpuEventsGroupBase<TImpl, TMode>::~CpuEventsGroupBase() {
+PerfEventsGroupBase<TImpl, TMode>::~PerfEventsGroupBase() {
   if (isOpen()) {
     close();
   }
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
+void PerfEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
     const EventConfs& confs,
     uint64_t sample_period,
     struct perf_event_attr* attrs,
@@ -992,7 +992,7 @@ void CpuEventsGroupBase<TImpl, TMode>::init_perf_event_attrs(
 /// head page info, such as clocks.
 ///
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::open_counting_(
+void PerfEventsGroupBase<TImpl, TMode>::open_counting_(
     uint64_t sample_period,
     bool pinned,
     bool thread) {
@@ -1087,7 +1087,7 @@ void CpuEventsGroupBase<TImpl, TMode>::open_counting_(
 /// head page info, such as clocks.
 ///
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::open_(
+void PerfEventsGroup<TImpl, TMode>::open_(
     size_t num_data_pages,
     uint64_t sample_period,
     bool pinned,
@@ -1143,7 +1143,7 @@ void CpuEventsGroup<TImpl, TMode>::open_(
 }
 
 template <class TImpl, class TMode>
-int CpuEventsGroup<TImpl, TMode>::mmap_(int fd) {
+int PerfEventsGroup<TImpl, TMode>::mmap_(int fd) {
   HBT_DCHECK_GT(fd, 0);
   // Mmap sampling buffer for leader event.
   size_t mmap_size = page_size_ * (1 + num_data_pages_);
@@ -1202,7 +1202,7 @@ int CpuEventsGroup<TImpl, TMode>::mmap_(int fd) {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::closeEvents_() {
+void PerfEventsGroupBase<TImpl, TMode>::closeEvents_() {
   HBT_THROW_ASSERT_IF(!isOpen());
 
   // Reverse order to delete leader last.
@@ -1221,7 +1221,7 @@ void CpuEventsGroupBase<TImpl, TMode>::closeEvents_() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::close() {
+void PerfEventsGroupBase<TImpl, TMode>::close() {
   if (!isOpen()) {
     return;
   }
@@ -1232,7 +1232,7 @@ void CpuEventsGroupBase<TImpl, TMode>::close() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::close() {
+void PerfEventsGroup<TImpl, TMode>::close() {
   if (!this->isOpen()) {
     return;
   }
@@ -1274,7 +1274,7 @@ void CpuEventsGroup<TImpl, TMode>::close() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::enable(bool reset) {
+void PerfEventsGroupBase<TImpl, TMode>::enable(bool reset) {
   HBT_ARG_CHECK(isOpen()) << "Cannot enable events that are not open";
 
   if (enabled_) {
@@ -1318,7 +1318,7 @@ void CpuEventsGroupBase<TImpl, TMode>::enable(bool reset) {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroupBase<TImpl, TMode>::disable() {
+void PerfEventsGroupBase<TImpl, TMode>::disable() {
   HBT_ARG_CHECK(isOpen()) << "Cannot disable events that are not open";
 
   if (!enabled_)
@@ -1332,7 +1332,7 @@ void CpuEventsGroupBase<TImpl, TMode>::disable() {
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::changeSamplePeriod(
+void PerfEventsGroup<TImpl, TMode>::changeSamplePeriod(
     uint64_t new_sample_period) {
   if (this->sample_period_ == new_sample_period)
     return;
@@ -1345,7 +1345,7 @@ void CpuEventsGroup<TImpl, TMode>::changeSamplePeriod(
 }
 
 template <class TImpl, class TMode>
-void* CpuEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
+void* PerfEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
   if (aux_buffer_.size < size) {
     aux_buffer_.base = ::realloc(aux_buffer_.base, size);
     aux_buffer_.size = size;
@@ -1362,9 +1362,9 @@ void* CpuEventsGroup<TImpl, TMode>::enlargeAuxBuffer(size_t size) {
 /// of actually collected events. If an error, it will return a
 /// negative value with error number.
 template <class TImpl, class TMode>
-ssize_t CpuEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
+ssize_t PerfEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
   HBT_ARG_CHECK(this->isOpen())
-      << "CpuEventsGroup must be open for events to be consumed "
+      << "PerfEventsGroup must be open for events to be consumed "
       << " (event fd must be valid). Did you mean to only disable it?";
 
   ssize_t err = 0;
@@ -1548,7 +1548,7 @@ ssize_t CpuEventsGroup<TImpl, TMode>::consume(unsigned max_num_records) {
 
 exit:
   HBT_DCHECK_GE(max_num_records, num_records);
-  // HBT_LOG_INFO() << "CpuEventsGroup::consume err: " << err
+  // HBT_LOG_INFO() << "PerfEventsGroup::consume err: " << err
   //    << " data_head: " << data_head << " data_tail: " << data_tail
   //    << " num_records: " << num_records
   //    << " max_num_records: " << max_num_records;
@@ -1560,11 +1560,11 @@ exit:
 }
 
 template <class TImpl, class TMode>
-void CpuEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
+void PerfEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
     OnRbReadCallback callback,
     bool consume) {
   HBT_ARG_CHECK(this->isOpen())
-      << "CpuEventsGroup must be open for events to be consumed "
+      << "PerfEventsGroup must be open for events to be consumed "
       << " (event fd must be valid). Did you mean to only disable it?";
 
   auto mmap_header =
@@ -1613,10 +1613,10 @@ void CpuEventsGroup<TImpl, TMode>::onCpuDataBufferRead(
 
 /// Convert TSC to kernel time (reference bus-cycles to nanoseconds since boot).
 template <class TImpl, class TMode>
-uint64_t CpuEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
+uint64_t PerfEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
     uint64_t tsc_cycles) const {
   HBT_DCHECK(mmap_base_ != nullptr)
-      << "Cannot call kernelTimeFromTsc in closed CpuEventsGroup "
+      << "Cannot call kernelTimeFromTsc in closed PerfEventsGroup "
       << "because perf_event mmap page is not available";
   auto mmap_header =
       static_cast<volatile struct perf_event_mmap_page*>(mmap_base_);
@@ -1630,9 +1630,10 @@ uint64_t CpuEventsGroup<TImpl, TMode>::kernelTimeFromTsc(
 
 /// Convert kernel time to TSC (nanoseconds since boot to reference bus-cycles).
 template <class TImpl, class TMode>
-uint64_t CpuEventsGroup<TImpl, TMode>::tscFromKernelTime(uint64_t ktime) const {
+uint64_t PerfEventsGroup<TImpl, TMode>::tscFromKernelTime(
+    uint64_t ktime) const {
   HBT_THROW_ASSERT_IF(mmap_base_ == nullptr)
-      << "Cannot call tscFromKernelTimec in closed CpuEventsGroup "
+      << "Cannot call tscFromKernelTimec in closed PerfEventsGroup "
          "because perf_event mmap page is not available";
 
   // XXX: It's likely that time_mult is usually a hardware division friendly

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -157,7 +157,9 @@ PmuDevice::ConfigType ConfigTypeFromStr(const std::string& str) {
   __builtin_unreachable();
 }
 
-void parseSysFsPmuFormat_(fs::directory_entry dentry, PmuDevice& pmu_device) {
+void parseSysFsPmuFormat_(
+    const fs::directory_entry& dentry,
+    PmuDevice& pmu_device) {
   auto format_dir = dentry.path() / "format";
   if (!fs::is_directory(format_dir)) {
     return;
@@ -249,6 +251,47 @@ void parseSysFsPmuCaps_(fs::directory_entry dentry, PmuDevice& pmu_device) {
   }
 }
 
+std::optional<cpu_set_t> parseSysFsPmuCpuMask_(fs::directory_entry dentry) {
+  auto cpu_mask_path = dentry.path() / "cpumask";
+  if (!fs::is_regular_file(cpu_mask_path)) {
+    // not all pmu devices have cpumask file
+    return std::nullopt;
+  }
+  auto is = std::ifstream(cpu_mask_path, std::ifstream::in);
+  std::string cpu_mask_str;
+  is >> cpu_mask_str;
+  if (is.fail() || is.eof()) {
+    HBT_LOG_ERROR() << "CpuMask entry " << cpu_mask_path
+                    << " contains invalid character or is empty";
+    return std::nullopt;
+  }
+  cpu_set_t res;
+  CPU_ZERO(&res);
+  // parse cpumask string to cpu_set_t
+  // string format is expected to be ^\d+(,\d+)*$
+  size_t start_pos = 0;
+  while (true) {
+    auto end_pos = cpu_mask_str.find(',', start_pos);
+    size_t len = end_pos == std::string::npos ? cpu_mask_str.size() - start_pos
+                                              : end_pos - start_pos;
+    size_t cpu_idx;
+    try {
+      cpu_idx = std::stoul(cpu_mask_str.substr(start_pos, len));
+    } catch (const std::logic_error& e) {
+      HBT_LOG_ERROR() << "Failed to parse cpu mask string " << cpu_mask_str
+                      << "(" << cpu_mask_str.substr(start_pos, len) << ") from "
+                      << cpu_mask_path << " because " << e.what();
+      return std::nullopt;
+    }
+    CPU_SET(cpu_idx, &res);
+    start_pos = end_pos + 1;
+    if (end_pos >= cpu_mask_str.size()) {
+      break;
+    }
+  }
+  return res;
+}
+
 /// Parse string published by kernel in /sys/devices to a pair of
 /// PmuType and device id.
 std::pair<PmuType, std::optional<uint32_t>> parseDeviceTypeFromStr(
@@ -286,8 +329,11 @@ void parseSysFsPmu_(fs::directory_entry dentry, PmuDeviceManager& pmu_manager) {
   uint32_t pmu_id;
   is >> pmu_id;
 
-  auto pmu_device =
-      std::make_shared<PmuDevice>(p, pmu_type, pmu_idx, pmu_id, p, true);
+  // Read cpumask
+  auto cpu_mask = parseSysFsPmuCpuMask_(dentry);
+
+  auto pmu_device = std::make_shared<PmuDevice>(
+      p, pmu_type, pmu_idx, pmu_id, p, true, cpu_mask);
   parseSysFsPmuFormat_(dentry, *pmu_device);
   parseSysFsPmuCaps_(dentry, *pmu_device);
 

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -556,8 +556,11 @@ std::vector<TPerfPmuDevice> PmuDeviceManager::getPerfPmuGroupByScope(
   std::vector<TPerfPmuDevice> perf_pmu_group;
   // Get all PmuDevices of this type (e.g one per package).
   for (const auto& [dev_idx, device] : it->second) {
-    HBT_THROW_ASSERT_IF(device->getCpuMask() == std::nullopt)
-        << "Cannot find cpu mask info from pmu device " << device->getName();
+    if (device->getCpuMask() == std::nullopt) {
+      HBT_LOG_ERROR() << "Cannot find cpu mask info from pmu device "
+                      << device->getName() << ". Ignore this device.";
+      continue;
+    }
     for_each_cpu_set_t(cpu, device->getCpuMask().value()) {
       perf_pmu_group.push_back(TPerfPmuDevice{cpu, device});
     }

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "hbt/src/perf_event/PmuDevices.h"
-
 #include <hbt/src/perf_event/PmuEvent.h>
+#include <cstdint>
 #include <string>
 
 #include <filesystem>
@@ -493,6 +493,22 @@ void PmuDeviceManager::makePerCpuConfs(
   }
 }
 
+void PmuDeviceManager::makePerUncoreConfs(
+    PmuType pmu_type,
+    EventId ev_id,
+    EventExtraAttr extra_attrs,
+    EventValueTransforms transforms,
+    uncore_scope::Scope scope,
+    PerUncoreEventConfs& per_uncore_confs) const {
+  std::vector<TPerfPmuDevice> perf_pmu_group =
+      getPerfPmuGroupByScope(pmu_type, scope);
+
+  for (const auto& perf_pmu : perf_pmu_group) {
+    auto& confs = per_uncore_confs[perf_pmu];
+    confs.push_back(perf_pmu.second->makeConf(ev_id, extra_attrs, transforms));
+  }
+}
+
 EventConf PmuDeviceManager::makeNoCpuTopologyConf(
     PmuType pmu_type,
     EventId ev_id,
@@ -523,6 +539,26 @@ std::set<std::string> PmuDeviceManager::getPmuNames() const {
     }
   }
   return pmu_ids;
+}
+
+std::vector<TPerfPmuDevice> PmuDeviceManager::getPerfPmuGroupByScope(
+    PmuType pmu_type,
+    uncore_scope::Scope scope) const {
+  HBT_ARG_CHECK(std::holds_alternative<uncore_scope::Host>(scope))
+      << "Only Host scope supported";
+  auto it = pmu_groups_.find(pmu_type);
+  HBT_ARG_CHECK(it != pmu_groups_.end())
+      << "Invalid pmu_type: " + PmuTypeToStr(pmu_type);
+  std::vector<TPerfPmuDevice> perf_pmu_group;
+  // Get all PmuDevices of this type (e.g one per package).
+  for (const auto& [dev_idx, device] : it->second) {
+    HBT_THROW_ASSERT_IF(device->getCpuMask() == std::nullopt)
+        << "Cannot find cpu mask info from pmu device " << device->getName();
+    for_each_cpu_set_t(cpu, device->getCpuMask().value()) {
+      perf_pmu_group.push_back(TPerfPmuDevice{cpu, device});
+    }
+  }
+  return perf_pmu_group;
 }
 
 std::shared_ptr<PmuDevice> PmuDeviceManager::findPmuDeviceByName(

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -89,6 +89,8 @@ std::string PmuTypeToStr(PmuType pmu_type) {
     CASE_PMU_TYPE(uncore_mchbm);
 
     CASE_PMU_TYPE(armv8_pmuv3);
+
+    CASE_PMU_TYPE(nvidia_scf_pmu);
   }
 }
 
@@ -139,6 +141,8 @@ PmuType PmuTypeFromStr(const std::string& str) {
   IF_PMU_TYPE(str, uncore_mchbm);
 
   IF_PMU_TYPE(str, armv8_pmuv3);
+
+  IF_PMU_TYPE(str, nvidia_scf_pmu);
 
   HBT_THROW_EINVAL() << "Unrecognized PmuType string: \"" + str + "\"";
   __builtin_unreachable();

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -71,13 +71,15 @@ class PmuDevice {
       std::optional<unsigned> pmu_device_enumeration,
       uint32_t perf_pmu_id,
       const std::string& desc,
-      bool in_sysfs)
+      bool in_sysfs,
+      std::optional<cpu_set_t> cpu_mask = std::nullopt)
       : pmu_name_{pmu_name},
         pmu_type_{pmu_type},
         pmu_device_enumeration_{pmu_device_enumeration},
         perf_pmu_id_{perf_pmu_id},
         desc_{desc},
-        in_sysfs_{in_sysfs} {}
+        in_sysfs_{in_sysfs},
+        cpu_mask_{cpu_mask} {}
 
   PmuDevice(const PmuDevice&) = delete;
   PmuDevice(PmuDevice&&) = delete;

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -80,6 +80,9 @@ enum class PmuType : uint16_t {
 
   // Arm
   armv8_pmuv3,
+
+  // Nvidia Uncore
+  nvidia_scf_pmu,
 };
 
 std::string PmuTypeToStr(PmuType);

--- a/hbt/src/perf_event/ThreadCountReader.h
+++ b/hbt/src/perf_event/ThreadCountReader.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
-#include "hbt/src/perf_event/CpuEventsGroup.h"
 #include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 #include <memory>
 
@@ -21,9 +21,9 @@ namespace facebook::hbt::perf_event {
 //
 
 class ThreadCountReaderImpl
-    : public CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting> {
+    : public PerfEventsGroupBase<ThreadCountReaderImpl, mode::Counting> {
  public:
-  using TBase = CpuEventsGroupBase<ThreadCountReaderImpl, mode::Counting>;
+  using TBase = PerfEventsGroupBase<ThreadCountReaderImpl, mode::Counting>;
 
   /// Convenience type definition to create structure to store read values.
   using ReadValues = GroupReadValues<mode::Counting>;

--- a/hbt/src/perf_event/tests/CMakeLists.txt
+++ b/hbt/src/perf_event/tests/CMakeLists.txt
@@ -4,10 +4,10 @@ add_compile_options("-Wconversion")
 
 include_directories(${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include)
 
-add_executable(CpuEventsGroupTest CpuEventsGroupTest.cpp)
-target_link_libraries(CpuEventsGroupTest PRIVATE gtest gmock gtest_main)
-target_link_libraries(CpuEventsGroupTest PUBLIC stdc++fs)
-target_link_libraries(CpuEventsGroupTest PUBLIC CpuEventsGroup)
+add_executable(PerfEventsGroupTest PerfEventsGroupTest.cpp)
+target_link_libraries(PerfEventsGroupTest PRIVATE gtest gmock gtest_main)
+target_link_libraries(PerfEventsGroupTest PUBLIC stdc++fs)
+target_link_libraries(PerfEventsGroupTest PUBLIC PerfEventsGroup)
 
 # add_executable(PmuDevicesTest PmuDevicesTest.cpp)
 # target_link_libraries(PmuDevicesTest PRIVATE gtest gmock gtest_main)

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -212,7 +212,7 @@ TEST(PerCpuCountReader, SmokeTest) {
   // Read per CPUs
   auto rv_percpu = g.readPerCpu();
   ASSERT_NE(rv_percpu, std::nullopt);
-  for (auto& grv : *rv_percpu) {
+  for (auto& [_, grv] : *rv_percpu) {
     if (grv.getTimeRunning() == 0) {
       continue;
     }

--- a/hbt/src/perf_event/tests/PerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/PerfEventsGroupTest.cpp
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 
 #include <gtest/gtest.h>
 #include <filesystem>
@@ -55,9 +55,9 @@ EventConfs constructIntelPTEventConfs() {
 }
 
 // Create a CRTP implementation for test purposes.
-class SamplingEvents : public CpuEventsGroup<SamplingEvents, mode::Sampling> {
+class SamplingEvents : public PerfEventsGroup<SamplingEvents, mode::Sampling> {
  public:
-  using TBase = CpuEventsGroup<SamplingEvents, mode::Sampling>;
+  using TBase = PerfEventsGroup<SamplingEvents, mode::Sampling>;
   using TMode = TBase::TMode;
 
   SamplingEvents(CpuId cpu, const EventConfs& confs)
@@ -89,9 +89,9 @@ class SamplingEvents : public CpuEventsGroup<SamplingEvents, mode::Sampling> {
 
 // Create a CRTP implementation for test purposes.
 class ContextSwitchEvents
-    : public CpuEventsGroup<ContextSwitchEvents, mode::ContextSwitch> {
+    : public PerfEventsGroup<ContextSwitchEvents, mode::ContextSwitch> {
  public:
-  using TBase = CpuEventsGroup<ContextSwitchEvents, mode::ContextSwitch>;
+  using TBase = PerfEventsGroup<ContextSwitchEvents, mode::ContextSwitch>;
   using TMode = TBase::TMode;
 
   ContextSwitchEvents(CpuId cpu, const EventConfs& confs)
@@ -131,9 +131,9 @@ class ContextSwitchEvents
   }
 };
 
-class IntelPTEvents : public CpuEventsGroup<IntelPTEvents, mode::AUXSpace> {
+class IntelPTEvents : public PerfEventsGroup<IntelPTEvents, mode::AUXSpace> {
  public:
-  using TBase = CpuEventsGroup<IntelPTEvents, mode::AUXSpace>;
+  using TBase = PerfEventsGroup<IntelPTEvents, mode::AUXSpace>;
   using TMode = TBase::TMode;
 
   IntelPTEvents(CpuId cpu, pid_t pid, const EventConfs& confs)
@@ -339,7 +339,7 @@ TEST(IntelPTEvents, SmokeTest_IntelPT) {
 TEST(ContextSwitchEvents, SmokeTest_IntelPTSpecificProcess) {
   /*
    * XXX: Temporarily comment because this test requires
-   * IntelPT availablity that is not always available in SandCastle.
+   * IntelPT availability that is not always available in SandCastle.
   // Fork a new process for testing
   auto pid = fork();
   ASSERT_NE(pid, -1);

--- a/hbt/src/tagstack/PerfEventStream.h
+++ b/hbt/src/tagstack/PerfEventStream.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "hbt/src/perf_event/CpuEventsGroup.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/ringbuffer/Consumer.h"
 #include "hbt/src/tagstack/Event.h"
 


### PR DESCRIPTION
Summary: it's fine if we are unable to collect perf metrics from some PMUs (possible reason could be the numa node is offlined). ignore opening perf metric for empty cpu_mask rather than crash dynolog

Differential Revision: D55105429
