### PR TITLE
decouple per thread map lookup and data update

### DIFF
--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -8,7 +8,7 @@
 
 #define BPERF_MAX_GROUP_SIZE 8
 
-#define BPERF_MAX_THREAD_READER 65536
+#define BPERF_MAX_THREAD_READER 65535
 typedef __u16 idx_t;
 
 /* x86


### PR DESCRIPTION
Summary: extract task->bperf_thread_data lookup out of update_(prev|next)_task function. the overhead of hash map lookup cannot be ignored when we increase the max allowed reader. doing this refactor can help reduce one map lookup per bperf_pmu_enable_exit()

Differential Revision: D72009630


