### PR TITLE
Stop using `stringstream` for `/proc/interrupts` parsing

### DIFF
--- a/dynolog/src/String.cpp
+++ b/dynolog/src/String.cpp
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "dynolog/src/String.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook {
+namespace dynolog {
+
+std::vector<std::string> split(const std::string& line, char delim) {
+  std::vector<std::string> ret;
+
+  auto emplaceNonEmptySubstr = [&ret, &line](size_t beg, size_t end) {
+    size_t len = end - beg;
+    if (len > 0) {
+      ret.emplace_back(line.begin() + beg, line.begin() + end);
+    }
+  };
+
+  size_t beg = 0;
+  size_t n = line.size();
+  for (size_t i = 0; i < n; ++i) {
+    if (line[i] == delim) {
+      emplaceNonEmptySubstr(beg, i);
+      beg = i + 1;
+    }
+  }
+  emplaceNonEmptySubstr(beg, n);
+
+  return ret;
+}
+
+} // namespace dynolog
+} // namespace facebook

--- a/dynolog/src/String.h
+++ b/dynolog/src/String.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace facebook {
+namespace dynolog {
+
+/*
+ * Split a line into a vector of non-empty tokens by delimiter.
+ *
+ * Usage example:
+ *
+ *  const std::string line = "hello world";
+ *  std::vector<std::string_view> tokens = split(line, ' ');
+ *  assert(tokens == {"hello", "world"});
+ */
+std::vector<std::string> split(const std::string& line, char delim);
+
+} // namespace dynolog
+} // namespace facebook

--- a/dynolog/src/procfs/parser/InterruptStatsMonitor.cpp
+++ b/dynolog/src/procfs/parser/InterruptStatsMonitor.cpp
@@ -1,6 +1,10 @@
 #include "dynolog/src/procfs/parser/InterruptStatsMonitor.h"
 
 #include <filesystem>
+#include <string>
+#include <vector>
+
+#include "dynolog/src/String.h"
 
 namespace facebook {
 namespace dynolog {
@@ -70,11 +74,10 @@ InterruptStats InterruptStatsMonitor::interruptsRefresh() {
       // cpuCount_
       //   TLB xxxx xxxx xxxx .... xxxx xxxx TLB shootdowns
       if (line.find("TLB shootdowns") != std::string::npos) {
-        std::istringstream ipStream(line);
-        std::string word;
+        const std::vector<std::string> words = split(line, ' ');
         int64_t tlbshootdowns = 0;
         size_t valueCount = 0;
-        while (ipStream >> word) {
+        for (const auto& word : words) {
           if (std::all_of(word.begin(), word.end(), ::isdigit)) {
             int64_t tlbshootdown = std::stoll(word);
             tlbshootdowns += tlbshootdown;
@@ -99,11 +102,10 @@ InterruptStats InterruptStatsMonitor::interruptsRefresh() {
       // space
       if (line.find("eth0-") != std::string::npos ||
           line.find("mlx5_comp") != std::string::npos) {
-        std::istringstream iss(line);
-        std::string word;
+        const std::vector<std::string> words = split(line, ' ');
         int64_t eth0IntrpRow = 0;
         size_t valueCount = 0;
-        while (iss >> word) {
+        for (const auto& word : words) {
           if (std::all_of(word.begin(), word.end(), ::isdigit)) {
             int64_t eth0Intrp = std::stoll(word);
             eth0IntrpRow += eth0Intrp;

--- a/dynolog/tests/StringTest.cpp
+++ b/dynolog/tests/StringTest.cpp
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dynolog/src/String.h"
+
+using facebook::dynolog::split;
+
+TEST(StringTest, Example) {
+  const std::string line = "hello world";
+  std::vector<std::string> tokens = split(line, ' ');
+
+  const std::vector<std::string> expected = {"hello", "world"};
+  EXPECT_EQ(tokens, expected);
+}
+
+TEST(StringTest, Empty) {
+  const std::string line;
+  std::vector<std::string> tokens = split(line, ' ');
+
+  EXPECT_TRUE(tokens.empty());
+}
+
+TEST(StringTest, SkipEmpty) {
+  const std::string line = " 1 2     3 ";
+  std::vector<std::string> tokens = split(line, ' ');
+
+  const std::vector<std::string> expected = {"1", "2", "3"};
+  EXPECT_EQ(tokens, expected);
+}
+
+TEST(StringTest, Single) {
+  const std::string line = "1 2 3";
+  std::vector<std::string> tokens = split(line, ',');
+
+  const std::vector<std::string> expected = {"1 2 3"};
+  EXPECT_EQ(tokens, expected);
+}


### PR DESCRIPTION
Summary:
`std::stringstream` is well known to be not very performant. See
[this benchmark][1] for example. Replace `std::stringstream` usage by manually
written `split` as a parsing optimization.

Unfortunetly, there is no `std::stoll` for `std::string_view` and
`std::from_chars` in not available, since dynolog requires gcc 8.5.0+ to
compile and `std::from_chars` is C++17 feature (enabled by default since GCC
11). Once we can use `std::from_chars`, we can split into
`std::vector<std::string_view>` instead.

[1]: https://quick-bench.com/q/oNRh6sahmaFBdnwFktckHVEjTzE

Reviewed By: bigzachattack

Differential Revision: D76817841
