### PR TITLE
add ls_dmnd_fills_from_sys.dram_io_far event for amd

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -183,6 +183,38 @@ void addEvents(PmuDeviceManager& pmu_manager) {
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
           PmuType::cpu,
+          "ls_dmnd_fills_from_sys.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsDmndFillsFromSysDramIoFar.val},
+          "Demand data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Demand data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-dmnd-fills-from-sys.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_any_fills_from_sys.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsAnyFillsFromSysDramIoFar.val},
+          "Any data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Any data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-any-fills-from-sys.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_sw_pf_dc_fills.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsSwPfDcFillsDramIoFar.val},
+          "Software prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Software prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-sw-pf-dc-fills.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_hw_pf_dc_fills.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsHwPfDcFillsDramIoFar.val},
+          "Hardware prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Hardware prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-hw-pf-dc-fills.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
           "l2_fill_l3_resp",
           EventDef::Encoding{.code = amd_msr::kL2FillL3Responses.val},
           "L2 cache fill L3 responses.",
@@ -195,6 +227,38 @@ void addEvents(PmuDeviceManager& pmu_manager) {
 namespace turin {
 
 void addEvents(PmuDeviceManager& pmu_manager) {
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_dmnd_fills_from_sys.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsDmndFillsFromSysDramIoFar.val},
+          "Demand data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Demand data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-dmnd-fills-from-sys.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_any_fills_from_sys.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsAnyFillsFromSysDramIoFar.val},
+          "Any data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Any data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-any-fills-from-sys.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_sw_pf_dc_fills.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsSwPfDcFillsDramIoFar.val},
+          "Software prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Software prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-sw-pf-dc-fills.dram-io-far"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_hw_pf_dc_fills.dram_io_far",
+          EventDef::Encoding{.code = amd_msr::kLsHwPfDcFillsDramIoFar.val},
+          "Hardware prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket).",
+          "Hardware prefetch data cache fills from either DRAM or MMIO in a different NUMA node (same or different socket)."),
+      std::vector<EventId>({"ls-hw-pf-dc-fills.dram-io-far"}));
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
           PmuType::cpu,

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -127,6 +127,15 @@ union PmuMsr {
 constexpr PmuMsr kRetiredInstructions{.amdCore = {.event = 0xc0}};
 constexpr PmuMsr kUnhaltedCycles{.amdCore = {.event = 0x76}};
 
+constexpr PmuMsr kLsDmndFillsFromSysDramIoFar{
+    .amdCore = {.event = 0x43, .unitMask = 0x40}};
+constexpr PmuMsr kLsAnyFillsFromSysDramIoFar{
+    .amdCore = {.event = 0x44, .unitMask = 0x40}};
+constexpr PmuMsr kLsSwPfDcFillsDramIoFar{
+    .amdCore = {.event = 0x59, .unitMask = 0x40}};
+constexpr PmuMsr kLsHwPfDcFillsDramIoFar{
+    .amdCore = {.event = 0x5a, .unitMask = 0x40}};
+
 // L1 iCache
 constexpr PmuMsr kL1ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x7}}; // Same as e=0x60,u=0x10


### PR DESCRIPTION
Summary: Add ls_dmnd_fills_from_sys.dram_io_far event for amd.

Reviewed By: pdesupinski

Differential Revision: D79901128


