### PR TITLE
Fix build with libc++

### DIFF
--- a/hbt/src/common/Defs.h
+++ b/hbt/src/common/Defs.h
@@ -33,7 +33,7 @@ template <class TStream>
 TStream& LogCtxt(TStream& oss) {
   oss << "pid: " << ::getpid() << " on ";
   // Put date and time.
-  auto p = std::chrono::high_resolution_clock::now();
+  auto p = std::chrono::system_clock::now();
   auto t_c = std::chrono::system_clock::to_time_t(p);
   oss << std::put_time(std::localtime(&t_c), "%F %T");
   // Put microseconds.


### PR DESCRIPTION
Previously dynolog relied on a fact that `high_resolution_clock` is an alias of `system_clock`, however in general it is not true[1].
On systems where `high_resolution_clock` is an alias of `steady_clock` no conversion is possible.
Instead of relying that `high_resolution_clock` is an alias of `system_clock`, it is better to use `system_clock::now` directly.

[1] https://en.cppreference.com/w/cpp/chrono/high_resolution_clock

Closes: #275