### PR TITLE
hbt/bperf: Deprecate attr map

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -65,7 +65,6 @@ class BPerfEventsGroup {
       int cgroup_update_level);
 
   ~BPerfEventsGroup();
-  static std::string attrMapPath();
 
   size_t getNumEvents() const;
   bool open();
@@ -140,7 +139,6 @@ class BPerfEventsGroup {
       __u64 id,
       bool skip_offset = false);
 
-  int lockAttrMap_();
   int reloadSkel_(struct bperf_attr_map_elem* entry);
   int loadPerfEvent_(struct bperf_leader_cgroup* skel);
 

--- a/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
@@ -32,12 +32,6 @@ void checkReading(
 }
 } // namespace
 
-TEST(BPerfEventsGroupTest, attr_map_path) {
-  auto attr_map_path = BPerfEventsGroup::attrMapPath();
-
-  EXPECT_EQ(attr_map_path.find("/sys/fs/bpf/bperf_attr_map_v"), 0);
-}
-
 TEST(BPerfEventsGroupTest, RunSystemWide) {
   auto pmu_manager = makePmuDeviceManager();
   auto pmu = pmu_manager->findPmuDeviceByName("generic_hardware");


### PR DESCRIPTION
Summary: We don't really use attr map in bperf at the time. Let's remove it.

Differential Revision: D61219654
