### PR TITLE
Correct the paths where pmu events are located

### DIFF
--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -355,7 +355,7 @@ void parseSysFsPmu_(fs::directory_entry dentry, PmuDeviceManager& pmu_manager) {
 }
 
 void PmuDeviceManager::loadSysFsPmus() {
-  const fs::path p = "/sys/devices";
+  const fs::path p = "/sys/bus/event_source/devices";
   for (const auto& dentry : fs::directory_iterator(p)) {
     if (!fs::is_directory(dentry.path())) {
       continue;


### PR DESCRIPTION
Summary:
In 6.11 the paths for the PMU's no longer are available in
/sys/devices.  Look in /sys/bus/event_source/devices instead.

Reviewed By: r1mikey

Differential Revision: D65390415


