### PR TITLE
Fix unreachable-break-or-return issue in gorilla/lib2/gorilla/GorillaSmStateMachine.h +5

### DIFF
--- a/hbt/src/tagstack/Slicer.h
+++ b/hbt/src/tagstack/Slicer.h
@@ -91,19 +91,14 @@ inline std::string toStr(const Slice::TransitionType& type) {
   switch (type) {
     case Slice::TransitionType::NA:
       return "NA";
-      break;
     case Slice::TransitionType::Analysis:
       return "Analysis";
-      break;
     case Slice::TransitionType::ThreadPreempted:
       return "ThreadPreempted";
-      break;
     case Slice::TransitionType::ThreadYield:
       return "ThreadYield";
-      break;
     case Slice::TransitionType::PhaseChange:
       return "PhaseChange";
-      break;
   }
 }
 


### PR DESCRIPTION
Summary:
LLVM has two warnings `-Wunreachable-code-return` and `-Wunreachable-code-break` which identify `return` and `break` statements that cannot be reached. These compromise readability, can be misleading, and may identify bugs. This diff removes such statements.

`break` was often used defensively in `switch` statements. We now have `-Wimplicit-fallthrough` [enabled globally](https://fb.workplace.com/groups/fbcode/posts/8021835991186503), which replaces this inexact practice with a compiler guarantee.

The compiler used to be less intelligent and would throw an error if a function didn't return the correct type after a `throw` statement. The compiler is smarter now, so this code is unnecessary. `-Wreturn-type` is enabled globally and prevents functions from ending without an appropriate return.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D79967347


