### PR TITLE
facebook-unused-include-check in fbcode/dynolog

### DIFF
--- a/dynolog/src/KernelCollector.cpp
+++ b/dynolog/src/KernelCollector.cpp
@@ -5,10 +5,7 @@
 
 #include "dynolog/src/KernelCollector.h"
 #include <fmt/format.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/prctl.h>
 #include <iostream>
 
 namespace dynolog {

--- a/dynolog/src/KernelCollectorBase.cpp
+++ b/dynolog/src/KernelCollectorBase.cpp
@@ -6,9 +6,7 @@
 #include "dynolog/src/KernelCollectorBase.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <chrono>
 #include <sstream>
 #include <string>

--- a/dynolog/src/gpumon/Utils.cpp
+++ b/dynolog/src/gpumon/Utils.cpp
@@ -4,7 +4,6 @@
 #include <glog/logging.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <fstream>
 #include <optional>
 #include "pfs/procfs.hpp"

--- a/dynolog/src/rpc/SimpleJsonServer.cpp
+++ b/dynolog/src/rpc/SimpleJsonServer.cpp
@@ -7,7 +7,6 @@
 #include <arpa/inet.h>
 #include <fmt/format.h>
 #include <glog/logging.h>
-#include <stdio.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <cerrno>

--- a/dynolog/tests/rpc/SimpleJsonClientTest.cpp
+++ b/dynolog/tests/rpc/SimpleJsonClientTest.cpp
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "dynolog/tests/rpc/SimpleJsonClientTest.h"
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.dynolog.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uid
Autodiff partition: fbcode.dynolog
Autodiff bookmark: ad.uid.fbcode.dynolog

Differential Revision: D64989084


