### PR TITLE
Generate unique per trace id in OSS dynolog

### DIFF
--- a/dynolog/src/LibkinetoTypes.h
+++ b/dynolog/src/LibkinetoTypes.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 
 namespace dynolog {
@@ -16,6 +17,7 @@ enum class LibkinetoConfigType {
 };
 
 struct GpuProfilerResult {
+  std::vector<std::string> traceIds;
   std::vector<int32_t> processesMatched;
   std::vector<int32_t> eventProfilersTriggered;
   std::vector<int32_t> activityProfilersTriggered;


### PR DESCRIPTION
Summary:
- add `  std::vector<std::string> traceIds` to `GpuProfilerResult`
- update OSS dynolog to generate a unique (per trace) `trace_id`
  - the `trace_id` is generated as follows: `hash(hostname + pid + current_time)`
    - This combination of info should be unique since the code is single threaded

Differential Revision: D60242891
