### PR TITLE
Remove unused variables in dyno/cpp/lib/SAHHostAttributesWriterV2.cpp

### DIFF
--- a/dynolog/src/KernelCollector.cpp
+++ b/dynolog/src/KernelCollector.cpp
@@ -34,7 +34,6 @@ void KernelCollector::log(Logger& log) {
   }
 
   float total_ticks = cpuDelta_.total();
-  auto cpuMs = ticksToMs(cpuDelta_.total());
 
   // Relative utilization in percentage
   log.logFloat("cpu_u", cpuDelta_.u / total_ticks * 100.0);

--- a/dynolog/src/rpc/SimpleJsonServer.cpp
+++ b/dynolog/src/rpc/SimpleJsonServer.cpp
@@ -201,8 +201,6 @@ void SimpleJsonServerBase::loop() noexcept {
 }
 
 void SimpleJsonServerBase::processOne() noexcept {
-  int ret, flag;
-
   /* Wait for incoming connections, the accept call is blocking*/
   LOG(INFO) << "Waiting for connection.";
   ClientSocketWrapper client;


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D56022385


