### PR TITLE
add read local function to force read perf event on the core owns the event

### DIFF
--- a/hbt/src/perf_event/PerPerfEventsGroupBase.h
+++ b/hbt/src/perf_event/PerPerfEventsGroupBase.h
@@ -121,6 +121,40 @@ class PerPerfEventsGroupBase {
     return true;
   }
 
+  std::set<int> listCpus() const {
+    std::set<int> res;
+    for (const auto& [_, gen] : generators_) {
+      HBT_ARG_CHECK(gen != nullptr) << "Generator in generators_ is nullptr";
+      res.insert(gen->getCpu());
+    }
+    return res;
+  }
+
+  // read perf events group opened on the provided cpu
+  // noted there might be multiple perf events groups opened on the same cpu
+  // (e.g. some uncore events)
+  //
+  // return: a map containing all of the perf events value opened on the given
+  // cpu key is the same id used for inserting generator to generators_. this is
+  // implementation specific depends on if the generator is created by
+  // PerCpuCountReader of PerUncoreCountReader.
+  // value is a GroupReadValues containing the perf events values
+  template <class T = typename TPerfEventGroupGenBase::TMode>
+  mode::enable_if_counting_or_sampling<T, std::map<int, GroupReadValues<T>>>
+  readPerPerfEventsGroupOnCpu(CpuId cpu) const {
+    std::map<int, GroupReadValues<T>> res;
+    for (const auto& [key, gen] : generators_) {
+      if (gen->getCpu() == cpu) {
+        GroupReadValues<T> val(gen->getNumEvents());
+        if (!gen->read(val)) {
+          continue;
+        }
+        res.insert(std::make_pair(key, val));
+      }
+    }
+    return res;
+  }
+
   // Read all events from all monitored perf events group.
   template <class T = typename TPerfEventGroupGenBase::TMode>
   mode::enable_if_counting_or_sampling<T, bool> readPerPerfEventsGroup(

--- a/hbt/src/perf_event/PerfEventsGroup.h
+++ b/hbt/src/perf_event/PerfEventsGroup.h
@@ -624,6 +624,10 @@ class PerfEventsGroupBase {
     return cpu_;
   }
 
+  size_t getNumEvents() const {
+    return confs_.size();
+  }
+
   /// Read a value from file descriptors.
   /// Enable only for Counting and Sampling modes because only those modes
   /// use not Dummy events.


### PR DESCRIPTION
Summary: add new function readAllUncoreCountsPerPerfEventOnLocalCpu()  to provide a way to instruct hbt Monitor to read uncore perf events from the CPU that owns those events

Differential Revision: D68253099


