### PR TITLE
enable/disable uncore perf counter on the local cpu

### DIFF
--- a/hbt/src/mon/IntelPTMonitor.h
+++ b/hbt/src/mon/IntelPTMonitor.h
@@ -84,6 +84,11 @@ class IntelPTMonitor {
     sync_();
   }
 
+  void enableForCpu(bool reset, CpuId) {
+    HBT_THROW_EINVAL()
+        << "enableForCpu() is not implemented for IntelPTMonitor";
+  }
+
   bool isEnabled() const {
     std::lock_guard<std::mutex> lock{state_mutex_};
     return state_ == State::Enabled;
@@ -93,6 +98,16 @@ class IntelPTMonitor {
     std::lock_guard<std::mutex> lock{state_mutex_};
     state_ = State::Open;
     sync_();
+  }
+
+  void disableForCpu(CpuId) {
+    HBT_THROW_EINVAL()
+        << "disableForCpu() is not implemented for IntelPTMonitor";
+  }
+
+  std::set<CpuId> listCpus() const {
+    std::lock_guard<std::mutex> lock{state_mutex_};
+    return getMonCpus().asSet();
   }
 
   ~IntelPTMonitor() {

--- a/hbt/src/mon/TraceCollector.h
+++ b/hbt/src/mon/TraceCollector.h
@@ -196,6 +196,11 @@ class TraceCollector {
     sync_();
   }
 
+  void enableForCpu(bool reset, CpuId cpu) {
+    HBT_THROW_EINVAL()
+        << "enableForCpu() is not implemented for TraceCollector";
+  }
+
   bool isEnabled() const {
     std::lock_guard<std::mutex> slices_lock{slices_mutex_};
     std::lock_guard<std::mutex> counts_lock{counts_mutex_};
@@ -207,6 +212,15 @@ class TraceCollector {
     std::lock_guard<std::mutex> counts_lock{counts_mutex_};
     state_ = State::Open;
     sync_();
+  }
+
+  void disableForCpu(CpuId cpu) {
+    HBT_THROW_EINVAL()
+        << "disableForCpu() is not implemented for TraceCollector";
+  }
+
+  std::set<CpuId> listCpus() const {
+    return getMonCpus().asSet();
   }
 
   /// Read events in PerCpuCountSampleGenerator.


### PR DESCRIPTION
Summary:
1) define enableOnCpu(), disableOnCpu() and listCpus() as general interface so we are able to generally support enable/disable on local CPU for arbitrary type of perf events. There are not implemented for all of the Reader/Collector yet.

2) add a bool to muxRotate() to select if uncore perf events should be enabled/disabled on the local CPU. currently there is no plan to extend this to core events and other perf events. but it should be easy in the future if needed.

3) add a new JK `TEMP_hbt_mon_enable_disable_from_local_cpu` to guard the actual change in dynolog

Reviewed By: liu-song-6

Differential Revision: D72815675


