### PR TITLE
add l2_fill_resp_src event for bergamo, genoa and turin

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -11,6 +11,7 @@
 namespace facebook::hbt::perf_event {
 
 namespace milan {
+
 void addEvents(PmuDeviceManager& pmu_manager) {
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
@@ -173,9 +174,37 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "Dram_Near. Read-write. The number of sampled L3 cache fill requests from another NUMA node and return from another CCX's cache."),
       std::vector<EventId>({"zen4-l3-xi-sampled-ccx-latency-requests-far"}));
 }
+
 } // namespace milan
 
+namespace bergamo {
+
+void addEvents(PmuDeviceManager& pmu_manager) {
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l2_fill_l3_resp",
+          EventDef::Encoding{.code = amd_msr::kL2FillL3Responses.val},
+          "L2 cache fill L3 responses.",
+          "L2 cache fill L3 responses. Count all L3 responses to fill requests."),
+      std::vector<EventId>({"l2-fill-l3-resp"}));
+}
+
+} // namespace bergamo
+
 namespace turin {
+
+void addEvents(PmuDeviceManager& pmu_manager) {
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l2_fill_l3_resp",
+          EventDef::Encoding{.code = amd_msr::kL2FillL3Responses.val},
+          "L2 cache fill L3 responses.",
+          "L2 cache fill L3 responses. Count all L3 responses to fill requests."),
+      std::vector<EventId>({"l2-fill-l3-resp"}));
+}
+
 void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
@@ -202,6 +231,7 @@ void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
           "Total number of DRAM bus channel cycles."),
       std::vector<EventId>({"zen5-umc-write-cycles"}));
 }
+
 } // namespace turin
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
@@ -209,13 +239,25 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
   // to addEvents in json_events/generated/intel/JsonEvents.h
   switch (cpu_info.cpu_arch) {
     case CpuArch::MILAN:
+      milan::addEvents(pmu_manager);
+#ifdef FACEBOOK
+      milan::addEventsFb(pmu_manager);
+#endif
+      break;
     case CpuArch::BERGAMO:
     case CpuArch::GENOA:
+      milan::addEvents(pmu_manager);
+#ifdef FACEBOOK
+      milan::addEventsFb(pmu_manager);
+#endif
+      bergamo::addEvents(pmu_manager);
+      break;
     case CpuArch::TURIN:
       milan::addEvents(pmu_manager);
 #ifdef FACEBOOK
       milan::addEventsFb(pmu_manager);
 #endif
+      turin::addEvents(pmu_manager);
       break;
     default:
       HBT_LOG_ERROR()

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -147,6 +147,8 @@ constexpr PmuMsr kL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0x1f}};
 constexpr PmuMsr kL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0x1f}};
+constexpr PmuMsr kL2FillL3Responses{
+    .amdCore = {.event = 0x165, .unitMask = 0xfe}};
 // L2 and L1 Prefetcher misses
 constexpr PmuMsr kL1AndL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0xff}};
@@ -533,10 +535,6 @@ constexpr PmuMsr kDfZen4CxlWriteBeatsCmp3{
     }};
 
 } // namespace amd_msr
-
-namespace milan {
-void addEvents(PmuDeviceManager& pmu_manager);
-}
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager);
 


### PR DESCRIPTION
Summary: Add l2_fill_resp_src event for Bergamo, Genoa and Turin.

Differential Revision: D76595601
