### PR TITLE
Fix C++14 compile issues in CPUTimeMonitor

### DIFF
--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -3,13 +3,12 @@
 #pragma once
 
 #include <dynolog/src/metric_frame/MetricFrame.h>
-#include <gtest/gtest.h>
 #include <memory>
 #include <set>
 #include <shared_mutex>
 #include <thread>
-#include "dynolog/src/DynoMonitorBase.h"
-#include "dynolog/src/DynoTicker.h"
+#include "dynolog/src/MonitorBase.h"
+#include "dynolog/src/Ticker.h"
 
 namespace facebook {
 namespace dynolog {
@@ -30,15 +29,15 @@ different start time). If the CPU set is non-empty then the entire per-core
 /proc/stat file is parsed and the CPU Cores Usage of the allotment cores is
 determined by aggregation over its CPU set. */
 
-class DynoCPUTimeMonitor : DynoMonitorBase<DynoTicker<60000, 1000, 10, 3>> {
+class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
  public:
-  using TDynoTicker = DynoTicker<60000, 1000, 10, 3>;
-  using typename DynoMonitorBase<TDynoTicker>::TMask;
+  using TTicker = Ticker<60000, 1000, 10, 3>;
+  using typename MonitorBase<TTicker>::TMask;
 
   enum class Granularity { MINUTE, SECOND, HUNDRED_MS };
 
-  explicit DynoCPUTimeMonitor(
-      std::shared_ptr<TDynoTicker> ticker,
+  explicit CPUTimeMonitor(
+      std::shared_ptr<TTicker> ticker,
       const std::string& rootDir = "",
       uint64_t coreCount = std::thread::hardware_concurrency(),
       bool isUnitTest = false);
@@ -93,8 +92,7 @@ class DynoCPUTimeMonitor : DynoMonitorBase<DynoTicker<60000, 1000, 10, 3>> {
 
   std::shared_mutex dataLock_;
 
-  FRIEND_TEST(DynoCPUTimeMonitorTest, testProcStat);
-  FRIEND_TEST(DynoCPUTimeMonitorTest, testAllotment);
+  friend class CPUTimeMonitorTest;
 };
 } // namespace dynolog
 

--- a/dynolog/src/MonitorBase.h
+++ b/dynolog/src/MonitorBase.h
@@ -8,15 +8,15 @@
 namespace facebook {
 namespace dynolog {
 
-/* Skeleton Monitor class for Dyno which subscribes to a DynoTicker for
+/* Skeleton Monitor class which subscribes to a Ticker for
  * scheduling.
  */
-template <typename TDynoTicker>
-class DynoMonitorBase {
+template <typename TTicker>
+class MonitorBase {
  public:
-  using TMask = typename TDynoTicker::TMask;
-  DynoMonitorBase(
-      std::shared_ptr<TDynoTicker> ticker,
+  using TMask = typename TTicker::TMask;
+  MonitorBase(
+      std::shared_ptr<TTicker> ticker,
       const std::string& name,
       std::vector<double> subminor_tick_sample_rates)
       : _ticker(ticker),
@@ -24,17 +24,17 @@ class DynoMonitorBase {
         _subminor_tick_sample_rates(subminor_tick_sample_rates) {
     _ticker->subscribe(
         name,
-        TDynoTicker::TSubscriberConfig::make(
+        TTicker::TSubscriberConfig::make(
             name,
             [this](TMask mask) { this->tick(mask); },
             subminor_tick_sample_rates));
   }
 
   bool try_change_sample_rates(std::vector<double> subminor_tick_sample_rates) {
-    std::shared_ptr<typename TDynoTicker::TSubscriberConfig> new_config;
+    std::shared_ptr<typename TTicker::TSubscriberConfig> new_config;
     try {
-      new_config = std::make_shared<typename TDynoTicker::TSubscriberConfig>(
-          TDynoTicker::TSubscriberConfig::make(
+      new_config = std::make_shared<typename TTicker::TSubscriberConfig>(
+          TTicker::TSubscriberConfig::make(
               _name,
               [this](TMask mask) { this->tick(mask); },
               subminor_tick_sample_rates));
@@ -49,10 +49,10 @@ class DynoMonitorBase {
   }
 
   virtual void tick(TMask mask) = 0;
-  virtual ~DynoMonitorBase() {}
+  virtual ~MonitorBase() {}
 
  private:
-  std::shared_ptr<TDynoTicker> _ticker;
+  std::shared_ptr<TTicker> _ticker;
   std::string _name;
   std::vector<double> _subminor_tick_sample_rates;
 
@@ -60,8 +60,8 @@ class DynoMonitorBase {
   std::string get_name() const {
     return _name;
   }
-  std::array<double, TDynoTicker::_subtick_levels>
-  get_subminor_tick_sample_rates() const {
+  std::array<double, TTicker::_subtick_levels> get_subminor_tick_sample_rates()
+      const {
     return _ticker->get_config(_name)->get_subminor_tick_sample_rates();
   }
 };


### PR DESCRIPTION
Summary:
- Drop the 'Dyno' prefix for recently added modules for consistency with previous naming pattern
- Refactor CPUTimeMonitorTest to avoid linking gtest in CPUTimeMonitor
- Rewrite the make_geometric_array template to work with C++14

Reviewed By: bigzachattack

Differential Revision: D70471979
