### PR TITLE
Do not re-open `/proc/interrupts` on each `interruptsRefresh` call

### DIFF
--- a/dynolog/src/procfs/parser/InterruptStatsMonitor.h
+++ b/dynolog/src/procfs/parser/InterruptStatsMonitor.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <fstream>
 #include <memory>
 #include <shared_mutex>
 
@@ -23,9 +24,9 @@ struct InterruptStats {
 // 1sec intervals
 class InterruptStatsMonitor : MonitorBase<Ticker<60000, 1000, 1, 2>> {
  private:
-  std::string const rootDir_;
   int16_t cpuCount_;
   std::shared_mutex dataLock_;
+  std::ifstream procInterrupts_;
   InterruptStats stats{};
   InterruptStats statsAtMinuteTick_{};
   InterruptStats statsAtSecondTick_{};


### PR DESCRIPTION
Summary:
Re-open `/proc/interrupts` is expensive, let's open file once and then
rewind it.

```
$ cat /tmp/benchmark.cpp
#include <fstream>
#include <benchmark/benchmark.h>

static void BM_Rewind(benchmark::State& state) {
        std::ifstream file("/proc/interrupts");
  for (auto _ : state) {
    file.clear();
    file.seekg(0);
    benchmark::DoNotOptimize(file);
  }
}
BENCHMARK(BM_Rewind);

static void BM_Reopen(benchmark::State& state) {
  for (auto _ : state) {
    std::ifstream file("/proc/interrupts");
    benchmark::DoNotOptimize(file);
  }
}
BENCHMARK(BM_Reopen);

BENCHMARK_MAIN();
$ c++ -O3 /tmp/benchmark.cpp -o
/tmp/benchmark -lbenchmark && /tmp/benchmark
2025-06-17T09:59:42-07:00
Running /tmp/benchmark
Run on (80 X 3212.58 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x40)
  L1 Instruction 32 KiB (x40)
  L2 Unified 1024 KiB (x40)
  L3 Unified 28160 KiB (x2)
Load Average: 3.63, 4.00, 5.15
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_Rewind         164 ns          163 ns      4318854
BM_Reopen        1875 ns         1760 ns       399645
```

Reviewed By: bigzachattack

Differential Revision: D76748223
