### PR TITLE
Add l2_fill_l3_resp as a task counter

### DIFF
--- a/hbt/src/mon/tests/MonitorTest.cpp
+++ b/hbt/src/mon/tests/MonitorTest.cpp
@@ -407,7 +407,7 @@ TEST(CpuCountReader, SystemWideCountRead) {
   EXPECT_TRUE(mon.enable());
 
   auto vals = mon.readAllCpuCounts();
-  EXPECT_EQ(vals.contains(kInstruction), 1);
+  EXPECT_EQ(vals.count(kInstruction), 1);
   EXPECT_TRUE(vals.at(kInstruction).has_value());
 }
 

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -692,6 +692,22 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
         System::Permissions{},
         std::vector<std::string>{},
         getAddReducer()));
+    metrics->add(std::make_shared<MetricDesc>(
+        "l2_cache_fills_l3_reponses",
+        "L2 cache fill from L3 responses",
+        "Count all L3 responses to fill requests."
+        "This event is specific to AMD Zen4 and Zen5 CPUs.",
+        std::map<TOptCpuArch, EventRefs>{
+            {std::nullopt,
+             EventRefs{EventRef{
+                 "l2_fill_l3_resp",
+                 PmuType::cpu,
+                 "l2_fill_l3_resp",
+                 EventExtraAttr{},
+                 {}}}}},
+        100'000'000,
+        System::Permissions{},
+        std::vector<std::string>{}));
   }
   // l3_cache_misses replaces DynoPerfCounterType::L3CACHE_MISS
   metrics->add(std::make_shared<MetricDesc>(


### PR DESCRIPTION
Summary: This diff adds l2_fill_l3_resp as a task counter when in Bperf mode.

Reviewed By: bigzachattack

Differential Revision: D79138338


