### PR TITLE
increase max allowed concurrent readers

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -430,8 +430,13 @@ int BPerfEventsGroup::preparePerThreadBPerf_(bperf_leader_cgroup* skel) {
     goto error_out;
   }
 
+  /* Initialize idx_list */
+  for (int i = 0; i < BPERF_MAX_GROUP_SIZE; i++) {
+    skel->bss->idx_list[i] = i;
+  }
+
   /* Use the first element of array per_thread_data for meta data */
-  skel->bss->bitmap[0] |= 1;
+  skel->bss->idx_list_first_free = 1;
   memset(metadata, 0, per_thread_data_size_);
   err = ::bpf_map__lookup_elem(
       skel->maps.per_thread_data,

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -8,7 +8,8 @@
 
 #define BPERF_MAX_GROUP_SIZE 8
 
-#define BPERF_MAX_THREAD_READER 1024
+#define BPERF_MAX_THREAD_READER 65536
+typedef __u16 idx_t;
 
 /* x86
  * struct cyc2ns_data {


### PR DESCRIPTION
Summary: increase BPERF_MAX_THREAD_READER to 65535, also change the way how idx is allocated. Instead of using a bitmask, use a stack like structure to assign the idx on top. This is going to achieve a more efficient idx assignment on high concurrent # of readers, with a trade off of using 16x memory.

Differential Revision: D70737037


