### PR TITLE
Fix `-Wgnu-variable-sized-type-not-at-end` errors across fbcode

### DIFF
--- a/dynolog/src/rdmamon/EthtoolCounters.h
+++ b/dynolog/src/rdmamon/EthtoolCounters.h
@@ -61,9 +61,11 @@ class EthtoolCounters {
 
   [[nodiscard]] bool setup_ethtool_counters(
       const std::vector<std::string>& eth_counter_names_) {
-    struct {
+    union {
       struct ethtool_sset_info hdr;
-      uint32_t buf[1];
+      // Allocate extra space for flexible array member.
+      uint8_t
+          _buf[offsetof(struct ethtool_sset_info, data) + sizeof(uint32_t[1])];
     } ss_stats;
     uint32_t ss_stats_len;
 


### PR DESCRIPTION
Summary:
Newer versions of the kernel have moved to flexible array members,
which triggers compiler warnings with the pattern used here.

https://patchwork.kernel.org/project/linux-nvdimm/patch/20220627180432.GA136081@embeddedor/

Reviewed By: psaab

Differential Revision: D67374150


