### PR TITLE
Handle potential null deference exception on dcgm instance

### DIFF
--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -177,7 +177,12 @@ int main(int argc, char** argv) {
   if (FLAGS_enable_gpu_monitor) {
     dcgm = gpumon::DcgmGroupInfo::factory(
         gpumon::FLAGS_dcgm_fields, FLAGS_dcgm_reporting_interval_s * 1000);
-    gpumon_thread = std::make_unique<std::thread>(gpu_monitor_loop, dcgm);
+    if (!dcgm) {
+      LOG(ERROR) << "Failed to initialize DCGM";
+      return 1;
+    } else {
+      gpumon_thread = std::make_unique<std::thread>(gpu_monitor_loop, dcgm);
+    }
   }
   std::thread km_thread{kernel_monitor_loop};
   if (FLAGS_enable_perf_monitor) {

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -125,6 +125,7 @@ std::shared_ptr<DcgmGroupInfo> DcgmGroupInfo::factory(
   auto dcgmGroupInfo = std::shared_ptr<DcgmGroupInfo>(
       new DcgmGroupInfo(fields, prof_fields, updateIntervalMs));
   if (dcgmGroupInfo->isFailing()) {
+    LOG(ERROR) << "Failed to create DcgmGroupInfo instance";
     return nullptr;
   }
   return dcgmGroupInfo;


### PR DESCRIPTION
Summary:
Suggested in dynolog open source community: https://fburl.com/98xag6qt 
It's addressing null pointer dereference issue when it fails on dcgm instance creation.

Differential Revision: D77449623


