### PR TITLE
Fix Core Counter Accounting 2.0

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -113,6 +113,7 @@ class Monitor {
     return toState_(State::Open);
   }
 
+  // Return a null optional if the element is not found.
   std::optional<bool> isMetricEnabled(const ElemId& elem_id) {
     if (cpu_count_readers_.contains(elem_id)) {
       return cpu_count_readers_.at(elem_id)->isEnabled();


### PR DESCRIPTION
Summary: D57904550 attempted to fix PerfCounterManagerHbt's core counter accounting, but fails to do so. This [check](https://www.internalfb.com/code/fbsource/[6aa310e0372997181b5ced0b7e9fcd7b746f24a5]/fbcode/dyno/cpp/server/PerfCounterManagerHbtBase.cpp?lines=222) always returns true because isMetricEnabled() returns an optional. All this does is check if the metric is contained in the monitor.

Differential Revision: D61372884
