### PR TITLE
Remove unused exception parameter from hbt/src/perf_event/PerPerfEventsGroupBase.h

### DIFF
--- a/hbt/src/perf_event/PerPerfEventsGroupBase.h
+++ b/hbt/src/perf_event/PerPerfEventsGroupBase.h
@@ -33,7 +33,7 @@ class PerPerfEventsGroupBase {
       for (auto& [_, gen] : generators_) {
         gen->enable(reset);
       }
-    } catch (std::exception& /*e*/) {
+    } catch (std::exception&) {
       for (auto& [_, gen] : generators_) {
         if (gen->isEnabled()) {
           gen->disable();


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D58830840
