### PR TITLE
hbt/bperf: Per thread monitoring core logic part 1

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -36,14 +36,23 @@ struct bperf_attr_map_elem {
 
 class BPerfEventsGroup {
  public:
+  static std::string perThreadArrayMapPath(const std::string& n);
+  static std::string perThreadIndexMapPath(const std::string& n);
+
   using ReadValues = GroupReadValues<mode::Counting>;
   ///
   ///  - confs: Event Confs for group.
-  BPerfEventsGroup(const EventConfs& confs, int cgroup_update_level);
+  BPerfEventsGroup(
+      const EventConfs& confs,
+      int cgroup_update_level,
+      bool support_per_thread = false,
+      const std::string& pin_name = "");
   BPerfEventsGroup(
       const MetricDesc& metric,
       const PmuDeviceManager& pmu_manager,
-      int cgroup_update_level);
+      int cgroup_update_level,
+      bool support_per_thread = false,
+      const std::string& pin_name = "");
 
   ~BPerfEventsGroup();
 
@@ -125,6 +134,16 @@ class BPerfEventsGroup {
   static int syncCpu_(__u32 cpu, int leader_pd);
   static void toReadValues(ReadValues& rv, struct bpf_perf_event_value*);
   void syncGlobal_();
-};
 
+  // For per thread monitoring
+  bool per_thread_;
+  const std::string pin_name_;
+
+  int pinThreadMaps_(bperf_leader_cgroup* skel);
+  int preparePerThreadBPerf_(bperf_leader_cgroup* skel);
+
+  ::bpf_link* register_thread_link_ = nullptr;
+  ::bpf_link* unregister_thread_link_ = nullptr;
+  ::bpf_link* update_thread_link_ = nullptr;
+};
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "hbt/src/perf_event/BPerfPerThreadReader.h"
+#include <bpf/bpf.h>
+#include <time.h>
+#include "hbt/src/perf_event/BPerfEventsGroup.h"
+
+namespace facebook::hbt::perf_event {
+
+BPerfPerThreadReader::BPerfPerThreadReader(std::string pin_name, int event_cnt)
+    : pin_name_(std::move(pin_name)), event_cnt_(event_cnt) {
+  // TODO: to be really backward/forward compatible, it is necessary to
+  // adjust mmap_size_ based after mmap.
+  mmap_size_ = (sizeof(struct bperf_thread_data) +
+                event_cnt * sizeof(struct bperf_perf_event_data)) *
+      BPERF_MAX_THREAD_READER;
+}
+
+static __u64 getRefMonoTime(void) {
+  struct timespec ts;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+int BPerfPerThreadReader::enable() {
+  int idx_fd, tid, idx = 0, err;
+
+  idx_fd =
+      ::bpf_obj_get(BPerfEventsGroup::perThreadIndexMapPath(pin_name_).c_str());
+  data_fd_ =
+      ::bpf_obj_get(BPerfEventsGroup::perThreadArrayMapPath(pin_name_).c_str());
+
+  if (idx_fd < 0 || data_fd_ < 0) {
+    HBT_LOG_ERROR() << "cannot open fds " << idx_fd << " " << data_fd_;
+    goto error;
+  }
+
+  mmap_ptr_ = mmap(
+      nullptr, mmap_size_, PROT_READ | PROT_WRITE, MAP_SHARED, data_fd_, 0);
+
+  if (mmap_ptr_ == MAP_FAILED) {
+    HBT_LOG_ERROR() << "mmap failed with " << errno;
+    goto error;
+  }
+
+  tid = gettid();
+  err = ::bpf_map_lookup_elem(idx_fd, &tid, &idx);
+
+  if (err != 0) {
+    HBT_LOG_ERROR() << "cannot lookup the idx";
+    goto error;
+  }
+
+  ::close(idx_fd);
+
+  data_ = (struct bperf_thread_data*)mmap_ptr_;
+  data_ += idx;
+
+  // There is a small drift between time from clock_gettime() and tsc.
+  // On a skylake host, I get about 0.02% difference. Get the initial
+  // drift at the moment and use it to fix future readings.
+  struct BPerfThreadData data;
+  read(&data);
+  initial_clock_drift_ = getRefMonoTime() - data.monoTime;
+  return 0;
+
+error:
+  ::close(idx_fd);
+  disable();
+  return -1;
+}
+
+void BPerfPerThreadReader::disable() {
+  munmap(mmap_ptr_, mmap_size_);
+  mmap_ptr_ = nullptr;
+  data_ = nullptr;
+  ::close(data_fd_);
+  data_fd_ = -1;
+  initial_clock_drift_ = 0LL;
+}
+
+BPerfPerThreadReader::~BPerfPerThreadReader() {
+  disable();
+}
+
+int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
+  struct bperf_clock_param *ptr = &data_->tsc_param, p;
+  __u64 tsc;
+  __u32 lock;
+
+  do {
+    lock = data_->lock;
+    tsc = rdtsc();
+    memcpy(&p, ptr, sizeof(p));
+  } while (lock != data_->lock);
+
+  data->monoTime = (((__uint128_t)tsc * p.multi) >> p.shift) + p.offset +
+      initial_clock_drift_;
+  data->cpuTime =
+      data_->runtime_until_schedin + (data->monoTime - data_->schedin_time);
+
+  // TODO: Detect when the lead program exists. It is a bit tricky, as
+  //       it may look like current thread is always running.
+  //       This will be easier once with some perf event.
+  return 0;
+}
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/perf_event/Metrics.h"
+#include "hbt/src/perf_event/PerfEventsGroup.h"
+#include "hbt/src/perf_event/PmuDevices.h"
+#include "hbt/src/perf_event/PmuEvent.h"
+#include "hbt/src/perf_event/bpf/bperf.h"
+
+namespace facebook::hbt::perf_event {
+
+struct BPerfThreadData {
+  __u64 cpuTime;
+  __u64 monoTime;
+  __u64 counters[BPERF_MAX_GROUP_SIZE];
+};
+
+class BPerfPerThreadReader {
+ public:
+  BPerfPerThreadReader(std::string pin_name, int event_cnt);
+  ~BPerfPerThreadReader();
+  int read(struct BPerfThreadData* data);
+  int enable();
+  void disable();
+
+ protected:
+  void* mmap_ptr_ = nullptr;
+  struct bperf_thread_data* data_ = nullptr;
+  int data_fd_ = -1;
+  const std::string pin_name_;
+  __s64 initial_clock_drift_ = 0;
+  int event_cnt_;
+  int mmap_size_;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -8,4 +8,54 @@
 
 #define BPERF_MAX_GROUP_SIZE 8
 
+#define BPERF_MAX_THREAD_READER 1024
+
+/* x86
+ * struct cyc2ns_data {
+ *   u32 cyc2ns_mul;
+ *   u32 cyc2ns_shift;
+ *   u64 cyc2ns_offset;
+ *  };
+ *
+ * time_ns = (tsc * multi) >> shift - offset
+ *
+ * On arm64
+ *   time_ns = TODO
+ */
+struct bperf_clock_param {
+  __u32 multi;
+  __u32 shift;
+  __u64 offset;
+  __u64 reserved;
+};
+
+/* data of a single perf_event */
+struct bperf_perf_event_data {};
+
+/* BPerfEventsGroup may have variable number of perf events.
+ * Therefore, the bperf_thread_data used for each thread may
+ * change. To show the data, we use fixed size header for per
+ * group data (time, etc.), and a variable sized array for
+ * per event data (bperf_perf_event_data).
+ */
+struct bperf_thread_data {
+  __u32 header_size; /* sizeof(bperf_thread_data) */
+  __u32 event_data_size; /* sizeof(bperf_perf_event_data) */
+  __u32 event_cnt;
+  __u32 flags;
+
+  __u32 lock;
+  struct bperf_clock_param tsc_param;
+
+  /* all the times are in nano seconds */
+
+  /* when the task got sched in the last time */
+  __u64 schedin_time;
+
+  /* runtime = runtime_until_schedin + tsc_time - schedin_time; */
+  __u64 runtime_until_schedin;
+
+  struct bperf_perf_event_data events[];
+} __attribute__((packed));
+
 #endif

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -46,6 +46,9 @@ struct {
   __uint(max_entries, DEFAULT_CGROUP_MAP_SIZE);
 } cgroup_output SEC(".maps");
 
+static void update_prev_user_page(struct bpf_perf_event_value* diff_val,
+                                  struct task_struct *task);
+
 int event_cnt = 0;
 int cpu_cnt = 0;
 int cgroup_update_level = 0;
@@ -140,6 +143,216 @@ SEC("raw_tp/sched_switch")
 int BPF_PROG(bperf_read_trigger) {
   /* Account for current task */
   return bperf_leader_prog(bpf_get_current_task_btf());
+}
+
+/* bperf per thread monitoring */
+
+/* per_thread_idx and per_thread_data map the channel that lead program,
+ * e.g. dynolog, communicates with per thread users. The user will mmap
+ * per_thread_data and check per_thread_idx for its index to use in the
+ * mmapped area.
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(key_size, sizeof(int)); /* pid */
+  __uint(value_size, sizeof(int)); /* idx in per_thread_data */
+  __uint(max_entries, BPERF_MAX_THREAD_READER);
+} per_thread_idx SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(key_size, sizeof(int));
+  /* for variable size bperf_thread_data, update value_size before load */
+  __uint(value_size, 1);
+  __uint(max_entries, BPERF_MAX_THREAD_READER);
+  __uint(map_flags, BPF_F_MMAPABLE);
+} per_thread_data SEC(".maps");
+
+/* The following is a simple bitmap for per_thread_idx */
+#define BITS_PER_U64 64
+__u64 bitmap[BPERF_MAX_THREAD_READER / BITS_PER_U64];
+#define NULL_BIT 0xffffffff
+
+#define private(name) SEC(".data." #name) __hidden __attribute__((aligned(8)))
+private(A) struct bpf_spin_lock bitmap_lock;
+
+static __u32 __always_inline find_free_bit(void) {
+  int i, j;
+
+  for (i = 0; i < BPERF_MAX_THREAD_READER / BITS_PER_U64; i++) {
+    if (bitmap[i] == ~0ULL)
+      continue;
+    for (j = 0; j < BITS_PER_U64; j++) {
+      if (((1ULL << j) & bitmap[i]) == 0) {
+        bitmap[i] |= 1ULL << j;
+        return i * BITS_PER_U64 + j;
+      }
+    }
+  }
+  return NULL_BIT;
+}
+
+static void __always_inline clear_bit(__u32 idx) {
+  __u32 key, shift;
+
+  if (idx >= BPERF_MAX_THREAD_READER)
+    return;
+
+  key = idx / BITS_PER_U64;
+  shift = idx % BITS_PER_U64;
+
+  bitmap[key] &= ~(1ULL << shift);
+}
+
+static int __always_inline bperf_update_thread_time(struct bperf_thread_data *data, __u64 now);
+
+__u32 per_thread_data_id; /* map id of per_thread_data */
+
+/* Trace mmap of per_thread_data */
+SEC("fentry/array_map_mmap")
+int BPF_PROG(bperf_register_thread, struct bpf_map *map) {
+  struct bperf_thread_data *data;
+  __u32 map_id = map->id;
+  __u32 tid;
+  __u32 idx;
+
+  if (map_id != per_thread_data_id)
+    return 0;
+
+  bpf_spin_lock(&bitmap_lock);
+  idx = find_free_bit();
+  bpf_spin_unlock(&bitmap_lock);
+
+  if (idx == NULL_BIT)
+    return 0;
+
+  data = bpf_map_lookup_elem(&per_thread_data, &idx);
+  if (!data)
+    return 0;
+
+  data->header_size = sizeof(struct bperf_thread_data);
+  data->event_data_size = sizeof(struct bperf_perf_event_data);
+  data->event_cnt = event_cnt;
+  data->flags = 0;
+  data->lock = 1;
+
+  tid = bpf_get_current_pid_tgid() & 0xffffffff;
+  bpf_map_update_elem(&per_thread_idx, &tid, &idx, BPF_ANY);
+
+  data->runtime_until_schedin = 0;
+  bperf_update_thread_time(data, bpf_ktime_get_ns());
+  return 0;
+}
+
+/* Trace munmap of per_thread_data */
+SEC("fentry/bpf_map_mmap_close")
+int BPF_PROG(bperf_unregister_thread, struct vm_area_struct *vma) {
+  struct bpf_map *map = bpf_core_cast(vma->vm_file->private_data,
+                                      struct bpf_map);
+  __u32 map_id = map->id;
+  __u32 tid;
+  __u32 *idx;
+
+  if (map_id != per_thread_data_id)
+    return 0;
+
+  tid = bpf_get_current_pid_tgid() & 0xffffffff;
+
+  idx = bpf_map_lookup_elem(&per_thread_idx, &tid);
+  if (!idx)
+    return 0;
+
+  bpf_map_delete_elem(&per_thread_idx, &tid);
+
+  bpf_spin_lock(&bitmap_lock);
+  clear_bit(*idx);
+  bpf_spin_unlock(&bitmap_lock);
+
+  return 0;
+}
+
+/* The following handle monotonic time and thread run time */
+#if __x86_64__
+extern const struct cyc2ns cyc2ns __ksym;
+#endif
+
+static int __always_inline bperf_update_thread_time(struct bperf_thread_data *data, __u64 now)
+{
+#if __x86_64__
+  struct cyc2ns *c;
+  int seq, idx, i;
+
+  /* Get tsc parameters, the logic is from kernel code:
+   *
+   *   arch/x86/kernel/tsc.c __cyc2ns_read
+   */
+  c = bpf_this_cpu_ptr(&cyc2ns);
+
+  /* TODO: Consider adding some warning when i hit 10,
+   * which shouldn't really happen
+   */
+  for (i = 0; i < 10; i++) {
+    struct cyc2ns_data *cd;
+
+    seq = c->seq.seqcount.sequence;
+    idx = seq & 1;
+
+    cd = bpf_core_cast(&c->data[idx], struct cyc2ns_data);
+    data->tsc_param.offset = cd->cyc2ns_offset;
+    data->tsc_param.multi = cd->cyc2ns_mul;
+    data->tsc_param.shift = cd->cyc2ns_shift;
+
+    if (seq == c->seq.seqcount.sequence)
+      break;
+  }
+
+#elif __aarch64__
+  /* TODO add arm64 support */
+#endif
+
+  data->schedin_time = now;
+}
+
+static void __always_inline update_prev_task(struct task_struct *prev, __u64 now) {
+  struct bperf_thread_data *data;
+  int pid = prev->pid;
+  int *idx;
+
+  idx = bpf_map_lookup_elem(&per_thread_idx, &pid);
+  if (!idx)
+    return;
+
+  data = bpf_map_lookup_elem(&per_thread_data, idx);
+  if (!data)
+    return;
+
+  data->runtime_until_schedin += now - data->schedin_time;
+}
+
+static void __always_inline update_next_task(struct task_struct *next, __u64 now) {
+  struct bperf_thread_data *data;
+  int pid = next->pid;
+  int *idx;
+
+  idx = bpf_map_lookup_elem(&per_thread_idx, &pid);
+  if (!idx)
+    return;
+
+  data = bpf_map_lookup_elem(&per_thread_data, idx);
+  if (!data)
+    return;
+
+  data->lock += 1;
+  bperf_update_thread_time(data, now);
+}
+
+SEC("tp_btf/sched_switch")
+int BPF_PROG(bperf_update_thread, bool preempt, struct task_struct *prev,
+             struct task_struct *next) {
+  __u64 now = bpf_ktime_get_ns();
+  update_prev_task(prev, now);
+  update_next_task(next, now);
+  return 0;
 }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Summary:
This is most of the non-perf_event part of the bperf per thread
monitoring:

1. Mechanism to share data between lead (e.g. dynolog) and per thread
   users (e.g. services). This is done via two pinned bpf map.
2. An extendable data format (struct bperf_thread_data) between lead
   and users. This is designed to provide some compatibility between
   dynolog and services with different versions of bperf.
3. Cumulative CPU time (cpuTime) and MONOTONIC clock (monoTime), for
   x86_64. Both of these require proper handling off TSC (or equivalent
   on arm64).
4. Basic userspace library BPerfPerThreadReader.

The code is designed to share with regular bperf. If the flag
support_per_thread is not set in the constructor, some maps in the
BPF skeleton will be loaded initially, but freed soon. This is achieved
by holding extra fd on the maps and programs in use, and destroying the
initial skeleton.

Differential Revision: D61421284
