### PR TITLE
Add initial support for Zen5 and claritfy Zen3 vs Zen5 CPU family

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -182,6 +182,7 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
     case CpuArch::MILAN:
     case CpuArch::BERGAMO:
     case CpuArch::GENOA:
+    case CpuArch::TURIN:
       milan::addEvents(pmu_manager);
 #ifdef FACEBOOK
       milan::addEventsFb(pmu_manager);

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -476,7 +476,8 @@ std::shared_ptr<PmuDeviceManager> makePmuDeviceManager() {
     populateGenericEventsTracepoint(pmu_manager);
   }
 
-  if (cpu_info.cpu_family == CpuFamily::AMD) {
+  if (cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
     addAmdEvents(cpu_info, *pmu_manager);
   } else if (cpu_info.cpu_family == CpuFamily::INTEL) {
     //
@@ -607,7 +608,9 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
         100'000'000,
         System::Permissions{},
         std::vector<std::string>{}));
-  } else if (cpu_info.cpu_family == CpuFamily::AMD) {
+  } else if (
+      cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
     metrics->add(std::make_shared<MetricDesc>(
         "l2_cache_misses",
         "Core-originated cacheable demand requests missed L2",
@@ -852,6 +855,20 @@ std::shared_ptr<Metrics> makeAvailableMetrics() {
                    EventExtraAttr{},
                    {}}}},
           {CpuArch::GENOA,
+           EventRefs{
+               EventRef{
+                   "flops_scalar",
+                   PmuType::cpu,
+                   "zen3/4::fp_ret_x87_fp_ops.all",
+                   EventExtraAttr{},
+                   {}},
+               EventRef{
+                   "flops_vector",
+                   PmuType::cpu,
+                   "zen4::fp_ret_sse_avx_ops.all",
+                   EventExtraAttr{},
+                   {}}}},
+          {CpuArch::TURIN,
            EventRefs{
                EventRef{
                    "flops_scalar",

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -12,12 +12,14 @@
 
 namespace facebook::hbt::perf_event {
 
-enum class CpuFamily { AMD, INTEL, ARM, UNKNOWN };
+enum class CpuFamily { AMDZEN3, AMDZEN5, INTEL, ARM, UNKNOWN };
 
 inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
   switch (f) {
-    case CpuFamily::AMD:
-      return os << "AMD";
+    case CpuFamily::AMDZEN3:
+      return os << "AMD Zen 3 / Zen 3+ / Zen 4";
+    case CpuFamily::AMDZEN5:
+      return os << "AMD Zen 5";
     case CpuFamily::INTEL:
       return os << "INTEL";
     case CpuFamily::ARM:
@@ -40,8 +42,9 @@ inline CpuFamily makeCpuFamily(
     case 6:
       return CpuFamily::INTEL;
     case 25:
+      return CpuFamily::AMDZEN3;
     case 26:
-      return CpuFamily::AMD;
+      return CpuFamily::AMDZEN5;
     // Not recognized CPU model.
     default:
       return CpuFamily::UNKNOWN;

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -20,6 +20,7 @@ enum class CpuArch {
   MILAN,
   GENOA,
   BERGAMO,
+  TURIN,
   // Intel Architectures Sorted by model id.
   BDW,
   BDW_DE,
@@ -58,6 +59,8 @@ inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
       return os << "GENOA";
     case CpuArch::BERGAMO:
       return os << "BERGAMO";
+    case CpuArch::TURIN:
+      return os << "TURIN";
     case CpuArch::BDW:
       return os << "BDW";
     case CpuArch::BDW_DE:
@@ -104,7 +107,7 @@ inline CpuArch makeCpuArchX86(
     uint32_t cpu_model_num,
     uint32_t cpu_step_num) {
   auto cpu_family = makeCpuFamily(cpu_family_num);
-  if (cpu_family == CpuFamily::AMD) {
+  if (cpu_family == CpuFamily::AMDZEN3) {
     switch (cpu_model_num) {
       case 1:
         return CpuArch::MILAN;
@@ -112,6 +115,11 @@ inline CpuArch makeCpuArchX86(
         return CpuArch::GENOA;
       case 160:
         return CpuArch::BERGAMO;
+    }
+  } else if (cpu_family == CpuFamily::AMDZEN5) {
+    switch (cpu_model_num) {
+      case 17:
+        return CpuArch::TURIN;
     }
   } else if (cpu_family == CpuFamily::INTEL) {
     switch (cpu_model_num) {


### PR DESCRIPTION
Summary:
This diff includes changes in hbt to support adding Zen5 CPUs.

`CpuFamily::AMD` has been renamed `CpuFamily::AMDZEN3` and adds `CpuFamily::AMDZEN5`, since AMD changes families more often than Intel.

Differential Revision: D62447334
