### PR TITLE
hbt/bperf: Enforce one BPerfPerThreadReader per thread

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -57,6 +57,12 @@ int BPerfPerThreadReader::enable() {
     goto error;
   }
 
+  tid = gettid();
+  if (::bpf_map_lookup_elem(idx_fd, &tid, &idx) == 0) {
+    HBT_LOG_ERROR() << "cannot register the same thread twice";
+    goto error;
+  }
+
   mmap_ptr_ = mmap(nullptr, mmap_size_, PROT_READ, MAP_SHARED, data_fd_, 0);
 
   if (mmap_ptr_ == MAP_FAILED) {
@@ -64,7 +70,6 @@ int BPerfPerThreadReader::enable() {
     goto error;
   }
 
-  tid = gettid();
   err = ::bpf_map_lookup_elem(idx_fd, &tid, &idx);
 
   if (err != 0) {

--- a/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
@@ -19,8 +19,11 @@ namespace {
 
 std::shared_ptr<BPerfPerThreadReader> createReader(void) {
   auto reader = std::make_shared<BPerfPerThreadReader>("cycles", 1);
+  auto second_reader = std::make_shared<BPerfPerThreadReader>("cycles", 1);
 
   EXPECT_EQ(reader->enable(), 0);
+  // second_read will fail to enable
+  EXPECT_EQ(second_reader->enable(), -1);
   return reader;
 }
 

--- a/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <unistd.h>
+#include <chrono>
 #include <thread>
 
 using namespace facebook::hbt;
@@ -47,6 +48,7 @@ volatile __u64 __work = 0;
 static void doSomeWork(long count) {
   long i;
 
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   for (i = 0; i < count; i++) {
     __work += i * count;
   }
@@ -55,7 +57,7 @@ static void doSomeWork(long count) {
 __u64 normalizedValue(const struct bpf_perf_event_value& value) {
   if (value.running == 0)
     return 0;
-  return (__u64)((float)value.counter * value.enabled / value.running);
+  return (__u64)((double)value.counter * value.enabled / value.running);
 }
 
 #define TESTS 4


### PR DESCRIPTION
Summary:
BPerfPerThreadReader uses tid as key, therefore, we cannot handle more
than one BPerfPerThreadReader (for the same leader BPerfEventGroup) per
thread. Add logic to fail the second reader.

Differential Revision: D63661038
