### PR TITLE
unskip cgroup usage reporting when it exceeds provided core limit

### DIFF
--- a/dynolog/src/CPUTimeMonitor.cpp
+++ b/dynolog/src/CPUTimeMonitor.cpp
@@ -489,10 +489,15 @@ void CPUTimeMonitor::processCgroupUsage(
         LOG(ERROR) << "Invalid cgroup usage at level: " << level
                    << " allotmentId: " << allotmentId
                    << " wallDelta: " << wallDelta
-                   << " cgroupUsage: " << cgroupUsage << " usage: " << newUsage
-                   << " lastUsage: " << lastUsage[allotmentId];
+                   << " cgroupUsage: " << cgroupUsage
+                   << " newUsage: " << newUsage << " oldUsage: " << oldUsage
+                   << " coreCount: " << coreCount_;
       }
-      continue;
+      if (cgroupUsage < 0) {
+        // Only skip when cgroupUsage is negative as the coreCount_ limit may be
+        // unreliable.
+        continue;
+      }
     }
 
     line.emplace_back(allotmentId, cgroupUsage);


### PR DESCRIPTION
Summary:
At the moment we skip cgroup usage readings when it exceeds the provided coreCount_, which is evaluated from std::thread::hardware_concurrency(). On 1% of the hosts, this std::thread::hardware_concurrency() seems to return a number lower than expected, causing valid cgroup usage readings being skipped. Example logs

```
E0823 23:57:25.632484 3649054 CPUTimeMonitor.cpp:489] Invalid cgroup usage at level: 0 allotmentId: da8a448c-d762-4e4b-a052-50e9ed237cdf wallDelta: 60000289 cgroupUsage: 42.5328

E0823 23:57:25.632543 3649054 CPUTimeMonitor.cpp:489] Invalid cgroup usage at level: 1 allotmentId: host wallDelta: 1000186 cgroupUsage: 44.2457
```

This diff takes a more conservative approach to unskip these values first, and added logging of coreCount_ for future debugging

Differential Revision: D81052459


