### PR TITLE
free leader_link on destruction

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -188,6 +188,8 @@ void BPerfEventsGroup::close() {
     ::close(fd);
     fd = -1;
   }
+  ::bpf_link__destroy(leader_link_);
+  leader_link_ = nullptr;
   ::bperf_leader_cgroup__destroy(skel_);
   skel_ = nullptr;
   opened_ = false;


### PR DESCRIPTION
Summary: leader_link_ will be freed on disable() but not close(). there might be a memory leak if close() is called when BPerfEventsGroup is enabled status

Reviewed By: homie-homin

Differential Revision: D77162928


