### PR TITLE
dynolog/tests/rpc/SimpleJsonClientTest.cpp: json-extraction requires different getter

### DIFF
--- a/dynolog/tests/rpc/SimpleJsonClientTest.cpp
+++ b/dynolog/tests/rpc/SimpleJsonClientTest.cpp
@@ -207,8 +207,8 @@ TEST_F(SimpleJsonClientTest, DISABLED_SetKinetoOnDemandRequestTest) {
   ASSERT_TRUE(resp_str) << "Null response on setKinetOnDemandRequest()";
   EXPECT_EQ(handler_->setKinetoOnDemandCalls_, 1);
 
-  EXPECT_EQ(handler_->config_, request["config"]);
-  EXPECT_EQ(handler_->pids_, request["pids"]);
+  EXPECT_EQ(request["config"], handler_->config_);
+  EXPECT_EQ(request["pids"], handler_->pids_);
   EXPECT_EQ(handler_->job_id_, 10);
   EXPECT_EQ(handler_->limit_, 42);
 


### PR DESCRIPTION
Summary:
This avoids the following errors:
```
In file included from fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:9:
fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:1379:11: error: invalid operands to binary expression ('const std::basic_string<char>' and 'const nlohmann::basic_json<>')
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: error: invalid operands to binary expression ('const std::basic_string<char>' and 'const nlohmann::basic_json<>')
 1379 |   if (lhs == rhs) {
      |       ~~~ ^  ~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1398:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<std::basic_string<char>, nlohmann::basic_json<>>' requested here
 1398 |     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
      |            ^
fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:210:3: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<std::basic_string<char>, nlohmann::basic_json<>, nullptr>' requested here
  210 |   EXPECT_EQ(handler_->config_, request["config"]);
      |   ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1869:54: note: expanded from macro 'EXPECT_EQ'
 1869 |   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
      |                                                      ^
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const allocator<char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const allocator<unsigned char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:344:3: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const error_code' for 1st argument
  344 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:351:3: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const error_code' for 1st argument
  351 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: note: remaining 76 candidates omitted; pass -fshow-overloads=all to show them
 1379 |   if (lhs == rhs) {
      |           ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: error: invalid operands to binary expression ('const std::set<int>' and 'const nlohmann::basic_json<>')
 1379 |   if (lhs == rhs) {
      |       ~~~ ^  ~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1398:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<std::set<int>, nlohmann::basic_json<>>' requested here
 1398 |     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
      |            ^
fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:211:3: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<std::set<int>, nlohmann::basic_json<>, nullptr>' requested here
  211 |   EXPECT_EQ(handler_->pids_, request["pids"]);
      |   ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1869:54: note: expanded from macro 'EXPECT_EQ'
 1869 |   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
      |                                                      ^
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<int>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<unsigned char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:344:3: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const error_code' for 1st argument
  344 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: note: remaining 79 candidates omitted; pass -fshow-overloads=all to show them
 1379 |   if (lhs == rhs) {
      |           ^
2 errors generated.

[2024-10-08T15:53:07.213-07:00] Cache hits: 0%
[2024-10-08T15:53:07.213-07:00] Commands: 1 (cached: 0, remote: 0, local: 1)
[2024-10-08T15:53:07.213-07:00] Network: Up: 1.2KiB  Down: 2.7KiB  (reSessionID-6bbffebc-2bba-46ac-9819-2103be38c001)
[2024-10-08T15:53:07.218-07:00]
[2024-10-08T15:53:07.218-07:00] BUILD ERRORS (1)
[2024-10-08T15:53:07.218-07:00] The following actions failed during the execution of this command:
[2024-10-08T15:53:07.219-07:00] Action failed: fbcode//dynolog/tests/rpc:SimpleJsonClientTest (cfg:linux-x86_64-fbcode-platform010-clang17-asan-ubsan-dev#a2196b42e020abdc) (cxx_compile SimpleJsonClientTest.cpp (pic))
[2024-10-08T15:53:07.219-07:00] Local command returned non-zero exit code 1
[2024-10-08T15:53:07.219-07:00] Local command: env -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/fbcode/3e680eeab58932cf/cxx_compile/_buck_736804d712b05bd5' /usr/bin/env 'PYTHONPATH=buck-out/v2/gen/prelude/08961b14cfb182aa/cxx/tools/__dep_file_processor__/__dep_file_processor__' /usr/local/fbcode/platform010/bin/python3.12 buck-out/v2/gen/prelude/08961b14cfb182aa/cxx/tools/__dep_file_processor__/dep_file_processor.py makefile buck-out/v2/gen/fbcode/a2196b42e020abdc/dynolog/tests/rpc/__SimpleJsonClientTest__/__dep_files_intermediaries__/SimpleJsonClientTest.cpp.pic buck-out/v2/gen/fbcode/a2196b42e020abdc/dynolog/tests/rpc/__SimpleJsonClientTest__/__dep_files__/SimpleJsonClientTest.cpp.pic buck-out/v2/gen/fbcode/08961b14cfb182aa/tools/build/buck/wrappers/__fbcc__/fbcc '--cc=fbcode/third-party-buck/platform010/build/llvm-fb/17/bin/clang++' '--target=x86_64-redhat-linux-gnu' -nostdinc -nostdinc++ -resource-dir fbcode/third-party-buck/platform010/build/llvm-fb/17/lib/clang/stable -idirafter fbcode/third-party-buck/platform010/build/llvm-fb/17/lib/clang/stable/include -idirafter fbcode/third-party-buck/platform010/build/glibc/include -idirafter fbcode/third-party-buck/platform010/build/kernel-headers/include -Bfbcode/third-party-buck/platform010/build/binutils/x86_64-facebook-linux/bin -o buck-out/v2/gen/fbcode/a2196b42e020abdc/dynolog/tests/rpc/__SimpleJsonClientTest__/__objects__/SimpleJsonClientTest.cpp.pic.o -fPIC buck-out/v2/gen/fbcode/a2196b42e020abdc/dynolog/tests/rpc/__SimpleJsonClientTest__/.cpp.cxx_compile_argsfile -c fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp -MD -MF buck-out/v2/gen/fbcode/a2196b42e020abdc/dynolog/tests/rpc/__SimpleJsonClientTest__/__dep_files_intermediaries__/SimpleJsonClientTest.cpp.pic
[2024-10-08T15:53:07.219-07:00] Stdout: <empty>
[2024-10-08T15:53:07.219-07:00] Stderr:
In file included from fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:9:
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: error: invalid operands to binary expression ('const std::basic_string<char>' and 'const nlohmann::basic_json<>')
 1379 |   if (lhs == rhs) {
      |       ~~~ ^  ~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1398:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<std::basic_string<char>, nlohmann::basic_json<>>' requested here
 1398 |     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
      |            ^
fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:210:3: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<std::basic_string<char>, nlohmann::basic_json<>, nullptr>' requested here
  210 |   EXPECT_EQ(handler_->config_, request["config"]);
      |   ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1869:54: note: expanded from macro 'EXPECT_EQ'
 1869 |   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
      |                                                      ^
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const allocator<char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const allocator<unsigned char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:344:3: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const error_code' for 1st argument
  344 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:351:3: note: candidate function not viable: no known conversion from 'const std::basic_string<char>' to 'const error_code' for 1st argument
  351 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: note: remaining 76 candidates omitted; pass -fshow-overloads=all to show them
 1379 |   if (lhs == rhs) {
      |           ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: error: invalid operands to binary expression ('const std::set<int>' and 'const nlohmann::basic_json<>')
 1379 |   if (lhs == rhs) {
      |       ~~~ ^  ~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1398:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<std::set<int>, nlohmann::basic_json<>>' requested here
 1398 |     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
      |            ^
fbcode/dynolog/tests/rpc/SimpleJsonClientTest.cpp:211:3: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<std::set<int>, nlohmann::basic_json<>, nullptr>' requested here
  211 |   EXPECT_EQ(handler_->pids_, request["pids"]);
      |   ^
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1869:54: note: expanded from macro 'EXPECT_EQ'
 1869 |   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
      |                                                      ^
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<int>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/allocator.h:216:7: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const allocator<unsigned char>' for 1st argument
  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/system_error:344:3: note: candidate function not viable: no known conversion from 'const std::set<int>' to 'const error_code' for 1st argument
  344 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
buck-out/v2/gen/fbsource/a2196b42e020abdc/third-party/googletest/1.14.0/__gtest_headers__/buck-headers/gtest/gtest.h:1379:11: note: remaining 79 candidates omitted; pass -fshow-overloads=all to show them
 1379 |   if (lhs == rhs) {
      |           ^
```

Differential Revision: D64076139


