### PR TITLE
fix lbr profiler on amd zen5 and zen6 cpu families

### DIFF
--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -40,6 +40,7 @@ inline CpuFamily makeCpuFamily(
     case 6:
       return CpuFamily::INTEL;
     case 25:
+    case 26:
       return CpuFamily::AMD;
     // Not recognized CPU model.
     default:


### PR DESCRIPTION
Summary: Fix lbr profiler on amd zen5 and zen6 cpu families.

Differential Revision: D65220231


