### PR TITLE
hbt/bperf: Rename schedin_time as schedule_time

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -183,7 +183,7 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
 
   data->monoTime = (((__uint128_t)tsc * p.multi) >> p.shift) + p.offset +
       initial_clock_drift_;
-  time_after_sched_in = data->monoTime - raw_thread_data.schedin_time;
+  time_after_sched_in = data->monoTime - raw_thread_data.schedule_time;
   data->cpuTime = raw_thread_data.runtime_until_schedin + time_after_sched_in;
 
   // TODO: Detect when the lead program stops. It is a bit tricky, as

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -56,8 +56,8 @@ struct bperf_thread_data {
   struct bperf_clock_param tsc_param;
 
   /* all the times are in nano seconds */
-  /* when the task got sched in the last time */
-  __u64 schedin_time;
+  /* when the task got scheduled the last time */
+  __u64 schedule_time;
 
   /* runtime = runtime_until_schedin + tsc_time - schedin_time; */
   __u64 runtime_until_schedin;

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -338,15 +338,15 @@ static void __always_inline update_prev_task(struct task_struct *prev, __u64 now
   if (!data)
     return;
 
-  data->runtime_until_schedin += now - data->schedin_time;
+  data->runtime_until_schedin += now - data->schedule_time;
   /* We may call update_prev_task twice on the same context switch:
    * 1. From bperf_update_thread();
    * 2. From bperf_pmu_enable_exit().
    *
-   * Update schedin_time here so that we do not account
+   * Update schedule_time here so that we do not account
    * runtime_until_schedin twice.
    */
-  data->schedin_time = now;
+  data->schedule_time = now;
 
   diff_val = bpf_map_lookup_elem(&diff_readings, &zero);
   if (!diff_val)
@@ -402,7 +402,7 @@ static void __always_inline update_next_task(struct task_struct *next, __u64 now
 
   data->lock += 1;
   bperf_update_thread_time(data);
-  data->schedin_time = now;
+  data->schedule_time = now;
 
   prev_val = bpf_map_lookup_elem(&prev_readings, &zero);
   if (!prev_val)


### PR DESCRIPTION
Summary:
We update time in both sched in and sched out, so rename the variable to
avoid confusion. No functional changes.

Reviewed By: Alston-Tang

Differential Revision: D64068948


