### PR TITLE
Fix unused-value issue in hbt/src/tagstack/Slicer.h +1

### DIFF
--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -524,7 +524,7 @@ class Slicer {
       Slice::TransitionType swin_type) {
     // HBT_LOG_INFO() << "activateStackState_ idx: " << group_idx << " stack: "
     // <<
-    ss.stats.stack;
+    //  ss.stats.stack;
     HBT_ARG_CHECK(active_states_[group_idx] == nullptr);
     active_states_[group_idx] = &ss;
     ss.markSwitchIn(group_idx, ts, swin_type);


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-value` which we treat as an error because it's so often diagnostic of a code issue. Unused values often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D69691758


