### PR TITLE
Apply LICENSELINT to OSS Dynolog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 cmake_minimum_required(VERSION 3.16)
 
 cmake_policy(SET CMP0079 NEW)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Rust project build
 

--- a/cli/src/commands/dcgm.rs
+++ b/cli/src/commands/dcgm.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::net::TcpStream;
 

--- a/cli/src/commands/gputrace.rs
+++ b/cli/src/commands/gputrace.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::net::TcpStream;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // Export all command submodules to be used in main.rs
 // Note: This "intermediate" commands module is purely for organizational purposes.

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::net::TcpStream;
 

--- a/cli/src/commands/utils.rs
+++ b/cli/src/commands/utils.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::io::Read;
 use std::io::Write;

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::net::TcpStream;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 use std::net::TcpStream;
 use std::net::ToSocketAddrs;

--- a/dynolog/CMakeLists.txt
+++ b/dynolog/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(src)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 cmake_minimum_required(VERSION 3.16)
 add_definitions(-DDYNOLOG_VERSION=${DYNOLOG_VERSION} -DDYNOLOG_GIT_REV=${DYNOLOG_GIT_REV})

--- a/dynolog/src/CPUTimeMonitor.cpp
+++ b/dynolog/src/CPUTimeMonitor.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/CPUTimeMonitor.h"
 #include <dynolog/src/metric_frame/MetricFrameTsUnit.h>

--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 
@@ -133,5 +138,3 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
   friend class CPUTimeMonitorTest;
 };
 } // namespace facebook::dynolog
-
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/dynolog/src/CompositeLogger.cpp
+++ b/dynolog/src/CompositeLogger.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/CompositeLogger.h"
 

--- a/dynolog/src/CompositeLogger.h
+++ b/dynolog/src/CompositeLogger.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 #include "dynolog/src/Logger.h"

--- a/dynolog/src/FBRelayLogger.cpp
+++ b/dynolog/src/FBRelayLogger.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/FBRelayLogger.h"
 #include <arpa/inet.h>

--- a/dynolog/src/FBRelayLogger.h
+++ b/dynolog/src/FBRelayLogger.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/KernelCollector.cpp
+++ b/dynolog/src/KernelCollector.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/KernelCollector.h"
 #include <fmt/format.h>

--- a/dynolog/src/KernelCollector.h
+++ b/dynolog/src/KernelCollector.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/KernelCollectorBase.cpp
+++ b/dynolog/src/KernelCollectorBase.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/KernelCollectorBase.h"
 #include <gflags/gflags.h>

--- a/dynolog/src/KernelCollectorBase.h
+++ b/dynolog/src/KernelCollectorBase.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/LibkinetoConfigManager.cpp
+++ b/dynolog/src/LibkinetoConfigManager.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/LibkinetoConfigManager.h"
 #include <fmt/core.h>

--- a/dynolog/src/LibkinetoConfigManager.h
+++ b/dynolog/src/LibkinetoConfigManager.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/LibkinetoTypes.h
+++ b/dynolog/src/LibkinetoTypes.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/Logger.cpp
+++ b/dynolog/src/Logger.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/Logger.h"
 #include <fmt/format.h>

--- a/dynolog/src/Logger.h
+++ b/dynolog/src/Logger.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // Dynolog : A portable telemetry monitoring daemon.
 

--- a/dynolog/src/Metrics.cpp
+++ b/dynolog/src/Metrics.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/Metrics.h"
 

--- a/dynolog/src/Metrics.h
+++ b/dynolog/src/Metrics.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/MonitorBase.h
+++ b/dynolog/src/MonitorBase.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/ODSJsonLogger.cpp
+++ b/dynolog/src/ODSJsonLogger.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/ODSJsonLogger.h"
 #include "hbt/src/common/System.h"

--- a/dynolog/src/ODSJsonLogger.h
+++ b/dynolog/src/ODSJsonLogger.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/PerfMonitor.cpp
+++ b/dynolog/src/PerfMonitor.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/PerfMonitor.h"
 #include <glog/logging.h>

--- a/dynolog/src/PerfMonitor.h
+++ b/dynolog/src/PerfMonitor.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/PrometheusLogger.cpp
+++ b/dynolog/src/PrometheusLogger.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/PrometheusLogger.h"
 #include "dynolog/src/Metrics.h"

--- a/dynolog/src/PrometheusLogger.h
+++ b/dynolog/src/PrometheusLogger.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/ScubaLogger.cpp
+++ b/dynolog/src/ScubaLogger.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/ScubaLogger.h"
 #include <string>

--- a/dynolog/src/ScubaLogger.h
+++ b/dynolog/src/ScubaLogger.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/ServiceHandler.cpp
+++ b/dynolog/src/ServiceHandler.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/ServiceHandler.h"
 #include "dynolog/src/LibkinetoConfigManager.h"

