### PR TITLE
add latest() function

### DIFF
--- a/dynolog/src/metric_frame/MetricFrameBase.cpp
+++ b/dynolog/src/metric_frame/MetricFrameBase.cpp
@@ -54,6 +54,14 @@ std::optional<MetricFrameSlice> MetricFrameBase::slice(
   return MetricFrameSlice(*this, rangeMaybe.value());
 }
 
+std::optional<MetricFrameSlice> MetricFrameBase::latest() const {
+  auto rangeMaybe = ts_->getLatest();
+  if (!rangeMaybe.has_value()) {
+    return std::nullopt;
+  }
+  return MetricFrameSlice(*this, ts_->getLatest().value());
+}
+
 template <bool flag = false>
 void unknown_type_assert() {
   static_assert(flag, "type provided to add samples is not supported");

--- a/dynolog/src/metric_frame/MetricFrameBase.h
+++ b/dynolog/src/metric_frame/MetricFrameBase.h
@@ -50,6 +50,8 @@ class MetricFrameBase {
       TimePoint endTime,
       MATCH_POLICY startTimePolicy = MATCH_POLICY::CLOSEST,
       MATCH_POLICY endTimePolicy = MATCH_POLICY::CLOSEST) const;
+  // this returns a slice only containing the latest sample regardless of time
+  std::optional<MetricFrameSlice> latest() const;
   virtual size_t width() const = 0;
   virtual std::optional<MetricSeriesVar> series(
       const std::string& name) const = 0;

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.cpp
@@ -57,6 +57,22 @@ size_t MetricFrameTsUnit::maxLength() const {
   return timeSeries_.maxLength();
 }
 
+std::optional<MetricFrameRange> MetricFrameTsUnit::getLatest() const {
+  if (timeSeries_.size() == 0) {
+    return std::nullopt;
+  }
+  return MetricFrameRange{
+      .start =
+          MetricFrameOffset{
+              .offset = timeSeries_.size() - 1,
+              .time = *(timeSeries_.end() - 1)},
+      .end =
+          MetricFrameOffset{
+              .offset = timeSeries_.size() - 1,
+              .time = *(timeSeries_.end() - 1)},
+  };
+}
+
 std::optional<MetricFrameRange> MetricFrameTsUnit::getRange(
     TimePoint startTime,
     TimePoint endTime,
@@ -82,6 +98,7 @@ std::optional<MetricFrameOffset> MetricFrameTsUnit::findMatchingOffset(
     case MATCH_POLICY::NEXT_CLOSEST:
       return nextClosestPolicy(time);
   }
+  return std::nullopt;
 }
 
 std::optional<MetricFrameOffset> MetricFrameTsUnit::closestPolicy(
@@ -167,6 +184,19 @@ size_t MetricFrameTsUnitFixInterval::length() const {
 
 size_t MetricFrameTsUnitFixInterval::maxLength() const {
   return frameLength_;
+}
+
+std::optional<MetricFrameRange> MetricFrameTsUnitFixInterval::getLatest()
+    const {
+  if (sampleCount_ == 0) {
+    return std::nullopt;
+  }
+  return MetricFrameRange{
+      .start =
+          MetricFrameOffset{
+              .offset = sampleCount_ - 1, .time = lastSampleTime_},
+      .end = MetricFrameOffset{
+          .offset = sampleCount_ - 1, .time = lastSampleTime_}};
 }
 
 std::optional<MetricFrameRange> MetricFrameTsUnitFixInterval::getRange(

--- a/dynolog/src/metric_frame/MetricFrameTsUnit.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnit.h
@@ -23,6 +23,7 @@ class MetricFrameTsUnit : public MetricFrameTsUnitInterface {
   std::vector<TimePoint> getTimeVector() const override;
   size_t length() const override;
   size_t maxLength() const override;
+  std::optional<MetricFrameRange> getLatest() const override;
   std::optional<MetricFrameRange> getRange(
       TimePoint startTime,
       TimePoint endTime,
@@ -51,6 +52,7 @@ class MetricFrameTsUnitFixInterval : public MetricFrameTsUnitInterface {
   std::vector<TimePoint> getTimeVector() const override;
   size_t length() const override;
   size_t maxLength() const override;
+  std::optional<MetricFrameRange> getLatest() const override;
   std::optional<MetricFrameRange> getRange(
       TimePoint startTime,
       TimePoint endTime,

--- a/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
+++ b/dynolog/src/metric_frame/MetricFrameTsUnitInterface.h
@@ -41,6 +41,7 @@ class MetricFrameTsUnitInterface {
   virtual std::vector<TimePoint> getTimeVector() const = 0;
   virtual size_t length() const = 0;
   virtual size_t maxLength() const = 0;
+  virtual std::optional<MetricFrameRange> getLatest() const = 0;
   virtual std::optional<MetricFrameRange> getRange(
       TimePoint startTime,
       TimePoint endTime,

--- a/dynolog/tests/metric_frame/MetricFrameTest.cpp
+++ b/dynolog/tests/metric_frame/MetricFrameTest.cpp
@@ -111,6 +111,12 @@ TEST(MetricSeriesSliceTest, metricFrameMapSmokeTest) {
   EXPECT_EQ(frameMap.firstSampleTime().value(), now + 60s);
   EXPECT_EQ(frameMap.lastSampleTime().value(), now + 600s);
 
+  auto latestSlice = frameMap.latest();
+  ASSERT_TRUE(latestSlice.has_value());
+  EXPECT_EQ(latestSlice->length(), 1);
+  EXPECT_EQ(latestSlice->duration(), 0s);
+  EXPECT_EQ(latestSlice->series<int64_t>("metric1")->raw()[0], 52);
+
   ASSERT_TRUE(frameMap.slice(now + 100s, now + 400s).has_value());
   auto frameSlice = frameMap.slice(now + 100s, now + 400s).value();
 
@@ -195,6 +201,12 @@ TEST(MetricSeriesSliceTest, metricFrameVectorSmokeTest) {
   EXPECT_EQ(frameVector.maxLength(), 10);
   EXPECT_EQ(frameVector.firstSampleTime().value(), now + 60s);
   EXPECT_EQ(frameVector.lastSampleTime().value(), now + 600s);
+
+  auto latestSlice = frameVector.latest();
+  ASSERT_TRUE(latestSlice.has_value());
+  EXPECT_EQ(latestSlice->length(), 1);
+  EXPECT_EQ(latestSlice->duration(), 0s);
+  EXPECT_EQ(latestSlice->series<int64_t>(0)->raw()[0], 52);
 
   ASSERT_TRUE(frameVector.slice(now + 100s, now + 400s).has_value());
   auto frameSlice = frameVector.slice(now + 100s, now + 400s).value();


### PR DESCRIPTION
Summary:
add latest() interface to MetricFrame

this will return either a slice that only contain the last sample if there is any sample, or nullopt if MetricFrame is empty.

Reviewed By: bigzachattack

Differential Revision: D81509114


