### PR TITLE
cleanup bpf link on class destructed

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -206,6 +206,8 @@ void BPerfEventsGroup::close() {
   unregister_thread_link_ = nullptr;
   ::bpf_link__destroy(pmu_enable_exit_link_);
   pmu_enable_exit_link_ = nullptr;
+  ::bpf_link__destroy(update_thread_link_);
+  update_thread_link_ = nullptr;
   opened_ = false;
 }
 


### PR DESCRIPTION
Summary: need to cleanup the link in destructor to avoid memory leak

Differential Revision: D70737040


