### PR TITLE
bperf: Fix veristat error

### DIFF
--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -159,11 +159,15 @@ struct {
   __uint(max_entries, BPERF_MAX_THREAD_READER);
 } per_thread_idx SEC(".maps");
 
+#define BPERF_MAX_THREAD_DATA_SIZE (sizeof(struct bperf_thread_data) + \
+                                    sizeof(struct bperf_perf_event_data) * BPERF_MAX_GROUP_SIZE)
 struct {
   __uint(type, BPF_MAP_TYPE_ARRAY);
   __uint(key_size, sizeof(int));
-  /* for variable size bperf_thread_data, update value_size before load */
-  __uint(value_size, 1);
+  /* for variable size bperf_thread_data, update value_size before load.
+   * Set the default size to the maximum to make veristat happy.
+   */
+  __uint(value_size, BPERF_MAX_THREAD_DATA_SIZE);
   __uint(max_entries, BPERF_MAX_THREAD_READER);
   __uint(map_flags, BPF_F_MMAPABLE);
 } per_thread_data SEC(".maps");


### PR DESCRIPTION
Summary:
BPF map per_thread_data has variable value size. The default value size
is 1.  This is ok for the actually code, as the userspace will adjust the
value size before loading the skeleton. However, this breaks veristat,
because veristat will load the skeleton without adjustment in user space.

Fix this by increasing the default size to the maximal possible value.

Differential Revision: D61823794
