### PR TITLE
Remove extra semi colon from hbt/src/ringbuffer/tests/ShmPerCpuRingBufferTest.cpp

### DIFF
--- a/hbt/src/ringbuffer/tests/ShmPerCpuRingBufferTest.cpp
+++ b/hbt/src/ringbuffer/tests/ShmPerCpuRingBufferTest.cpp
@@ -74,7 +74,7 @@ TEST(ShmPerCpuRingBuffer, SameProducerConsumer) {
 
   // All done. Unlink to cleanup.
   ringbuffer::shm::unlink<TPerCpuRingBuffer>(name_id);
-};
+}
 
 TEST(ShmPerCpuRingBuffer, SingleProducer_SingleConsumer) {
   // Make unique file name for shared memory
@@ -168,4 +168,4 @@ TEST(ShmPerCpuRingBuffer, SingleProducer_SingleConsumer) {
     wait(nullptr);
     HBT_LOG_INFO() << "Finished wait for children";
   }
-};
+}


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55534629


