### PR TITLE
hbt/bperf: Let per thread reader handle lead exit event.

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -194,14 +194,16 @@ void BPerfEventsGroup::close() {
   cgroup_output_fd_ = -1;
   ::close(global_output_fd_);
   global_output_fd_ = -1;
-  ::bpf_link__destroy(register_thread_link_);
-  register_thread_link_ = nullptr;
-  ::bpf_link__destroy(unregister_thread_link_);
-  unregister_thread_link_ = nullptr;
   for (auto& fd : pe_fds_) {
     ::close(fd);
     fd = -1;
   }
+  // Close the perf event fds before destroying the links for per thread
+  // monitoring. This will help the reader detect the lead has exited.
+  ::bpf_link__destroy(register_thread_link_);
+  register_thread_link_ = nullptr;
+  ::bpf_link__destroy(unregister_thread_link_);
+  unregister_thread_link_ = nullptr;
   ::bpf_link__destroy(pmu_enable_exit_link_);
   pmu_enable_exit_link_ = nullptr;
   opened_ = false;

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -28,6 +28,9 @@ class BPerfPerThreadReader {
   int read(struct BPerfThreadData* data);
   int enable();
   void disable();
+  bool isEnabled() {
+    return enabled_;
+  }
 
  protected:
   void* mmap_ptr_ = nullptr;
@@ -45,6 +48,10 @@ class BPerfPerThreadReader {
   int getDataSize_();
   int dummy_pe_fd_ = -1;
   void* dummy_pe_mmap_ = nullptr;
+  bool enabled_ = false;
+  // Previous reading of event 0, used to detect when the lead exits
+  __u64 prev_counter_zero_;
+  bool leadExited(__u64 counter_zero);
 };
 
 } // namespace facebook::hbt::perf_event


### PR DESCRIPTION
Summary:
When the leader process exits, the per thread readers will not be able to
read data. This is by design. The readers need to detect such event and
renable the reader after the leader process comes back.

An enabled_ flag is added to the reader. We need a heuristic algorithm to
detect when the leader exits. Currently, the algorithm is simple: if we
read same value for the first hardware counter twice, the leader is most
likely gone. We may need to revisit this later.

A unit test is added to cover this. We also need to adjust close()
function of BPerfEventsGroup to make it easier for the reader to detect
leader exit events.

Differential Revision: D64486001


