### PR TITLE
hbt/bperf: Enable some backward/forward compatibility

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -145,5 +145,6 @@ class BPerfEventsGroup {
   ::bpf_link* register_thread_link_ = nullptr;
   ::bpf_link* unregister_thread_link_ = nullptr;
   ::bpf_link* update_thread_link_ = nullptr;
+  int per_thread_data_size_ = 0;
 };
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -30,11 +30,18 @@ class BPerfPerThreadReader {
  protected:
   void* mmap_ptr_ = nullptr;
   struct bperf_thread_data* data_ = nullptr;
+  // For compatibility (newer leader with older reader), we cannot use
+  // data_->events directly. Instead use event_data_ which is adjusted
+  // based on leader data structure.
+  struct bperf_perf_event_data* event_data_[BPERF_MAX_GROUP_SIZE] = {nullptr};
   int data_fd_ = -1;
   const std::string pin_name_;
   __s64 initial_clock_drift_ = 0;
   int event_cnt_;
-  int mmap_size_;
+  int data_size_ = 0;
+  int mmap_size_ = 0;
+
+  int getDataSize_();
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -32,6 +32,14 @@ struct bperf_clock_param {
 /* data of a single perf_event */
 struct bperf_perf_event_data {};
 
+struct bperf_thread_metadata {
+  __u32 metadata_size; /* sizeof(bperf_thread_metadata) */
+  __u32 thread_data_size; /* sizeof(bperf_thread_data) */
+  __u32 event_data_size; /* sizeof(bperf_perf_event_data) */
+  __u32 event_cnt;
+  __u32 flags;
+};
+
 /* BPerfEventsGroup may have variable number of perf events.
  * Therefore, the bperf_thread_data used for each thread may
  * change. To show the data, we use fixed size header for per
@@ -39,16 +47,11 @@ struct bperf_perf_event_data {};
  * per event data (bperf_perf_event_data).
  */
 struct bperf_thread_data {
-  __u32 header_size; /* sizeof(bperf_thread_data) */
-  __u32 event_data_size; /* sizeof(bperf_perf_event_data) */
-  __u32 event_cnt;
-  __u32 flags;
-
   __u32 lock;
+  __u32 __reserved;
   struct bperf_clock_param tsc_param;
 
   /* all the times are in nano seconds */
-
   /* when the task got sched in the last time */
   __u64 schedin_time;
 
@@ -56,6 +59,10 @@ struct bperf_thread_data {
   __u64 runtime_until_schedin;
 
   struct bperf_perf_event_data events[];
-} __attribute__((packed));
+};
+
+inline int bperf_roundup(int size, int align) {
+  return (size + align - 1) / align * align;
+}
 
 #endif

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -234,10 +234,6 @@ int BPF_PROG(bperf_register_thread, struct bpf_map *map) {
   if (!data)
     return 0;
 
-  data->header_size = sizeof(struct bperf_thread_data);
-  data->event_data_size = sizeof(struct bperf_perf_event_data);
-  data->event_cnt = event_cnt;
-  data->flags = 0;
   data->lock = 1;
 
   tid = bpf_get_current_pid_tgid() & 0xffffffff;


### PR DESCRIPTION
Summary:
First, calculate the data size and mmap size properly. Then allow older
reader to properly read data from newer leader (dynolog).

Differential Revision: D61705569
