### PR TITLE
add readGlobalPerCpu interface

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -72,6 +72,12 @@ class BPerfEventsGroup {
   // eBPF like interface to read counters from all CPUs and accumulate them.
   int readGlobal(struct bpf_perf_event_value* output, bool skip_offset = false);
   bool readGlobal(ReadValues& rv, bool skip_offset = false);
+  int readGlobalPerCpu(
+      std::map<
+          int,
+          std::array<struct bpf_perf_event_value, BPERF_MAX_GROUP_SIZE>>&
+          output);
+  bool readGlobalPerCpu(std::map<int, ReadValues>& rv);
 
   int readCgroup(struct bpf_perf_event_value* output, __u64 id);
   bool readCgroup(ReadValues& rv, __u64 id);
@@ -122,11 +128,21 @@ class BPerfEventsGroup {
   //     read(&offset_);
   struct bpf_perf_event_value offsets_[BPERF_MAX_GROUP_SIZE];
 
+  std::vector<struct bpf_perf_event_value> readFromBpf_(int fd, __u64 id);
+
   int read(
       struct bpf_perf_event_value* output,
       int fd,
       __u64 id,
       bool skip_offset = false);
+
+  int readPerCpu(
+      std::map<
+          int,
+          std::array<struct bpf_perf_event_value, BPERF_MAX_GROUP_SIZE>>&
+          output,
+      int fd,
+      __u64 id);
 
   int reloadSkel_(struct bperf_attr_map_elem* entry);
   int loadPerfEvent_(struct bperf_leader_cgroup* skel);

--- a/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupTest.cpp
@@ -55,6 +55,15 @@ TEST(BPerfEventsGroupTest, RunSystemWide) {
     checkReading(val, prev, n);
     ::memcpy(prev, val, sizeof(prev));
   }
+
+  std::map<int, std::array<struct bpf_perf_event_value, BPERF_MAX_GROUP_SIZE>>
+      perCpuValues;
+  auto n = system.readGlobalPerCpu(perCpuValues);
+  EXPECT_GT(n, 0);
+  EXPECT_EQ(perCpuValues.size(), CpuSet::makeAllOnline().numCpus());
+  for (const auto& [cpu, values] : perCpuValues) {
+    EXPECT_GE(values[0].counter, 0);
+  }
 }
 
 TEST(BPerfEventsGroupTest, RunCgroup) {


### PR DESCRIPTION
Summary:
make BPerfEventsGroup be able to report per CPU global value

we will need this for dynolog host-level perf counters reporting

Differential Revision: D61691843
