### PR TITLE
Add AMD Zen4 HW Memory Latency Perf Counters in Dynolog

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -91,6 +91,77 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "Retired SSE and AVX floating-point ops of all types.",
           "The number of all SSE/AVX floating-point Ops that have retired."),
       std::vector<EventId>({"zen4-ret-sse-avx-fp-ops-all"}));
+
+  // Sampled memory latency for AMD Zen4. The latency is measured from the L3
+  // cache to near/far data sources (DRAM, CXL, CCX cache) and back in
+  // nano-seconds.
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_dram_latency.near",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4XiSampledLatDRamNear.val},
+          "Sampled latency of requests that target the same NUMA node and return from DRAM.",
+          "Dram_Near. Read-write. Sampled latency of requests that target the same NUMA node and return from DRAM."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-dram-latency-near"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_dram_latency_requests.near",
+          EventDef::Encoding{
+              .code = amd_msr::kL3Zen4XiSampledLatReqDRamNear.val},
+          "L3 cache fill requests sourced from the same NUMA node and return from DRAM.",
+          "Dram_Near. Read-write. The number of sampled L3 cache fill requests from the same NUMA node and return from DRAM."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-dram-latency-requests-near"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_dram_latency.far",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4XiSampledLatDRamFar.val},
+          "Sampled latency of requests that target another NUMA node and return from DRAM.",
+          "Dram_Near. Read-write. Sampled latency of requests that target another NUMA node and return from DRAM."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-dram-latency-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_dram_latency_requests.far",
+          EventDef::Encoding{
+              .code = amd_msr::kL3Zen4XiSampledLatReqDRamFar.val},
+          "L3 cache fill requests sourced from another NUMA node and return from DRAM.",
+          "Dram_Near. Read-write. The number of sampled L3 cache fill requests from another NUMA node and return from DRAM."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-dram-latency-requests-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_ccx_latency.near",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4XiSampledLatCCXNear.val},
+          "Sampled latency of requests that target the same NUMA node and return from another CCX's cache.",
+          "Dram_Near. Read-write. Sampled latency of requests that target the same NUMA node and return from another CCX's cache."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-ccx-latency-near"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_ccx_latency_requests.near",
+          EventDef::Encoding{
+              .code = amd_msr::kL3Zen4XiSampledLatReqCCXNear.val},
+          "L3 cache fill requests sourced from the same NUMA node and return from another CCX's cache.",
+          "Dram_Near. Read-write. The number of sampled L3 cache fill requests from the same NUMA node and return from another CCX's cache."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-ccx-latency-requests-near"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_ccx_latency.far",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4XiSampledLatCCXFar.val},
+          "Sampled latency of requests that target another NUMA node and return from another CCX's cache.",
+          "Dram_Near. Read-write. Sampled latency of requests that target another NUMA node and return from another CCX's cache."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-ccx-latency-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_xi_sampled_ccx_latency_requests.far",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4XiSampledLatReqCCXFar.val},
+          "L3 cache fill requests sourced from another NUMA node and return from another CCX's cache.",
+          "Dram_Near. Read-write. The number of sampled L3 cache fill requests from another NUMA node and return from another CCX's cache."),
+      std::vector<EventId>({"zen4-l3-xi-sampled-ccx-latency-requests-far"}));
 }
 } // namespace milan
 

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -248,6 +248,78 @@ constexpr PmuMsr kL3Zen4FillRdRespSmpl{
         .enAllCores = 0x1,
         .sliceId = 0x3,
         .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatDRamNear{
+    .amdL3 = {
+        .event = 0xAC,
+        .unitMask = 0x01,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatReqDRamNear{
+    .amdL3 = {
+        .event = 0xAD,
+        .unitMask = 0x01,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatDRamFar{
+    .amdL3 = {
+        .event = 0xAC,
+        .unitMask = 0x02,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatReqDRamFar{
+    .amdL3 = {
+        .event = 0xAD,
+        .unitMask = 0x02,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatCCXNear{
+    .amdL3 = {
+        .event = 0xAC,
+        .unitMask = 0x04,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatReqCCXNear{
+    .amdL3 = {
+        .event = 0xAD,
+        .unitMask = 0x04,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatCCXFar{
+    .amdL3 = {
+        .event = 0xAC,
+        .unitMask = 0x08,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
+constexpr PmuMsr kL3Zen4XiSampledLatReqCCXFar{
+    .amdL3 = {
+        .event = 0xAD,
+        .unitMask = 0x08,
+        .coreId = 0x0,
+        .enAllSlices = 0x1,
+        .enAllCores = 0x1,
+        .sliceId = 0x3,
+        .threadMask = 0x3}};
 
 // DF counters (Zen 4)
 constexpr PmuMsr kDfZen4UmcAReadReqsLocal{

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -91,6 +91,8 @@ std::string PmuTypeToStr(PmuType pmu_type) {
     CASE_PMU_TYPE(armv8_pmuv3);
 
     CASE_PMU_TYPE(nvidia_scf_pmu);
+
+    CASE_PMU_TYPE(amd_l3);
   }
 }
 
@@ -143,6 +145,8 @@ PmuType PmuTypeFromStr(const std::string& str) {
   IF_PMU_TYPE(str, armv8_pmuv3);
 
   IF_PMU_TYPE(str, nvidia_scf_pmu);
+
+  IF_PMU_TYPE(str, amd_l3);
 
   HBT_THROW_EINVAL() << "Unrecognized PmuType string: \"" + str + "\"";
   __builtin_unreachable();

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -83,6 +83,9 @@ enum class PmuType : uint16_t {
 
   // Nvidia Uncore
   nvidia_scf_pmu,
+
+  // AMD L3
+  amd_l3,
 };
 
 std::string PmuTypeToStr(PmuType);


### PR DESCRIPTION
Summary:
Adds support in Dynolog for AMD Zen4 (Bergamo and Genoa) HW memory latency performance counters. 

The diff adds 6 counters:
* l3_to_near_dram_lat_avg_ns The average latency for requests that target the same (near) NUMA node and return from DRAM.
* l3_to_far_dram_lat_avg_ns: The average latency for requests that target another (far) NUMA node and return from DRAM.
* l3_to_all_dram_lat_avg_ns: The average latency for requests that target all (near and far) NUMA nodes and return from DRAM.
* l3_to_near_ccx_lat_avg_ns: The average latency for requests that target the same (near) NUMA node and return from another CCX's cache.
* l3_to_far_ccx_lat_avg_ns: The average latency for requests that target another (far) NUMA node and return from another CCX's cache.
* l3_to_all_ccx_lat_avg_ns: The average latency for requests that target all (near and far) NUMA nodes and return from another CCX's cache.

All latencies are measured from the L3 cache and back in nano-seconds.

Reviewed By: bigzachattack, meteorfox

Differential Revision: D55431445


