### PR TITLE
fix incosistent enalbe/disable status during the commitElemChangeOnLocalCpu_

### DIFF
--- a/hbt/src/mon/IntelPTMonitor.h
+++ b/hbt/src/mon/IntelPTMonitor.h
@@ -64,6 +64,15 @@ class IntelPTMonitor {
     sync_();
   }
 
+  void openForCpu(CpuId cpu) {
+    HBT_THROW_EINVAL() << "openForCpu() is not implemented for IntelPTMonitor";
+  }
+
+  bool isOpenOnCpu(CpuId) {
+    HBT_THROW_EINVAL() << "isOpenOnCpu() is not implemented for IntelPTMonitor";
+    return false;
+  }
+
   // Enabled implies open.
   bool isOpen() const {
     std::lock_guard<std::mutex> lock{state_mutex_};
@@ -74,6 +83,10 @@ class IntelPTMonitor {
     std::lock_guard<std::mutex> lock{state_mutex_};
     state_ = State::Closed;
     sync_();
+  }
+
+  void closeForCpu(CpuId cpu) {
+    HBT_THROW_EINVAL() << "closeForCpu() is not implemented for IntelPTMonitor";
   }
 
   void enable(bool reset = false) {
@@ -92,6 +105,12 @@ class IntelPTMonitor {
   bool isEnabled() const {
     std::lock_guard<std::mutex> lock{state_mutex_};
     return state_ == State::Enabled;
+  }
+
+  bool isEnabledOnCpu(CpuId) const {
+    HBT_THROW_EINVAL()
+        << "isEnabledOnCpu() is not implemented for IntelPTMonitor";
+    return false;
   }
 
   void disable() {

--- a/hbt/src/mon/TraceCollector.h
+++ b/hbt/src/mon/TraceCollector.h
@@ -174,6 +174,11 @@ class TraceCollector {
     sync_();
   }
 
+  void openForCpu(CpuId cpu) {
+    HBT_THROW_EINVAL()
+        << "openForCpu() << is not implemented for TraceCollector";
+  }
+
   // Enabled implies open.
   bool isOpen() const {
     std::lock_guard<std::mutex> slices_lock{slices_mutex_};
@@ -181,11 +186,21 @@ class TraceCollector {
     return state_ == State::Open || state_ == State::Enabled;
   }
 
+  bool isOpenOnCpu(CpuId cpu) const {
+    HBT_THROW_EINVAL()
+        << "isOpenOnCpu() << is not implemented for TraceCollector";
+    return false;
+  }
+
   void close() {
     std::lock_guard<std::mutex> slices_lock{slices_mutex_};
     std::lock_guard<std::mutex> counts_lock{counts_mutex_};
     state_ = State::Closed;
     sync_();
+  }
+
+  void closeForCpu(CpuId cpu) {
+    HBT_THROW_EINVAL() << "closeForCpu() is not implemented for TraceCollector";
   }
 
   void enable(bool reset) {
@@ -205,6 +220,12 @@ class TraceCollector {
     std::lock_guard<std::mutex> slices_lock{slices_mutex_};
     std::lock_guard<std::mutex> counts_lock{counts_mutex_};
     return state_ == State::Enabled;
+  }
+
+  bool isEnabledOnCpu(CpuId cpu) const {
+    HBT_THROW_EINVAL()
+        << "isEnabledOnCpu() << is not implemented for TraceCollector";
+    return false;
   }
 
   void disable() {

--- a/hbt/src/perf_event/PerCpuCountReader.h
+++ b/hbt/src/perf_event/PerCpuCountReader.h
@@ -100,6 +100,17 @@ class PerCpuCountReader : public PerCpuBase<CpuCountReader> {
     }
   }
 
+  void openForCpu(CpuId cpu, bool pinned = false) {
+    try {
+      if (generators_.count(static_cast<int>(cpu))) {
+        generators_.at(static_cast<int>(cpu))->open(pinned);
+      }
+    } catch (...) {
+      closeForCpu(cpu);
+      throw;
+    }
+  }
+
   size_t getNumEvents() const {
     return this->metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch)
         .value_or(0);

--- a/hbt/src/perf_event/PerUncoreCountReader.h
+++ b/hbt/src/perf_event/PerUncoreCountReader.h
@@ -118,6 +118,19 @@ class PerUncoreCountReader : public PerPerfEventsGroupBase<UncoreCountReader> {
     }
   }
 
+  void openForCpu(CpuId cpu, bool pinned = false) {
+    try {
+      for (const auto& [key, gen] : this->generators_) {
+        if (gen->getCpu() == cpu) {
+          gen->open(pinned);
+        }
+      }
+    } catch (...) {
+      closeForCpu(cpu);
+      throw;
+    }
+  }
+
   size_t getNumEvents() const {
     return this->metric_desc->getNumEvents(pmu_manager->cpuInfo.cpu_arch)
         .value_or(0);


### PR DESCRIPTION
Summary:
we cannot use isEnabled() in commitElemChangeOnLocalCpu_. isEnabled() assume that all of the readers in the same CountReader should have consistent enable/disable/open/close status. however, this is no longer true in commitElemChangeOnLocalCpu_() because it will enable a portion of readers belonged to the same CPU first

always use is(Enable||Open)OnCpu to make sure we only check the status consistency for readers opened for the same CPU.

since commitElemChangeOnLocalCpu_() is not a public interface, we could limit the change within this function and don't need to worry about potential misuse from a hbt user.

Differential Revision: D73643269


