### PR TITLE
do not enable/disble underlying bperf event in BPerfCountReader

### DIFF
--- a/hbt/src/perf_event/BPerfCountReader.cpp
+++ b/hbt/src/perf_event/BPerfCountReader.cpp
@@ -32,9 +32,10 @@ bool BPerfCountReader::enable() {
       cgroup_tracking_ = true;
     }
     return cgroup_tracking_;
-  } else {
-    return bperf_eg_->enable();
   }
+  // if BPerfCountReader is open for global perf counter, then enable() is a
+  // no-op
+  return false;
 }
 
 bool BPerfCountReader::disable() {
@@ -43,9 +44,10 @@ bool BPerfCountReader::disable() {
       cgroup_tracking_ = false;
     }
     return !cgroup_tracking_;
-  } else {
-    return bperf_eg_->disable();
   }
+  // if BPerfCountReader is open for global perf counter, then disable() is a
+  // no-op
+  return false;
 }
 
 bool BPerfCountReader::read(


### PR DESCRIPTION
Summary:
we will need to create BPerfCountReader upon global bperf event that is always on

so the expected behavior of BPerfCountReader is to just remove itself from the bpf map but do not change the underlying bperf event because some other BPerfCountReader instance may still use that event.

this should not change the behavior of current BPerf usage in TwTaskMonitor as we only create BPerfCountReader in cgroup mode.

Reviewed By: liu-song-6

Differential Revision: D61893592
