### PR TITLE
switch to rdc in ROCm 6.2.1

### DIFF
--- a/dynolog/src/gpumon/amd/RdcWrapper.cpp
+++ b/dynolog/src/gpumon/amd/RdcWrapper.cpp
@@ -21,7 +21,7 @@ constexpr std::chrono::milliseconds kUpdateInterval{500};
 // == 1, this should of no use when sufficiently large
 constexpr std::chrono::seconds kMaxKeepAge{2};
 // how many sample to keep in the RDC cache, we only use the latest value
-constexpr int kMaxKeepSamples = 1;
+constexpr int kMaxKeepSamples = 2;
 
 // check the RDC API reference
 // https://rocm.docs.amd.com/projects/rdc/en/docs-6.2.0/reference/api_ref.html


### PR DESCRIPTION
Summary: change kMaxKeepSamples from 1 to 2 so some metrics can be calculated by RDC

Reviewed By: bigzachattack

Differential Revision: D65433407


