### PR TITLE
hbt/bperf: Track perf event for per thread monitoring

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -459,6 +459,40 @@ inline TimeStamp rdtsc() {
 #endif
 }
 
+inline uint64_t rdpmc(int idx) {
+  uint64_t val;
+
+#if defined(__x86_64__)
+  val = __rdpmc(idx);
+#elif defined(__aarch64__)
+  /* TODO: Test and verify this */
+  switch (idx) {
+    case 0:
+      __asm__ volatile("mrs %0, pmevcntr0_el0" : "=r"(val));
+      break;
+    case 1:
+      __asm__ volatile("mrs %0, pmevcntr1_el0" : "=r"(val));
+      break;
+    case 2:
+      __asm__ volatile("mrs %0, pmevcntr2_el0" : "=r"(val));
+      break;
+    case 3:
+      __asm__ volatile("mrs %0, pmevcntr3_el0" : "=r"(val));
+      break;
+    case 4:
+      __asm__ volatile("mrs %0, pmevcntr4_el0" : "=r"(val));
+      break;
+    case 5:
+      __asm__ volatile("mrs %0, pmevcntr5_el0" : "=r"(val));
+      break;
+    default:
+      val = 0ULL;
+      break;
+  }
+#endif
+  return val;
+}
+
 #if defined(__i386__) || defined(__x86_64__)
 // Store CPU ID in <cpu> variable.
 inline TimeStamp rdtscp(CpuId& cpu) {

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -141,10 +141,12 @@ class BPerfEventsGroup {
 
   int pinThreadMaps_(bperf_leader_cgroup* skel);
   int preparePerThreadBPerf_(bperf_leader_cgroup* skel);
+  int lookupPerfEvent_(struct bperf_leader_cgroup* skel);
 
   ::bpf_link* register_thread_link_ = nullptr;
   ::bpf_link* unregister_thread_link_ = nullptr;
   ::bpf_link* update_thread_link_ = nullptr;
   int per_thread_data_size_ = 0;
+  ::bpf_link* pmu_enable_exit_link_ = nullptr;
 };
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <bpf/libbpf.h>
+
 #include "hbt/src/perf_event/Metrics.h"
 #include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/perf_event/PmuDevices.h"
@@ -16,7 +18,7 @@ namespace facebook::hbt::perf_event {
 struct BPerfThreadData {
   __u64 cpuTime;
   __u64 monoTime;
-  __u64 counters[BPERF_MAX_GROUP_SIZE];
+  struct bpf_perf_event_value values[BPERF_MAX_GROUP_SIZE];
 };
 
 class BPerfPerThreadReader {
@@ -37,11 +39,12 @@ class BPerfPerThreadReader {
   int data_fd_ = -1;
   const std::string pin_name_;
   __s64 initial_clock_drift_ = 0;
-  int event_cnt_;
+  int event_cnt_ = -1;
   int data_size_ = 0;
   int mmap_size_ = 0;
-
   int getDataSize_();
+  int dummy_pe_fd_ = -1;
+  void* dummy_pe_mmap_ = nullptr;
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -30,7 +30,11 @@ struct bperf_clock_param {
 };
 
 /* data of a single perf_event */
-struct bperf_perf_event_data {};
+struct bperf_perf_event_data {
+  struct bpf_perf_event_value output_value;
+  __u64 offset;
+  __u32 idx;
+};
 
 struct bperf_thread_metadata {
   __u32 metadata_size; /* sizeof(bperf_thread_metadata) */


### PR DESCRIPTION
Summary:
Use a per cpu array to save perf_event information: the pointer and the
hardware idx used by rdpmc(). This map is initially populated by a
task_file iterator. Then fexit program bperf_pmu_enable_exit keeps the
idx value up to date.

The user space library uses rdpmc and data from the bpf maps to calculate
the event counter value.

TODO: handle perf event multiplexing, i.e. time_enabled != time_running.

Differential Revision: D61815801
