### PR TITLE
hbt/bperf: Fix a confusing variable name

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -65,7 +65,6 @@ class BPerfEventsGroup {
       int cgroup_update_level);
 
   ~BPerfEventsGroup();
-  static std::string attrMapPath();
 
   size_t getNumEvents() const;
   bool open();
@@ -140,7 +139,6 @@ class BPerfEventsGroup {
       __u64 id,
       bool skip_offset = false);
 
-  int lockAttrMap_();
   int reloadSkel_(struct bperf_attr_map_elem* entry);
   int loadPerfEvent_(struct bperf_leader_cgroup* skel);
 

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -75,7 +75,7 @@ static void update_cgroup_output(struct bpf_perf_event_value* diff_val,
 
 static __always_inline int bperf_leader_prog(struct task_struct *prev) {
   struct bpf_perf_event_value val, *prev_val, *diff_val, *sys_val;
-  __u32 key = bpf_get_smp_processor_id();
+  __u32 cpu = bpf_get_smp_processor_id();
   __u32 zero = 0, i;
   long err;
 
@@ -92,7 +92,7 @@ static __always_inline int bperf_leader_prog(struct task_struct *prev) {
     return 0;
 
   for (i = 0; i < BPERF_MAX_GROUP_SIZE; i++) {
-    __u32 idx = i * cpu_cnt + key;
+    __u32 idx = i * cpu_cnt + cpu;
 
     if (i >= event_cnt)
       break;

--- a/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
@@ -32,12 +32,6 @@ void checkReading(
 }
 } // namespace
 
-TEST(BPerfEventsGroupTest, attr_map_path) {
-  auto attr_map_path = BPerfEventsGroup::attrMapPath();
-
-  EXPECT_EQ(attr_map_path.find("/sys/fs/bpf/bperf_attr_map_v"), 0);
-}
-
 TEST(BPerfEventsGroupTest, RunSystemWide) {
   auto pmu_manager = makePmuDeviceManager();
   auto pmu = pmu_manager->findPmuDeviceByName("generic_hardware");


### PR DESCRIPTION
Summary:
s/key/cpu/ in bperf_leader_prog(), as "key" could also mean the idx in
the list of events (0 for "cycles", 1 for "instructions", etc.).

Differential Revision: D61219662