--- a/dynolog/src/ServiceHandler.h
+++ b/dynolog/src/ServiceHandler.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/String.cpp
+++ b/dynolog/src/String.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/String.h"
 

--- a/dynolog/src/String.h
+++ b/dynolog/src/String.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/Ticker.h
+++ b/dynolog/src/Ticker.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/Types.h
+++ b/dynolog/src/Types.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/gpumon/CMakeLists.txt
+++ b/dynolog/src/gpumon/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 add_library(dynolog_dcgm_lib
     DcgmApiStub.cpp DcgmApiStub.h

--- a/dynolog/src/gpumon/DcgmApiStub.cpp
+++ b/dynolog/src/gpumon/DcgmApiStub.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/DcgmApiStub.h"
 #include <dlfcn.h>

--- a/dynolog/src/gpumon/DcgmApiStub.h
+++ b/dynolog/src/gpumon/DcgmApiStub.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/DcgmGroupInfo.h"
 #include <gflags/gflags.h>

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 #include <string.h>

--- a/dynolog/src/gpumon/Entity.cpp
+++ b/dynolog/src/gpumon/Entity.cpp
@@ -1,18 +1,9 @@
-// Portions Copyright (c) Meta Platforms, Inc. and affiliates.
-// Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/Entity.h"
 

--- a/dynolog/src/gpumon/Entity.h
+++ b/dynolog/src/gpumon/Entity.h
@@ -1,19 +1,9 @@
-// Portions Copyright (c) Meta Platforms, Inc. and affiliates.
-// Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// clang format off
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/gpumon/Utils.cpp
+++ b/dynolog/src/gpumon/Utils.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/Utils.h"
 #include <glog/logging.h>

--- a/dynolog/src/gpumon/Utils.h
+++ b/dynolog/src/gpumon/Utils.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/gpumon/amd/AmdDeviceTopology.cpp
+++ b/dynolog/src/gpumon/amd/AmdDeviceTopology.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /*
  * Implementation of AMD GPU device topology parsing.

--- a/dynolog/src/gpumon/amd/AmdDeviceTopology.h
+++ b/dynolog/src/gpumon/amd/AmdDeviceTopology.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/gpumon/amd/RdcWrapper.cpp
+++ b/dynolog/src/gpumon/amd/RdcWrapper.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/amd/RdcWrapper.h"
 

--- a/dynolog/src/gpumon/amd/RdcWrapper.h
+++ b/dynolog/src/gpumon/amd/RdcWrapper.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <cstdint>
 #include <memory>

--- a/dynolog/src/gpumon/dcgm_agent.h
+++ b/dynolog/src/gpumon/dcgm_agent.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+/* @lint-ignore LICENSELINT */
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
  *

--- a/dynolog/src/gpumon/dcgm_api_export.h
+++ b/dynolog/src/gpumon/dcgm_api_export.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+/* @lint-ignore LICENSELINT */
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
  *

--- a/dynolog/src/gpumon/dcgm_errors.h
+++ b/dynolog/src/gpumon/dcgm_errors.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+/* @lint-ignore LICENSELINT */
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
  *

--- a/dynolog/src/gpumon/dcgm_fields.h
+++ b/dynolog/src/gpumon/dcgm_fields.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+/* @lint-ignore LICENSELINT */
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
  *

--- a/dynolog/src/gpumon/dcgm_structs.h
+++ b/dynolog/src/gpumon/dcgm_structs.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+/* @lint-ignore LICENSELINT */
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
  *

--- a/dynolog/src/ipcfabric/CMakeLists.txt
+++ b/dynolog/src/ipcfabric/CMakeLists.txt
@@ -1,3 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 add_library (dynolog_ipcfabric_lib INTERFACE)

--- a/dynolog/src/ipcfabric/Endpoint.h
+++ b/dynolog/src/ipcfabric/Endpoint.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <asm/unistd.h>
 #include <stdlib.h>

--- a/dynolog/src/ipcfabric/FabricManager.h
+++ b/dynolog/src/ipcfabric/FabricManager.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/ipcfabric/Utils.h
+++ b/dynolog/src/ipcfabric/Utils.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/CMakeLists.txt
+++ b/dynolog/src/metric_frame/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 add_library(extra_types STATIC ExtraTypes.h ExtraTypes.cpp)
 add_library(text_table STATIC TextTable.h TextTable.cpp)
 add_library(metric_series STATIC MetricSeries.h)

--- a/dynolog/src/metric_frame/ExtraTypes.cpp
+++ b/dynolog/src/metric_frame/ExtraTypes.cpp
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "dynolog/src/metric_frame/ExtraTypes.h"
 
 namespace facebook::dynolog {

--- a/dynolog/src/metric_frame/ExtraTypes.h
+++ b/dynolog/src/metric_frame/ExtraTypes.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricFrame.cpp
+++ b/dynolog/src/metric_frame/MetricFrame.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/metric_frame/MetricFrame.h"
 #include "dynolog/src/metric_frame/MetricFrameTsUnitInterface.h"

--- a/dynolog/src/metric_frame/MetricFrame.h
+++ b/dynolog/src/metric_frame/MetricFrame.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/metric_frame/MetricFrameBase.h"
 

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/metric_frame/MetricFrameTsUnit.h"
 

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricSeries.h
+++ b/dynolog/src/metric_frame/MetricSeries.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/MetricValues.h
+++ b/dynolog/src/metric_frame/MetricValues.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/metric_frame/TextTable.cpp
+++ b/dynolog/src/metric_frame/TextTable.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/metric_frame/TextTable.h"
 

--- a/dynolog/src/metric_frame/TextTable.h
+++ b/dynolog/src/metric_frame/TextTable.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/procfs/parser/InterruptStatsMonitor.cpp
+++ b/dynolog/src/procfs/parser/InterruptStatsMonitor.cpp
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "dynolog/src/procfs/parser/InterruptStatsMonitor.h"
 
 #include <filesystem>

--- a/dynolog/src/procfs/parser/InterruptStatsMonitor.h
+++ b/dynolog/src/procfs/parser/InterruptStatsMonitor.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rdmamon/CMakeLists.txt
+++ b/dynolog/src/rdmamon/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 file (GLOB dynolog_rdmamon_files "*.h" "*.cpp")
 add_library(dynolog_rdmamon_lib ${dynolog_rdmamon_files})

--- a/dynolog/src/rdmamon/EthtoolCounters.cpp
+++ b/dynolog/src/rdmamon/EthtoolCounters.cpp
@@ -1,4 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/dynolog/src/rdmamon/EthtoolCounters.h
+++ b/dynolog/src/rdmamon/EthtoolCounters.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rdmamon/RdmaCounters.cpp
+++ b/dynolog/src/rdmamon/RdmaCounters.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/rdmamon/RdmaCounters.h"
 #include <fmt/format.h>

--- a/dynolog/src/rdmamon/RdmaCounters.h
+++ b/dynolog/src/rdmamon/RdmaCounters.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rdmamon/RdmaMonitor.cpp
+++ b/dynolog/src/rdmamon/RdmaMonitor.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/rdmamon/RdmaMonitor.h"
 

--- a/dynolog/src/rdmamon/RdmaMonitor.h
+++ b/dynolog/src/rdmamon/RdmaMonitor.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rdmamon/SysfsCounter.cpp
+++ b/dynolog/src/rdmamon/SysfsCounter.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/rdmamon/SysfsCounter.h"
 

--- a/dynolog/src/rdmamon/SysfsCounter.h
+++ b/dynolog/src/rdmamon/SysfsCounter.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rpc/CMakeLists.txt
+++ b/dynolog/src/rpc/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 add_library(dynolog_rpc_lib STATIC
     SimpleJsonServer.cpp SimpleJsonServer.h

--- a/dynolog/src/rpc/SimpleJsonServer.cpp
+++ b/dynolog/src/rpc/SimpleJsonServer.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/rpc/SimpleJsonServer.h"
 #include <arpa/inet.h>

--- a/dynolog/src/rpc/SimpleJsonServer.h
+++ b/dynolog/src/rpc/SimpleJsonServer.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/src/rpc/SimpleJsonServerInl.h
+++ b/dynolog/src/rpc/SimpleJsonServerInl.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <fmt/format.h>
 #include <glog/logging.h>

--- a/dynolog/src/tracing/CMakeLists.txt
+++ b/dynolog/src/tracing/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 add_library (dynolog_ipcmonitor_lib IPCMonitor.cpp IPCMonitor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../LibkinetoConfigManager.h

--- a/dynolog/src/tracing/IPCMonitor.cpp
+++ b/dynolog/src/tracing/IPCMonitor.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/tracing/IPCMonitor.h"
 #include <glog/logging.h>

--- a/dynolog/src/tracing/IPCMonitor.h
+++ b/dynolog/src/tracing/IPCMonitor.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/dynolog/tests/CMakeLists.txt
+++ b/dynolog/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 include(${PROJECT_SOURCE_DIR}/testing/BuildTests.cmake)
 

--- a/dynolog/tests/CPUTimeMonitorTest.cpp
+++ b/dynolog/tests/CPUTimeMonitorTest.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/CPUTimeMonitor.h"
 #include <gtest/gtest.h>

--- a/dynolog/tests/InterruptStatsMonitorTest.cpp
+++ b/dynolog/tests/InterruptStatsMonitorTest.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/procfs/parser/InterruptStatsMonitor.h"
 #include <gtest/gtest.h>

--- a/dynolog/tests/KernelCollecterTest.cpp
+++ b/dynolog/tests/KernelCollecterTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <glog/logging.h>
 #include <gmock/gmock.h>

--- a/dynolog/tests/MonitorTickerTest.cpp
+++ b/dynolog/tests/MonitorTickerTest.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>

--- a/dynolog/tests/PrometheusLoggerTest.cpp
+++ b/dynolog/tests/PrometheusLoggerTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/PrometheusLogger.h"
 #include <fmt/format.h>

--- a/dynolog/tests/StringTest.cpp
+++ b/dynolog/tests/StringTest.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <string>
 #include <vector>

--- a/dynolog/tests/gpumon/amd/AmdDeviceTopologyTest.cpp
+++ b/dynolog/tests/gpumon/amd/AmdDeviceTopologyTest.cpp
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/gpumon/amd/RdcWrapperTest.cpp
+++ b/dynolog/tests/gpumon/amd/RdcWrapperTest.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/gpumon/amd/RdcWrapper.h"
 #include <gtest/gtest.h>

--- a/dynolog/tests/ipcfabric/CMakeLists.txt
+++ b/dynolog/tests/ipcfabric/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 include(${PROJECT_SOURCE_DIR}/tests/BuildTests.cmake)
 

--- a/dynolog/tests/ipcfabric/IPCFabricTest.cpp
+++ b/dynolog/tests/ipcfabric/IPCFabricTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // Use glog for FabricManager.h
 #define USE_GOOGLE_LOG

--- a/dynolog/tests/ipcfabric/IPCSender.cpp
+++ b/dynolog/tests/ipcfabric/IPCSender.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #define USE_GOOGLE_LOG
 #include "dynolog/src/ipcfabric/FabricManager.h"

--- a/dynolog/tests/metric_frame/CMakeLists.txt
+++ b/dynolog/tests/metric_frame/CMakeLists.txt
@@ -1,4 +1,8 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 dynolog_add_test(TextTableTest TextTableTest.cpp)
 target_link_libraries(TextTableTest PRIVATE text_table)
 

--- a/dynolog/tests/metric_frame/MetricFrameTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 #include <chrono>

--- a/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTsUnitTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/metric_frame/MetricSeriesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricSeriesTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/metric_frame/MetricValuesTest.cpp
+++ b/dynolog/tests/metric_frame/MetricValuesTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/metric_frame/TextTableTest.cpp
+++ b/dynolog/tests/metric_frame/TextTableTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/rdmamon/RdmaMonitorTests.cpp
+++ b/dynolog/tests/rdmamon/RdmaMonitorTests.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <unistd.h>
 #include <cstdio>

--- a/dynolog/tests/rdmamon/SysfsCountersTests.cpp
+++ b/dynolog/tests/rdmamon/SysfsCountersTests.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gtest/gtest.h>
 

--- a/dynolog/tests/rpc/CMakeLists.txt
+++ b/dynolog/tests/rpc/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 add_executable(json_client SimpleJsonClientTestCLI.cpp SimpleJsonClientTest.h)
 

--- a/dynolog/tests/rpc/SimpleJsonClientTest.cpp
+++ b/dynolog/tests/rpc/SimpleJsonClientTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/tests/rpc/SimpleJsonClientTest.h"
 #include <glog/logging.h>

--- a/dynolog/tests/rpc/SimpleJsonClientTest.h
+++ b/dynolog/tests/rpc/SimpleJsonClientTest.h
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <arpa/inet.h>
 #include <glog/logging.h>

--- a/dynolog/tests/rpc/SimpleJsonClientTestCLI.cpp
+++ b/dynolog/tests/rpc/SimpleJsonClientTestCLI.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/dynolog/tests/tracing/CMakeLists.txt
+++ b/dynolog/tests/tracing/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 dynolog_add_test(IPCMonitorTest IPCMonitorTest.cpp)
 

--- a/dynolog/tests/tracing/IPCMonitorTest.cpp
+++ b/dynolog/tests/tracing/IPCMonitorTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "dynolog/src/tracing/IPCMonitor.h"
 #include <gtest/gtest.h>

--- a/scripts/pytorch/xor.py
+++ b/scripts/pytorch/xor.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import torch
 import torch.nn as nn
 import torch.optim as optim


### PR DESCRIPTION
Summary: We received an alert that we are failing to meeting OSS requirements due to missing or incorrect headers. I found out that we actually have LICENSELINT (https://www.internalfb.com/wiki/Linting/License_Lint/) that can automatically fix the headers and should help catching this issue at diff time in the future.

Differential Revision: D81940929
