### PR TITLE
support health check when DCGM_INT64_BLANK found

### DIFF
--- a/dynolog/src/ServiceHandler.cpp
+++ b/dynolog/src/ServiceHandler.cpp
@@ -9,6 +9,9 @@
 namespace dynolog {
 
 int ServiceHandler::getStatus() {
+  if (dcgm_) {
+    return dcgm_->getRpcStatus();
+  }
   return 1;
 }
 

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -324,6 +324,7 @@ void DcgmGroupInfo::update() {
           }
         }
         metricsInt["dcgm_error"] = blank_value_field ? 1 : 0;
+        rpcStatus_ = blank_value_field ? 0 : 1;
         metricsMapDouble_[entity.m_entityId] = metricsDouble;
         metricsMapInt_[entity.m_entityId] = metricsInt;
       }

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -36,6 +36,9 @@ class DcgmGroupInfo {
   void log(Logger& logger);
   bool pauseProfiling(int duration_s);
   bool resumeProfiling();
+  int getRpcStatus() const {
+      return rpcStatus_;
+  }
 
  private:
   DcgmGroupInfo(
@@ -49,6 +52,7 @@ class DcgmGroupInfo {
   void watchProfFields(const std::vector<unsigned short>& prof_fields);
 
   std::vector<unsigned int> gpuIdList_;
+  int rpcStatus_ = 1; // Default to 1, will be set to 0 when DCGM_INT64_BLANK is detected
   int deviceCount_ = 0;
   bool profEnabled_ = false;
   int updateIntervalMs_;


### PR DESCRIPTION
ServiceHandler::getStatus is useless currently, which can used to detect the DCGM_INT64_BLANK error.