### PR TITLE
Add MockPerCpuCountReader so that we can unit test Monitor and PerfCounterManager

### DIFF
--- a/hbt/src/mon/tests/MonitorMockTest.cpp
+++ b/hbt/src/mon/tests/MonitorMockTest.cpp
@@ -1,0 +1,97 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "hbt/src/mon/Monitor.h"
+#include "hbt/src/perf_event/BuiltinMetrics.h"
+#include "hbt/src/perf_event/tests/MockPerCpuCountReader.h"
+
+namespace facebook::hbt::mon {
+namespace {
+using namespace ::testing;
+
+TEST(CpuCountReader, ReadAllCpuCounts) {
+  auto cpu_info = CpuInfo("Intel", 6, 207, 0);
+  auto cpu_set = CpuSet::makeFromCpusList("0,1,2,3");
+  auto pmu_manager = std::make_shared<perf_event::PmuDeviceManager>(cpu_info);
+  pmu_manager->addPmu(std::make_shared<perf_event::PmuDevice>(
+      PmuTypeToStr(perf_event::PmuType::generic_hardware),
+      perf_event::PmuType::generic_hardware,
+      std::nullopt,
+      PERF_TYPE_HARDWARE,
+      "PMU of Generic Hardware Events",
+      false));
+  pmu_manager->addEvent(
+      std::make_shared<perf_event::EventDef>(
+          perf_event::PmuType::generic_hardware,
+          "cpu_cycles",
+          perf_event::EventDef::Encoding{.code = PERF_COUNT_HW_CPU_CYCLES},
+          "CPU cycles.",
+          "Actual CPU cycles. Depends on frequency scaling, turbo mode and other effects."),
+      std::vector<perf_event::EventId>({"cpu-cycles", "cycles"}));
+  pmu_manager->addEvent(
+      std::make_shared<perf_event::EventDef>(
+          perf_event::PmuType::generic_hardware,
+          "instructions",
+          perf_event::EventDef::Encoding{.code = PERF_COUNT_HW_INSTRUCTIONS},
+          "Instructions retired.",
+          "Instructions executed. Does not count speculative execution."),
+      std::vector<perf_event::EventId>(
+          {"retired_instructions", "retired-instructions"}));
+
+  auto metrics = perf_event::makeAvailableMetrics();
+  auto factory = std::make_unique<perf_event::MockPerCpuCountReaderFactory>();
+  factory->setExpectation(
+      "instructions",
+      [](perf_event::MockPerCpuCountReader* instructionsReader) {
+        perf_event::PerCpuCountReader::ReadValues instValues(4);
+        instValues.t->count[0] = 100;
+        instValues.t->time_enabled = 1;
+        instValues.t->time_running = 1;
+        EXPECT_CALL(*instructionsReader, isOpen).WillRepeatedly(Return(true));
+        EXPECT_CALL(*instructionsReader, isEnabled)
+            .WillRepeatedly(Return(true));
+        EXPECT_CALL(*instructionsReader, read)
+            .WillOnce(Return(std::make_optional(instValues)));
+        EXPECT_CALL(*instructionsReader, close).Times(AtLeast(1));
+        EXPECT_CALL(*instructionsReader, disable).Times(AtLeast(1));
+      });
+  factory->setExpectation(
+      "cycles", [](perf_event::MockPerCpuCountReader* cyclesReader) {
+        perf_event::PerCpuCountReader::ReadValues cycleValues(4);
+        cycleValues.t->count[0] = 200;
+        cycleValues.t->time_enabled = 1;
+        cycleValues.t->time_running = 1;
+        EXPECT_CALL(*cyclesReader, isOpen).WillRepeatedly(Return(true));
+        EXPECT_CALL(*cyclesReader, isEnabled).WillRepeatedly(Return(true));
+        EXPECT_CALL(*cyclesReader, read)
+            .WillOnce(Return(std::make_optional(cycleValues)));
+        EXPECT_CALL(*cyclesReader, close).Times(AtLeast(1));
+        EXPECT_CALL(*cyclesReader, disable).Times(AtLeast(1));
+      });
+
+  Monitor mon(std::move(factory), false, true);
+  mon.emplaceCpuCountReader(
+      "instructions",
+      "instructions",
+      metrics->getMetricDesc("instructions"),
+      pmu_manager,
+      cpu_set,
+      nullptr);
+  mon.emplaceCpuCountReader(
+      "cycles",
+      "cycles",
+      metrics->getMetricDesc("cycles"),
+      pmu_manager,
+      cpu_set,
+      nullptr);
+
+  EXPECT_TRUE(mon.open());
+  EXPECT_TRUE(mon.enable());
+
+  auto vals = mon.readAllCpuCounts();
+  EXPECT_THAT(vals, ElementsAre(Key("cycles"), Key("instructions")));
+  EXPECT_THAT(vals.at("cycles")->getCounts(), ElementsAre(200, 0, 0, 0));
+  EXPECT_THAT(vals.at("instructions")->getCounts(), ElementsAre(100, 0, 0, 0));
+};
+
+} // namespace
+} // namespace facebook::hbt::mon

