### PR TITLE
Refactor PerfCounterManagerHbt to Utilize Hbt for Uncore Metrics

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -1465,7 +1465,11 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
   return metrics;
 }
 
-void addCoreMetrics(std::shared_ptr<Metrics>& metrics) {
+void addArmCoreMetrics(std::shared_ptr<Metrics>& /*metrics*/) {
+  // TODO
+}
+
+void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics) {
   metrics->add(std::make_shared<MetricDesc>(
       "HW_CORE_ICACHE_MISSES",
       "L2 code requests",

--- a/hbt/src/perf_event/BuiltinMetrics.h
+++ b/hbt/src/perf_event/BuiltinMetrics.h
@@ -12,7 +12,8 @@ namespace facebook::hbt::perf_event {
 
 std::shared_ptr<PmuDeviceManager> makePmuDeviceManager();
 std::shared_ptr<Metrics> makeAvailableMetrics();
-void addCoreMetrics(std::shared_ptr<Metrics>& metrics);
+void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics);
+void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics);
 void addUncoreMetrics(std::shared_ptr<Metrics>& metrics);
 void addArmUncoreMetrics(std::shared_ptr<Metrics>& metrics);
 void addIntelUncoreMetrics(std::shared_ptr<Metrics>& metrics);


### PR DESCRIPTION
Summary: Deprecate legacy MemoryPcmIntel module for ICL and newer. Instead, use hbt for uncore metrics support and utilize metric frames to hold measured values.

Reviewed By: Alston-Tang

Differential Revision: D57255677


