### PR TITLE
Add nvidia_nvlink_c2c1 PMU

### DIFF
--- a/hbt/src/perf_event/ArmEvents.cpp
+++ b/hbt/src/perf_event/ArmEvents.cpp
@@ -81,6 +81,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
   scanPmu(pmu_manager, PmuType::armv8_pmuv3);
   scanPmu(pmu_manager, PmuType::nvidia_scf_pmu);
   scanPmu(pmu_manager, PmuType::nvidia_nvlink_c2c0_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_nvlink_c2c1_pmu);
   scanPmu(pmu_manager, PmuType::nvidia_pcie_pmu);
 }
 

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -92,6 +92,7 @@ std::string PmuTypeToStr(PmuType pmu_type) {
 
     CASE_PMU_TYPE(nvidia_scf_pmu);
     CASE_PMU_TYPE(nvidia_nvlink_c2c0_pmu);
+    CASE_PMU_TYPE(nvidia_nvlink_c2c1_pmu);
     CASE_PMU_TYPE(nvidia_pcie_pmu);
 
     CASE_PMU_TYPE(amd_l3);
@@ -148,6 +149,7 @@ PmuType PmuTypeFromStr(const std::string& str) {
 
   IF_PMU_TYPE(str, nvidia_scf_pmu);
   IF_PMU_TYPE(str, nvidia_nvlink_c2c0_pmu);
+  IF_PMU_TYPE(str, nvidia_nvlink_c2c1_pmu);
   IF_PMU_TYPE(str, nvidia_pcie_pmu);
 
   IF_PMU_TYPE(str, amd_l3);

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -84,6 +84,7 @@ enum class PmuType : uint16_t {
   // Nvidia Uncores
   nvidia_scf_pmu,
   nvidia_nvlink_c2c0_pmu,
+  nvidia_nvlink_c2c1_pmu,
   nvidia_pcie_pmu,
 
   // AMD L3


### PR DESCRIPTION
Summary:
NVIDIA has to Chip-to-chip PMUs, each one is responsible for different measurements:

{F1645197609}

Differential Revision: D57635524


