### PR TITLE
Add merge and reserve function to MetricValue

### DIFF
--- a/dynolog/src/metric_frame/MetricValues.h
+++ b/dynolog/src/metric_frame/MetricValues.h
@@ -43,6 +43,10 @@ class MetricValues final {
     return *(begin() + idx);
   }
 
+  void reserve(const size_t size) {
+    data_.reserve(size);
+  }
+
   void resize(const size_t size) {
     data_.resize(size);
   }
@@ -75,6 +79,11 @@ class MetricValues final {
     }
     const auto [min_it, max_it] = std::minmax_element(begin(), end());
     return std::make_pair(*min_it, *max_it);
+  }
+
+  void merge(const MetricValues<T>& other) {
+    data_.reserve(data_.size() + other.data_.size());
+    data_.insert(data_.end(), other.data_.begin(), other.data_.end());
   }
 
  private:

--- a/dynolog/tests/metric_frame/MetricValuesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricValuesTest.cpp
@@ -58,3 +58,22 @@ TEST(MetricValuesTest, aggTest) {
   EXPECT_TRUE(p50Maybe);
   EXPECT_EQ(p50Maybe.value(), 2.0);
 }
+
+TEST(MetricValuesTest, mergeTest) {
+  MetricValues<uint32_t> u, v;
+  for (int i = 0; i < 5; i++) {
+    u.push_back(i);
+  }
+  for (int i = 0; i < 5; i++) {
+    v.push_back(i);
+  }
+  EXPECT_EQ(u.size(), 5);
+
+  u.merge(v);
+  EXPECT_EQ(u.size(), 10);
+  EXPECT_EQ(u.sum(), 20);
+
+  auto avgMaybe = u.avg();
+  EXPECT_TRUE(avgMaybe);
+  EXPECT_EQ(avgMaybe.value(), 2.0);
+}


### PR DESCRIPTION
Summary: Add merge and reserve function to MetricValue. Merge allow concatenation of other MetricValues.

Differential Revision: D64163319


