### PR TITLE
some simple fix to BPerf implementation

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -431,7 +431,7 @@ int BPerfEventsGroup::preparePerThreadBPerf_(bperf_leader_cgroup* skel) {
   }
 
   /* Initialize idx_list */
-  for (int i = 0; i < BPERF_MAX_GROUP_SIZE; i++) {
+  for (int i = 0; i <= BPERF_MAX_THREAD_READER; i++) {
     skel->bss->idx_list[i] = i;
   }
 

--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -129,9 +129,9 @@ int BPerfPerThreadReader::enable() {
   // There is a small drift between time from clock_gettime() and tsc.
   // On a skylake host, I get about 0.02% difference. Get the initial
   // drift at the moment and use it to fix future readings.
+  enabled_ = true;
   read(&data);
   initial_clock_drift_ = getRefMonoTime() - data.monoTime;
-  enabled_ = true;
   return 0;
 
 error:

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -9,7 +9,13 @@
 #define BPERF_MAX_GROUP_SIZE 8
 
 #define BPERF_MAX_THREAD_READER 65535
+// index 0 is reserved for metadata, and will never be used for a thread
+#define BPERF_INVALID_THREAD_IDX 0
 typedef __u16 idx_t;
+
+_Static_assert(
+    (1 << (sizeof(idx_t) * 8)) > BPERF_MAX_THREAD_READER,
+    "idx_t need to be an unsigned type with the max value >= BPERF_MAX_THREAD_READER");
 
 /* x86
  * struct cyc2ns_data {


### PR DESCRIPTION
Summary:
- fix the index assignment list initialization, we should use field BPERF_MAX_THREAD_READER and the actual size of the array should be BPERF_MAX_THREAD_READER + 1 because of the reserved 0 index

- move enabled_ assignment before read() so initialDrift estimation could actually work

Differential Revision: D74493013


