### PR TITLE
Remove call to deprecated DCGM watchProfFields API

### DIFF
--- a/dynolog/src/gpumon/DcgmApiStub.cpp
+++ b/dynolog/src/gpumon/DcgmApiStub.cpp
@@ -163,8 +163,10 @@ dcgmApi* getDcgmAPI() {
     SETAPI(dcgmShutdown);
     SETAPI(dcgmStopEmbedded);
     SETAPI(dcgmProfGetSupportedMetricGroups);
-    SETAPI(dcgmProfWatchFields);
-    SETAPI(dcgmProfUnwatchFields);
+    if (api.dcgm_major_version < 3) {
+      SETAPI(dcgmProfWatchFields);
+      SETAPI(dcgmProfUnwatchFields);
+    }
     SETAPI(dcgmUnwatchFields);
     SETAPI(dcgmProfPause);
     SETAPI(dcgmProfResume);
@@ -361,7 +363,7 @@ dcgmReturn_t dcgmProfWatchFields_stub(
     dcgmHandle_t pDcgmHandle,
     dcgmProfWatchFields_t* watchFields) {
   if (auto api = detail::getDcgmAPI(); api) {
-    if (api->dcgm_major_version == 3) {
+    if (api->dcgm_major_version >= 3) {
       // DCGM 3.0 deprecated dcgmProfWatchFields and uses dcgmWatchFields
       // instead
       return DCGM_ST_OK;
@@ -376,7 +378,7 @@ dcgmReturn_t dcgmProfUnwatchFields_stub(
     dcgmHandle_t pDcgmHandle,
     dcgmProfUnwatchFields_t* unwatchFields) {
   if (auto api = detail::getDcgmAPI(); api) {
-    if (api->dcgm_major_version == 3) {
+    if (api->dcgm_major_version >= 3) {
       // DCGM 3.0 deprecated dcgmProfUnWatchFields and uses dcgmWatchFields
       // instead
       return DCGM_ST_OK;


### PR DESCRIPTION
Summary:
This has been stubbed out since the upgrade to DCGM 3.x several years back (`watchFields` replaces this functionality).  Internally we're using DCGM 3, so the calls to this have been noops (see code below)
 {F1974336679} 

This diff does two things:
1. Guards the DCGM stub's `SET_API` call for these APIs by major version - this will enable OSS to still use older DCGM versions, while fixing crashes with DCGM 4 due to the symbol being removed
2. Remove call to watch/unwatch prof fields internally - this removes the 32 field limit imposed by the call to `watchProfFields`

Reviewed By: haowangludx

Differential Revision: D68131677


