### PR TITLE
add instructions/cycles/l3cache misses per instruction to TaskMetricsPublisher

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -640,8 +640,26 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
   }
   // l3_cache_misses replaces DynoPerfCounterType::L3CACHE_MISS
   metrics->add(std::make_shared<MetricDesc>(
+      "l3_cache_misses",
+      "Core-originated cacheable demand requests missed L3.",
+      "Counts core-originated cacheable requests that miss the L3 cache (Longest Latency cache). "
+      "Requests include data and code reads, Reads-for-Ownership (RFOs), speculative accesses and hardware prefetches from L1 and L2. "
+      "It does not include all misses to the L3.",
+      std::map<TOptCpuArch, EventRefs>{
+          {std::nullopt,
+           EventRefs{EventRef{
+               "l3_cache_misses",
+               PmuType::cpu,
+               "LONGEST_LAT_CACHE.MISS",
+               EventExtraAttr{},
+               {}}}}},
+      100'000'000,
+      System::Permissions{},
+      std::vector<std::string>{},
+      getRateReducer()));
+  metrics->add(std::make_shared<MetricDesc>(
       "l3_cache_misses_per_instruction",
-      "Core-originated cacheable demand requests missed L3 per instruction.",
+      "Core-originated cacheable demand requests missed L3 normalized by number of instructions.",
       "Counts core-originated cacheable requests that miss the L3 cache (Longest Latency cache). "
       "Requests include data and code reads, Reads-for-Ownership (RFOs), speculative accesses and hardware prefetches from L1 and L2. "
       "It does not include all misses to the L3."

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -374,6 +374,18 @@ void populatePredefinedEventsOffcore(
     const CpuInfo& cpu_info) {
   auto offcoreEventDef = pmu_manager->findEventDef("OFFCORE_RESPONSE");
   if (!offcoreEventDef) {
+    // CLX doesn't have a general OFFCORE_RESPONSE event defined.
+    // So we use OCR.ALL_PF_RFO.L3_MISS.ANY_SNOOP event instead, which has the
+    // same code and umask but different msr.
+    // This doesn't make any difference as we only use code and umask from the
+    // generated event.
+    offcoreEventDef =
+        pmu_manager->findEventDef("OCR.ALL_PF_RFO.L3_MISS.ANY_SNOOP");
+  }
+  if (!offcoreEventDef) {
+    HBT_LOG_ERROR()
+        << "cannot find code and umask for offcore response event on architecture"
+        << cpu_info.cpu_arch;
     return;
   }
   // define equivalent event to replace DynoPerfCounter::DRAM_ACCESS_READS

--- a/hbt/src/perf_event/json_events/generated/intel/cascadelakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/cascadelakex_core.cpp
@@ -14,7 +14,7 @@ namespace cascadelakex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
 /*
-  Events from cascadelakex_core.json (2343 events).
+  Events from cascadelakex_core.json (2344 events).
 
   Supported SKUs:
       - Arch: x86, Model: CLX id: 85 Steps: ['5', '6', '7', '8', '9', 'A', 'B',
@@ -770,6 +770,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x32, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Number of PREFETCHW instructions executed.)",
       R"(Number of PREFETCHW instructions executed.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "SW_PREFETCH_ACCESS.ANY",
+      EventDef::Encoding{
+          .code = 0x32, .umask = 0x0F, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3025,7 +3040,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Number of all retired NOP instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.pebs = 1},
       R"(SKL091, SKL044)"));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
@@ -15913,7 +15928,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event OCR.ALL_PF_RFO.L3_MISS.ANY_SNOOP is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "OCR.ALL_PF_RFO.L3_MISS.ANY_SNOOP",
@@ -15929,7 +15944,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/icelakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/icelakex_core.cpp
@@ -14,7 +14,7 @@ namespace icelakex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
 /*
-  Events from icelakex_core.json (360 events).
+  Events from icelakex_core.json (361 events).
 
   Supported SKUs:
       - Arch: x86, Model: ICX id: 106
@@ -690,6 +690,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x32, .umask = 0x08, .cmask = 0, .msr_values = {0x00}},
       R"(Number of PREFETCHW instructions executed.)",
       R"(Counts the number of PREFETCHW instructions executed.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "SW_PREFETCH_ACCESS.ANY",
+      EventDef::Encoding{
+          .code = 0x32, .umask = 0x0F, .cmask = 0, .msr_values = {0x00}},
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
       100003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},

--- a/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
@@ -14,7 +14,7 @@ namespace sapphirerapids_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
 /*
-  Events from sapphirerapids_core.json (385 events).
+  Events from sapphirerapids_core.json (388 events).
 
   Supported SKUs:
       - Arch: x86, Model: SPR id: 143
@@ -1108,6 +1108,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "SW_PREFETCH_ACCESS.ANY",
+      EventDef::Encoding{
+          .code = 0x40, .umask = 0xF, .cmask = 0, .msr_values = {0x00}},
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      100003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "MEM_LOAD_COMPLETED.L1_MISS_ANY",
       EventDef::Encoding{
           .code = 0x43, .umask = 0xfd, .cmask = 0, .msr_values = {0x00}},
@@ -1930,6 +1945,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
+      "RS.EMPTY_RESOURCE",
+      EventDef::Encoding{
+          .code = 0xa5, .umask = 0x01, .cmask = 0, .msr_values = {0x00}},
+      R"(Cycles when Reservation Station (RS) is empty due to a resource in the back-end)",
+      R"(Cycles when Reservation Station (RS) is empty due to a resource in the back-end)",
+      1000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
       "RS.EMPTY",
       EventDef::Encoding{
           .code = 0xa5, .umask = 0x07, .cmask = 0, .msr_values = {0x00}},
@@ -2061,6 +2091,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Cycles no uop executed while RS was not empty, the SB was not full and there was no outstanding load.)",
       R"(Number of cycles total of 0 uops executed on all ports, Reservation Station (RS) was not empty, the Store Buffer (SB) was not full and there was no outstanding load.)",
       1000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "EXE_ACTIVITY.2_3_PORTS_UTIL",
+      EventDef::Encoding{
+          .code = 0xa6, .umask = 0xC, .cmask = 0, .msr_values = {0x00}},
+      R"(Cycles total of 2 or 3 uops are executed on all ports and Reservation Station (RS) was not empty.)",
+      R"(Cycles total of 2 or 3 uops are executed on all ports and Reservation Station (RS) was not empty.)",
+      2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
       std::nullopt // Errata

--- a/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylake_core.cpp
@@ -14,7 +14,7 @@ namespace skylake_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
 /*
-  Events from skylake_core.json (563 events).
+  Events from skylake_core.json (564 events).
 
   Supported SKUs:
       - Arch: x86, Model: SKL id: 78
@@ -729,6 +729,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x32, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Number of PREFETCHW instructions executed.)",
       R"(Number of PREFETCHW instructions executed.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "SW_PREFETCH_ACCESS.ANY",
+      EventDef::Encoding{
+          .code = 0x32, .umask = 0x0F, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -2998,7 +3013,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Number of all retired NOP instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.pebs = 1},
       R"(SKL091, SKL044)"));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 

--- a/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/skylakex_core.cpp
@@ -14,7 +14,7 @@ namespace skylakex_core {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
 /*
-  Events from skylakex_core.json (469 events).
+  Events from skylakex_core.json (470 events).
 
   Supported SKUs:
       - Arch: x86, Model: SKX id: 85 Steps: ['0', '1', '2', '3', '4']
@@ -784,6 +784,21 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           .code = 0x32, .umask = 0x08, .cmask = 0, .msr_values = {0}},
       R"(Number of PREFETCHW instructions executed.)",
       R"(Number of PREFETCHW instructions executed.)",
+      2000003,
+      std::nullopt, // ScaleUnit
+      EventDef::IntelFeatures{},
+      std::nullopt // Errata
+      ));
+#endif // HBT_ADD_ALL_GENERATED_EVENTS
+
+#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  pmu_manager.addEvent(std::make_shared<EventDef>(
+      PmuType::cpu,
+      "SW_PREFETCH_ACCESS.ANY",
+      EventDef::Encoding{
+          .code = 0x32, .umask = 0x0F, .cmask = 0, .msr_values = {0}},
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
+      R"(Counts the number of PREFETCHNTA, PREFETCHW, PREFETCHT0, PREFETCHT1 or PREFETCHT2 instructions executed.)",
       2000003,
       std::nullopt, // ScaleUnit
       EventDef::IntelFeatures{},
@@ -3053,7 +3068,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       R"(Number of all retired NOP instructions.)",
       2000003,
       std::nullopt, // ScaleUnit
-      EventDef::IntelFeatures{.pebs = 2},
+      EventDef::IntelFeatures{.pebs = 1},
       R"(SKL091, SKL044)"));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 


### PR DESCRIPTION
Summary: <add something about l3_cache_misses changes in hbt>

Reviewed By: bigzachattack

Differential Revision: D56083445


