### PR TITLE
publish cgroup cpu.stat to dyno_experimental table

### DIFF
--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -38,6 +38,7 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
 
   explicit CPUTimeMonitor(
       std::shared_ptr<TTicker> ticker,
+      bool readCgroupStat,
       std::string rootDir = "",
       uint64_t coreCount = std::thread::hardware_concurrency(),
       bool isUnitTest = false);
@@ -89,6 +90,13 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
       TimePoint measure_time_hi,
       TMask mask);
 
+  void processCgroupUsage(
+      int level,
+      const std::map<std::string, std::tuple<TimePoint, uint64_t>>&
+          cgroupCpuStats,
+      TimePoint measure_time_lo,
+      TMask mask);
+
   static std::array<MetricFrameMap, 3> createMetricFrameArray();
   std::string const rootDir_;
   uint64_t const coreCount_;
@@ -101,6 +109,12 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   std::array<MetricFrameMap, 3> procUsageMetricFrames_;
   std::array<std::map<std::string, uint64_t>, 3> procCpuTimeLast_;
   std::array<TimePoint, 3> procTimeLast_;
+
+  // Cgroup stat tracking. Index 0 is minute, 1 is second, 2 is 100ms
+  bool readCgroupStat_;
+  std::array<MetricFrameMap, 3> cgroupUsageMetricFrames_;
+  std::array<std::map<std::string, uint64_t>, 3> cgroupUsageLast_;
+  std::array<std::map<std::string, TimePoint>, 3> cgroupTimeLast_;
 
   std::shared_mutex dataLock_;
 

--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -74,13 +74,22 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   enum class Statistic { AVG, QUANTILE };
 
   std::vector<uint64_t> readProcStat(bool read_per_core = false);
-  std::optional<uint64_t> readCgroupCpuStat(const std::string& allotmentId);
+  std::optional<uint64_t> readCgroupCpuStat(const std::string& cgroupPath);
   std::optional<double> getStat(
       Granularity gran,
       uint64_t seconds_ago,
       const std::optional<std::string>& allotmentId,
       Statistic stat,
       double quant);
+
+  void processProcUsage(
+      int level,
+      const std::vector<uint64_t>& idleTime,
+      TimePoint measure_time_lo,
+      TimePoint measure_time_hi,
+      TMask mask);
+
+  static std::array<MetricFrameMap, 3> createMetricFrameArray();
   std::string const rootDir_;
   uint64_t const coreCount_;
   bool const isUnitTest_;
@@ -88,10 +97,10 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   std::set<std::string> allotmentsNeedPerCore_;
   std::map<std::string, std::string> allotmentCgroupPaths_;
 
-  // Index 0 is minute, 1 is second, 2 is 100ms
-  std::array<MetricFrameMap, 3> CPUTimeMetricFrames_;
-  std::array<std::map<std::string, uint64_t>, 3> CPUTimeLast_;
-  std::array<TimePoint, 3> TimeLast_;
+  // Proc stat tracking. Index 0 is minute, 1 is second, 2 is 100ms
+  std::array<MetricFrameMap, 3> procUsageMetricFrames_;
+  std::array<std::map<std::string, uint64_t>, 3> procCpuTimeLast_;
+  std::array<TimePoint, 3> procTimeLast_;
 
   std::shared_mutex dataLock_;
 

--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -35,6 +35,7 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   using typename MonitorBase<TTicker>::TMask;
 
   enum class Granularity { MINUTE, SECOND, HUNDRED_MS };
+  enum class DataSource { PROC_STAT, CGROUP_STAT };
 
   explicit CPUTimeMonitor(
       std::shared_ptr<TTicker> ticker,
@@ -55,18 +56,21 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   std::optional<double> getAvgCPUCoresUsage(
       Granularity gran,
       uint64_t seconds_ago,
-      const std::optional<std::string>& allotmentId = std::nullopt);
+      const std::optional<std::string>& allotmentId = std::nullopt,
+      DataSource dataSource = DataSource::PROC_STAT);
 
   std::optional<double> getQuantileCPUCoresUsage(
       Granularity gran,
       uint64_t seconds_ago,
       double quantile,
-      const std::optional<std::string>& allotmentId = std::nullopt);
+      const std::optional<std::string>& allotmentId = std::nullopt,
+      DataSource dataSource = DataSource::PROC_STAT);
 
   std::vector<double> getRawCPUCoresUsage(
       Granularity gran,
       uint64_t seconds_ago,
-      const std::optional<std::string>& allotmentId = std::nullopt);
+      const std::optional<std::string>& allotmentId = std::nullopt,
+      DataSource dataSource = DataSource::PROC_STAT);
 
  private:
   // Reads Idle time from /proc/stat
@@ -81,7 +85,8 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
       uint64_t seconds_ago,
       const std::optional<std::string>& allotmentId,
       Statistic stat,
-      double quant);
+      double quant,
+      DataSource dataSource = DataSource::PROC_STAT);
 
   void processProcUsage(
       int level,
@@ -98,6 +103,10 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
       TMask mask);
 
   static std::array<MetricFrameMap, 3> createMetricFrameArray();
+  std::optional<MetricFrameMap> getMetricFrame(
+      Granularity gran,
+      DataSource dataSource);
+
   std::string const rootDir_;
   uint64_t const coreCount_;
   bool const isUnitTest_;

--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -27,7 +27,11 @@ granularity 100ms, 1s and 60s. If the CPU set is empty the allotment is assumed
 to be whole-host and will have the same CPU data as host level (albeit with a
 different start time). If the CPU set is non-empty then the entire per-core
 /proc/stat file is parsed and the CPU Cores Usage of the allotment cores is
-determined by aggregation over its CPU set. */
+determined by aggregation over its CPU set.
+
+As of July 2025, we began testing a new cgroup-based CPU time monitoringfor more
+accurate measurements of cgroup CPU time usage.
+*/
 
 class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
  public:


### PR DESCRIPTION
Summary: This diff switches current experiemental table publishing from proc stats to cgroup cpu.stats

Differential Revision: D78685390


