### PR TITLE
Add a few functions to allow unit test mocking hardware info

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.h
+++ b/hbt/src/perf_event/BuiltinMetrics.h
@@ -11,7 +11,9 @@
 namespace facebook::hbt::perf_event {
 
 std::shared_ptr<PmuDeviceManager> makePmuDeviceManager();
+void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager);
 std::shared_ptr<Metrics> makeAvailableMetrics();
+std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info);
 void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics);
 void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics);
 void addUncoreMetrics(std::shared_ptr<Metrics>& metrics);

--- a/hbt/src/perf_event/PerUncoreCountReader.h
+++ b/hbt/src/perf_event/PerUncoreCountReader.h
@@ -203,6 +203,11 @@ class PerUncoreCountReader : public PerPerfEventsGroupBase<UncoreCountReader> {
     return rvs;
   }
 
+  virtual std::map<int, ReadValues> readPerPerfEventsGroupOnCpu(
+      CpuId cpu) const {
+    return TBase::readPerPerfEventsGroupOnCpu(cpu);
+  }
+
   std::ostream& printStatus(std::ostream& os) const {
     os << "Uncore Count Reader \"" << metric_desc->id;
     if (this->isEnabled()) {

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -365,7 +365,7 @@ void parseSysFsPmu_(fs::directory_entry dentry, PmuDeviceManager& pmu_manager) {
 }
 
 void PmuDeviceManager::loadSysFsPmus() {
-  const fs::path p = "/sys/bus/event_source/devices";
+  const fs::path p = rootDir_ + "/sys/bus/event_source/devices";
   for (const auto& dentry : fs::directory_iterator(p)) {
     if (!fs::is_directory(dentry.path())) {
       continue;

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <numeric>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -308,7 +309,11 @@ class PmuDeviceManager {
 
   const CpuInfo cpuInfo;
 
-  explicit PmuDeviceManager(CpuInfo cpu_info_in) : cpuInfo(cpu_info_in) {}
+  explicit PmuDeviceManager(CpuInfo cpuInfoIn)
+      : cpuInfo(std::move(cpuInfoIn)), rootDir_() {}
+
+  PmuDeviceManager(CpuInfo cpuInfoIn, const std::string& rootDir)
+      : cpuInfo(std::move(cpuInfoIn)), rootDir_(rootDir) {}
 
   // Sync PMUs exposed in /sys/devices with those in pmu_groups_.
   void loadSysFsPmus();
@@ -411,6 +416,7 @@ class PmuDeviceManager {
 
  protected:
   TPmuGroups pmu_groups_;
+  const std::string rootDir_;
 
   void updateSysFsPmus_();
 };

--- a/hbt/src/perf_event/tests/MockPerUncoreCountReader.h
+++ b/hbt/src/perf_event/tests/MockPerUncoreCountReader.h
@@ -35,6 +35,11 @@ class MockPerUncoreCountReader : public PerUncoreCountReader {
       readPerPerfEventsGroup,
       (),
       (const, override));
+  MOCK_METHOD(
+      (std::map<int, ReadValues>),
+      readPerPerfEventsGroupOnCpu,
+      (CpuId),
+      (const, override));
 };
 
 class MockPerUncoreCountReaderFactory : public PerUncoreCountReaderFactory {


### PR DESCRIPTION
Summary:
*   In `PmuDevices.h`, the `PmuDeviceManager` class is updated to include an additional constructor that takes a `rootDir` parameter so that we can provide mock sysfs files in unit test.
*   In `BuiltinMetrics.h`, added `populatePmuDeviceManager` function so that we can pass in custom `PmuDeviceManager` class.
*   In `MockPerUncoreCountReader.h`, the `readPerPerfEventsGroupOnCpu` function is added to the mock class. This function is also added to base class to allow mocking.

Differential Revision: D78767232


