### PR TITLE
fixes event umask used for estimating L3 cache misses on AMD Zen 4 & 5

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -223,6 +223,14 @@ void addEvents(PmuDeviceManager& pmu_manager) {
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
           PmuType::cpu,
+          "l2_fill_l3_miss_resp",
+          EventDef::Encoding{.code = amd_msr::kL2FillL3MissResponses.val},
+          "L2 Fill responses except from L3 or different L2 in the same CCX.",
+          "L2 Fill responses except from L3 or different L2 in the same CCX."),
+      std::vector<EventId>({"l2-fill-l3-miss-resp"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
           "l2_fill_dram_resp",
           EventDef::Encoding{.code = amd_msr::kL2FillDramResponses.val},
           "L2 cache fill from all DRAM or MMIO responses.",

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -156,11 +156,24 @@ constexpr PmuMsr kL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0x1f}};
 constexpr PmuMsr kL2PrefetcherMissesInL3{
     .amdCore = {.event = 0x72, .unitMask = 0x1f}};
+
+// L2 Fill Response Source events. Reference:
+// "Performance Monitor Counters for AMD Family 1Ah Model 00h0Fh Processors"
+
+// L2 Fill from all L3 responses, including both L3 hit and L3 miss.
 constexpr PmuMsr kL2FillL3Responses{
     .amdCore = {.event = 0x65, .unitMask = 0xfe, .event_11_8 = 0x1}};
-// L2 Fill from DRAM responses only. Umask bit 01001000
+
+// L2 Fill responses except from L3 or different L2 in the same CCX. This
+// can be used to estimate per-core L3 cache misses.
+constexpr PmuMsr kL2FillL3MissResponses{
+    .amdCore = {.event = 0x65, .unitMask = 0xfc, .event_11_8 = 0x1}};
+
+// L2 Fill from DRAM responses only, with bit 3 and 6 enabled. This can be used
+// to estimate per-core memory bandwidth.
 constexpr PmuMsr kL2FillDramResponses{
     .amdCore = {.event = 0x65, .unitMask = 0x48, .event_11_8 = 0x1}};
+
 // L2 and L1 Prefetcher misses
 constexpr PmuMsr kL1AndL2PrefetcherHitsInL3{
     .amdCore = {.event = 0x71, .unitMask = 0xff}};

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -709,7 +709,23 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
         System::Permissions{},
         std::vector<std::string>{}));
     metrics->add(std::make_shared<MetricDesc>(
-        "l2_cache_fills_dram_reponses",
+        "l2_cache_fills_l3_misses_responses",
+        "L2 Fill responses except from L3 or different L2 in the same CCX.",
+        "L2 Fill responses except from L3 or different L2 in the same CCX."
+        "This event is specific to AMD Zen4 and Zen5 CPUs.",
+        std::map<TOptCpuArch, EventRefs>{
+            {std::nullopt,
+             EventRefs{EventRef{
+                 "l2_fill_l3_miss_resp",
+                 PmuType::cpu,
+                 "l2_fill_l3_miss_resp",
+                 EventExtraAttr{},
+                 {}}}}},
+        100'000'000,
+        System::Permissions{},
+        std::vector<std::string>{}));
+    metrics->add(std::make_shared<MetricDesc>(
+        "l2_cache_fills_dram_responses",
         "L2 cache fill from all DRAM or MMIO responses.",
         "L2 cache fill responses returned from either DRAM or MMIO from the same or different NUMA node.",
         std::map<TOptCpuArch, EventRefs>{


### PR DESCRIPTION
Summary:
In previous iterations, we used umask of 0xfe which includes responses from both L3 cache hits and L3 cache misses. The goal is to estimate L3 cache misses, so we need to exclude bit 1 in the following manual:

https://pxl.cl/80jjV

Differential Revision: D81084870


