### PR TITLE
Remove unused variables in haystack/src2/http/IOProcessor.cpp

### DIFF
--- a/hbt/src/tagstack/tests/IntervalSlicerTest.cpp
+++ b/hbt/src/tagstack/tests/IntervalSlicerTest.cpp
@@ -254,7 +254,7 @@ TEST(IntervalSlicer, MultipleSlicerInSequence) {
   }
 
   {
-    auto s2_exp = Slice::makeSlice(
+    [[maybe_unused]] auto s2_exp = Slice::makeSlice(
         99,
         1,
         1,

--- a/hbt/src/tagstack/tests/StreamTest.cpp
+++ b/hbt/src/tagstack/tests/StreamTest.cpp
@@ -13,8 +13,6 @@ using namespace facebook::hbt;
 using namespace facebook::hbt::ringbuffer;
 using namespace facebook::hbt::tagstack;
 
-const auto maxTimeStamp = std::numeric_limits<facebook::hbt::TimeStamp>::max();
-
 struct MockRingBufferExtraData {};
 
 using TRingBuffer = RingBuffer<MockRingBufferExtraData>;


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D56065774


