### PR TITLE
Remove unused variables in gloo2/test/alltoallv_cpu_test.cc

### DIFF
--- a/hbt/src/mon/tests/MonitorTest.cpp
+++ b/hbt/src/mon/tests/MonitorTest.cpp
@@ -396,7 +396,7 @@ TEST(CpuCountReader, SystemWideCountRead) {
 
   auto cpu_set = CpuSet::makeAllOnline();
 
-  auto& reader = *mon.emplaceCpuCountReader(
+  mon.emplaceCpuCountReader(
       std::nullopt,
       kInstruction,
       metrics->getMetricDesc("instructions"),


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D57343994


