### PR TITLE
hbt/bperf: Disable autoload for per thread programs, when not in use

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -319,6 +319,13 @@ void bperf_attr_map_elem::loadFromSkelLink(
   skel->rodata->event_cnt = event_cnt;
   skel->bss->cgroup_update_level = cgroup_update_level_;
 
+  if (!per_thread_) {
+    bpf_program__set_autoload(skel->progs.bperf_register_thread, false);
+    bpf_program__set_autoload(skel->progs.bperf_unregister_thread, false);
+    bpf_program__set_autoload(skel->progs.bperf_update_thread, false);
+    bpf_program__set_autoload(skel->progs.bperf_pmu_enable_exit, false);
+    bpf_program__set_autoload(skel->progs.find_perf_events, false);
+  }
   if (err = bperf_leader_cgroup__load(skel); err) {
     HBT_LOG_ERROR() << "Failed to load skeleton.";
     return err;


### PR DESCRIPTION
Summary:
BPerf programs for per thread monitoring do not load on 5.12 kernels. This
also cause the main program fail to load. Disable autoload for these
programs when per thread monitoring is not enabled. This makes sure the
main program can load properly.

Reviewed By: Alston-Tang

Differential Revision: D64629900


