### PR TITLE
add l2_fill_dram_resp AMD event and task counters

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -220,6 +220,14 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "L2 cache fill L3 responses.",
           "L2 cache fill L3 responses. Count all L3 responses to fill requests."),
       std::vector<EventId>({"l2-fill-l3-resp"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l2_fill_dram_resp",
+          EventDef::Encoding{.code = amd_msr::kL2FillDramResponses.val},
+          "L2 cache fill from all DRAM or MMIO responses.",
+          "L2 cache fill responses returned from either DRAM or MMIO from the same or different NUMA node."),
+      std::vector<EventId>({"l2-fill-dram-resp"}));
 }
 
 } // namespace bergamo
@@ -267,6 +275,14 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "L2 cache fill L3 responses.",
           "L2 cache fill L3 responses. Count all L3 responses to fill requests."),
       std::vector<EventId>({"l2-fill-l3-resp"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "l2_fill_dram_resp",
+          EventDef::Encoding{.code = amd_msr::kL2FillDramResponses.val},
+          "L2 cache fill from all DRAM or MMIO responses.",
+          "L2 cache fill requests that target the same or another NUMA node and return from either DRAM or MMIO from the same or different NUMA node."),
+      std::vector<EventId>({"l2-fill-dram-resp"}));
 }
 
 void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -158,6 +158,9 @@ constexpr PmuMsr kL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0x1f}};
 constexpr PmuMsr kL2FillL3Responses{
     .amdCore = {.event = 0x65, .unitMask = 0xfe, .event_11_8 = 0x1}};
+// L2 Fill from DRAM responses only. Umask bit 01001000
+constexpr PmuMsr kL2FillDramResponses{
+    .amdCore = {.event = 0x65, .unitMask = 0x48, .event_11_8 = 0x1}};
 // L2 and L1 Prefetcher misses
 constexpr PmuMsr kL1AndL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0xff}};

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -708,6 +708,21 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
         100'000'000,
         System::Permissions{},
         std::vector<std::string>{}));
+    metrics->add(std::make_shared<MetricDesc>(
+        "l2_cache_fills_dram_reponses",
+        "L2 cache fill from all DRAM or MMIO responses.",
+        "L2 cache fill responses returned from either DRAM or MMIO from the same or different NUMA node.",
+        std::map<TOptCpuArch, EventRefs>{
+            {std::nullopt,
+             EventRefs{EventRef{
+                 "l2_fill_dram_resp",
+                 PmuType::cpu,
+                 "l2_fill_dram_resp",
+                 EventExtraAttr{},
+                 {}}}}},
+        100'000'000,
+        System::Permissions{},
+        std::vector<std::string>{}));
   }
   // l3_cache_misses replaces DynoPerfCounterType::L3CACHE_MISS
   metrics->add(std::make_shared<MetricDesc>(


### PR DESCRIPTION
Summary:
This diff adds l2_fill_dram_resp AMD event (code0x165, umask = 0x48), see https://fburl.com/gdoc/bzgrkpd0 for the specs.

This counter will be used in place of `L3_cache_misses` for BGM, GENOA and TRN to estimate task memory bandwidth

Differential Revision: D80552633