--- a/hbt/src/perf_event/tests/MockPerCpuCountReader.h
+++ b/hbt/src/perf_event/tests/MockPerCpuCountReader.h
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <utility>
+#include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/PerCpuCountReader.h"
+
+namespace facebook::hbt::perf_event {
+
+class MockPerCpuCountReader : public PerCpuCountReader {
+ public:
+  MockPerCpuCountReader(
+      const CpuSet& mon_cpus,
+      std::shared_ptr<const MetricDesc> metric_desc,
+      std::shared_ptr<const PmuDeviceManager> pmu_manager,
+      std::shared_ptr<FdWrapper> cgroup_fd_wrapper)
+      : PerCpuCountReader(
+            CpuSet::makeAllOnline(),
+            std::move(metric_desc),
+            std::move(pmu_manager),
+            std::move(cgroup_fd_wrapper)) {}
+  ~MockPerCpuCountReader() override = default;
+  MOCK_METHOD(void, open, (bool), (override));
+  MOCK_METHOD(void, openForCpu, (CpuId, bool), (override));
+  MOCK_METHOD(bool, isOpen, (), (const, override));
+  MOCK_METHOD(void, enable, (bool), (override));
+  MOCK_METHOD(void, enableForCpu, (CpuId, bool), (override));
+  MOCK_METHOD(bool, isEnabled, (), (const, override));
+  MOCK_METHOD(bool, isEnabledOnCpu, (CpuId), (const, override));
+  MOCK_METHOD(void, close, (), (override));
+  MOCK_METHOD(void, closeForCpu, (CpuId), (override));
+  MOCK_METHOD(void, disable, (), (override));
+  MOCK_METHOD(void, disableForCpu, (CpuId), (override));
+  MOCK_METHOD(std::optional<ReadValues>, read, (), (const, override));
+  MOCK_METHOD(
+      (std::optional<std::map<int, ReadValues>>),
+      readPerCpu,
+      (),
+      (const, override));
+};
+
+class MockPerCpuCountReaderFactory : public PerCpuCountReaderFactory {
+ public:
+  MockPerCpuCountReaderFactory() = default;
+  ~MockPerCpuCountReaderFactory() override = default;
+  std::unique_ptr<PerCpuCountReader> make(
+      const std::string& element_id,
+      const CpuSet& mon_cpus,
+      std::shared_ptr<const MetricDesc> metric_desc,
+      std::shared_ptr<const PmuDeviceManager> pmu_manager,
+      std::shared_ptr<FdWrapper> cgroup_fd_wrapper) override {
+    auto mockReader = std::make_unique<MockPerCpuCountReader>(
+        mon_cpus, metric_desc, pmu_manager, cgroup_fd_wrapper);
+    mockReaders_[element_id] = mockReader.get();
+    if (expectations_.find(element_id) != expectations_.end()) {
+      expectations_[element_id](mockReader.get());
+    }
+    return std::move(mockReader);
+  }
+
+  void setExpectation(
+      const std::string& element_id,
+      std::function<void(MockPerCpuCountReader*)> expects) {
+    expectations_[element_id] = std::move(expects);
+  }
+
+ private:
+  std::unordered_map<std::string, MockPerCpuCountReader*> mockReaders_;
+  std::unordered_map<std::string, std::function<void(MockPerCpuCountReader*)>>
+      expectations_;
+};
+
+} // namespace facebook::hbt::perf_event


### PR DESCRIPTION
Summary:
This diff introduces a MockPerCpuCountReader class to facilitate unit testing of the Monitor and PerfCounterManager.

Changes to existing PerCpuCountReader & Monitor:
- methods that need to be mocked out are changed to be `virtual` so the mock class can override it. All virtual methods are defined on PerCpuCountReader to minimize the scope of this diff.
- In Monitor class, I created PerCpuCountReaderFactory to encapsulate the creation of PerCpuCountReader, making it possible to create MockPerCpuCountReader in unit test. MockPerCpuCountReader also provides `setExpectation` method to setup

Also added a test file `MonitorMockTest.cpp` to demonstrate the usage of MockPerCpuCountReader for testing the Monitor class.

Differential Revision: D78382695


