### PR TITLE
use tw host shared bpffs mount as default thread-bperf pinned directory

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -21,8 +21,8 @@ namespace facebook::hbt::perf_event {
 
 class BPerfEventsGroup {
  public:
-  static std::string perThreadArrayMapPath(const std::string& n);
-  static std::string perThreadIndexMapPath(const std::string& n);
+  static std::string perThreadArrayMapFileName(const std::string& n);
+  static std::string perThreadIndexMapFileName(const std::string& n);
 
   using ReadValues = GroupReadValues<mode::Counting>;
   ///
@@ -31,13 +31,15 @@ class BPerfEventsGroup {
       const EventConfs& confs,
       int cgroup_update_level,
       bool support_per_thread = false,
-      const std::string& pin_name = "");
+      const std::string& pin_name = "",
+      const std::filesystem::path& bpf_pinned_map_dir = "/sys/fs/bpf/");
   BPerfEventsGroup(
       const MetricDesc& metric,
       const PmuDeviceManager& pmu_manager,
       int cgroup_update_level,
       bool support_per_thread = false,
-      const std::string& pin_name = "");
+      const std::string& pin_name = "",
+      const std::filesystem::path& bpf_pinned_map_dir = "/sys/fs/bpf/");
 
   ~BPerfEventsGroup();
 
@@ -142,6 +144,7 @@ class BPerfEventsGroup {
   // For per thread monitoring
   bool per_thread_;
   const std::string pin_name_;
+  const std::filesystem::path bpf_pinned_map_dir_;
 
   int pinThreadMaps_(bperf_leader_cgroup* skel);
   int preparePerThreadBPerf_(bperf_leader_cgroup* skel);

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -23,7 +23,10 @@ struct BPerfThreadData {
 
 class BPerfPerThreadReader {
  public:
-  BPerfPerThreadReader(std::string pin_name, int event_cnt);
+  BPerfPerThreadReader(
+      std::string pin_name,
+      const std::vector<std::filesystem::path>& bpf_pinned_map_dirs,
+      int event_cnt);
   ~BPerfPerThreadReader();
   int read(struct BPerfThreadData* data);
   int enable();
@@ -41,6 +44,7 @@ class BPerfPerThreadReader {
   struct bperf_perf_event_data* event_data_[BPERF_MAX_GROUP_SIZE] = {nullptr};
   int data_fd_ = -1;
   const std::string pin_name_;
+  const std::vector<std::filesystem::path> bpf_pinned_map_dirs_;
   __s64 initial_clock_drift_ = 0;
   int event_cnt_ = -1;
   int data_size_ = 0;

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -75,7 +75,7 @@ int cgroup_update_level = 0;
 
 static __always_inline __u64 event_prev_count(struct perf_event *event) {
   /*
-   * X86 perf event counter is fixed to be 48 bits (x86_pmu.cntval_bits). 
+   * X86 perf event counter is fixed to be 48 bits (x86_pmu.cntval_bits).
    * arch/x86/events/core.c?lines=121
    * TODO: verify this for aarch64 architecture
    */
@@ -147,7 +147,7 @@ static void update_task_output(struct bpf_perf_event_value* diff_val, struct tas
     return;
 
   /* if next is not NULL
-   * update_task_output is called during a context switch 
+   * update_task_output is called during a context switch
    */
   next_data = get_bperf_thread_data(next->pid);
   if (!next_data)

--- a/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
@@ -20,8 +20,10 @@ using namespace facebook::hbt::perf_event;
 namespace {
 
 std::shared_ptr<BPerfPerThreadReader> createReader(void) {
-  auto reader = std::make_shared<BPerfPerThreadReader>("cycles", 1);
-  auto second_reader = std::make_shared<BPerfPerThreadReader>("cycles", 1);
+  std::vector<std::filesystem::path> paths = {"/sys/fs/bpf/"};
+  auto reader = std::make_shared<BPerfPerThreadReader>("cycles", paths, 1);
+  auto second_reader =
+      std::make_shared<BPerfPerThreadReader>("cycles", paths, 1);
 
   EXPECT_EQ(reader->enable(), 0);
   // second_read will fail to enable
@@ -277,7 +279,8 @@ std::atomic<int> failed = 0;
 
 // A even simpler workload just for verifying we can create enough readers
 void emptyReaderThread() {
-  auto reader = std::make_shared<BPerfPerThreadReader>("cycles", 1);
+  std::vector<std::filesystem::path> paths = {"/sys/fs/bpf/"};
+  auto reader = std::make_shared<BPerfPerThreadReader>("cycles", paths, 1);
   int res = reader->enable();
   if (res != 0) {
     failed += 1;


### PR DESCRIPTION
Summary:
- change the pinned directory to be /run/wds/shared_bpf so per-thread bperf maps can be shared into tw container

- give unprivileged user read/write permission to register itself in thread-level bperf

- make BPerfPerThreadReader search both /sys/fs/bpf/ and  /run/wds/shared_bpf so process inside or outside tw container can access per-thread bperf bpf maps

Differential Revision: D82951552


