### PR TITLE
remove name from BPerfEventsGroup

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -59,12 +59,9 @@ static inline __u32 bpf_prog_get_id(int fd) {
 
 /// name: Path of ebpf map
 BPerfEventsGroup::BPerfEventsGroup(
-    const std::string& name,
     const EventConfs& confs,
     int cgroup_update_level)
-    : name_(name), confs_(confs), cgroup_update_level_(cgroup_update_level) {
-  HBT_ARG_CHECK_LE(name.length(), BPERF_METRIC_NAME_SIZE)
-      << "bpf map name is too long, max size is " << BPERF_METRIC_NAME_SIZE;
+    : confs_(confs), cgroup_update_level_(cgroup_update_level) {
   for (const auto& conf : confs_) {
     struct perf_event_attr attr = {
         .size = sizeof(attr),
@@ -80,12 +77,10 @@ BPerfEventsGroup::BPerfEventsGroup(
 }
 
 BPerfEventsGroup::BPerfEventsGroup(
-    const std::string& name,
     const MetricDesc& metric,
     const PmuDeviceManager& pmu_manager,
     int cgroup_update_level)
     : BPerfEventsGroup(
-          name,
           metric.makeNoCpuTopologyConfs(pmu_manager),
           cgroup_update_level) {}
 inline ino_t mapFdWrapperPtrIntoInode(

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -19,20 +19,6 @@ struct bperf_leader_cgroup;
 
 namespace facebook::hbt::perf_event {
 
-#define BPERF_METRIC_NAME_SIZE 16
-
-// This is the data we stored in a pinned BPF map
-//   /sys/fs/bpf/bperf_attr_map_vXXX
-// where XXX is the version number ATTR_MAP_VERSION.
-//
-// This map doesn't hold reference on any of these programs or maps.
-struct bperf_attr_map_key {
-  __u32 size;
-  __u32 flags = 0;
-  char name[BPERF_METRIC_NAME_SIZE];
-  bperf_attr_map_key(std::string n, int s);
-};
-
 struct bperf_attr_map_elem {
   __u32 perf_event_array_id;
   __u32 leader_prog_link_id;
@@ -52,14 +38,9 @@ class BPerfEventsGroup {
  public:
   using ReadValues = GroupReadValues<mode::Counting>;
   ///
-  ///  - name: Name for eBPF maps.
   ///  - confs: Event Confs for group.
+  BPerfEventsGroup(const EventConfs& confs, int cgroup_update_level);
   BPerfEventsGroup(
-      const std::string& name,
-      const EventConfs& confs,
-      int cgroup_update_level);
-  BPerfEventsGroup(
-      const std::string& name,
       const MetricDesc& metric,
       const PmuDeviceManager& pmu_manager,
       int cgroup_update_level);
@@ -87,7 +68,6 @@ class BPerfEventsGroup {
   bool readCgroup(ReadValues& rv, __u64 id);
 
  protected:
-  const std::string name_;
   const EventConfs confs_;
 
   // set of cgrup inodes that the BPerfEventsGroup is monitoring

--- a/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
@@ -42,7 +42,7 @@ TEST(BPerfEventsGroupTest, RunSystemWide) {
   auto ev_conf =
       pmu->makeConf(ev_def->id, EventExtraAttr(), EventValueTransforms());
 
-  auto system = BPerfEventsGroup("cycles", EventConfs({ev_conf}), 0);
+  auto system = BPerfEventsGroup(EventConfs({ev_conf}), 0);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE];
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
   if (!system.open() || !system.enable()) {
@@ -70,8 +70,7 @@ TEST(BPerfEventsGroupTest, RunCgroup) {
   auto instructions_conf = pmu->makeConf(
       instructions_def->id, EventExtraAttr(), EventValueTransforms());
   auto cgrpFdPtr = std::make_shared<FdWrapper>("/sys/fs/cgroup/system.slice/");
-  auto cgrp =
-      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 1);
+  auto cgrp = BPerfEventsGroup(EventConfs({cycles_conf, instructions_conf}), 1);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE];
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
 
@@ -130,7 +129,7 @@ TEST(BPerfEventsGroupTest, MetricConstructor) {
       std::vector<std::string>{} // No post-processing dives
   );
 
-  auto eg = BPerfEventsGroup("ipc", *m, *pmu_manager, 0);
+  auto eg = BPerfEventsGroup(*m, *pmu_manager, 0);
   if (!eg.open() || !eg.enable()) {
     GTEST_SKIP() << "Skip RunSystemWide test, do we have CAP_PERFMON?";
   }
@@ -157,8 +156,7 @@ TEST(BPerfEventsGroupTest, EnableDisable) {
       pmu->makeConf(cycles_def->id, EventExtraAttr(), EventValueTransforms());
   auto instructions_conf = pmu->makeConf(
       instructions_def->id, EventExtraAttr(), EventValueTransforms());
-  auto eg =
-      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 0);
+  auto eg = BPerfEventsGroup(EventConfs({cycles_conf, instructions_conf}), 0);
   struct bpf_perf_event_value val[BPERF_MAX_GROUP_SIZE] = {};
   struct bpf_perf_event_value prev[BPERF_MAX_GROUP_SIZE] = {};
 
@@ -192,8 +190,7 @@ TEST(BPerfEventsGroupTest, cgroup_update_level) {
   auto instructions_conf = pmu->makeConf(
       instructions_def->id, EventExtraAttr(), EventValueTransforms());
   auto cgrpFdPtr = std::make_shared<FdWrapper>("/sys/fs/cgroup/system.slice/");
-  auto cgrp =
-      BPerfEventsGroup("ipc", EventConfs({cycles_conf, instructions_conf}), 2);
+  auto cgrp = BPerfEventsGroup(EventConfs({cycles_conf, instructions_conf}), 2);
 
   if (!cgrp.open() || !cgrp.enable()) {
     GTEST_SKIP() << "Skip RunCgroup test, do we have CAP_PERFMON?";

--- a/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
+++ b/hbt/src/perf_event/tests/PerCpuGeneratorsTest.cpp
@@ -285,8 +285,7 @@ TEST(BPerfCountReader, SmokeTest) {
   // User's slice.
   auto cgroup_path = "/sys/fs/cgroup/user.slice";
 
-  auto eg =
-      std::make_shared<BPerfEventsGroup>("myperfunittest", *m, *pmu_manager, 1);
+  auto eg = std::make_shared<BPerfEventsGroup>(*m, *pmu_manager, 1);
   if (!eg->open() || !eg->enable()) {
     GTEST_SKIP()
         << "Failed to open global perf events. Something is wrong with BPerfEventsGroup"


### PR DESCRIPTION
Summary:
attr map has been completely deprecated now, name is useless.

remove field name_ from BPerfEventsGroup

Reviewed By: liu-song-6

Differential Revision: D61498946
