### PR TITLE
Modifying the flow to capture the IPC channel

### DIFF
--- a/dynolog/src/LibkinetoConfigManager.h
+++ b/dynolog/src/LibkinetoConfigManager.h
@@ -40,7 +40,8 @@ class LibkinetoConfigManager {
   std::string obtainOnDemandConfig(
       const std::string& jobId,
       const std::vector<int32_t>& pids,
-      int32_t configType);
+      int32_t configType,
+      const std::string& category = "ipc");
 
   GpuProfilerResult setOnDemandConfig(
       const std::string& jobId,

--- a/dynolog/src/LibkinetoJobRegistry.h
+++ b/dynolog/src/LibkinetoJobRegistry.h
@@ -24,6 +24,7 @@ struct LibkinetoProcess {
   std::string eventProfilerConfig;
   std::string activityProfilerConfig;
   std::chrono::time_point<std::chrono::system_clock> lastRequestTime;
+  std::string pid_ipc_channel_used; // IPC channel used ("ipc" or "thrift")
 };
 
 // Shared singleton registry for tracking libkineto processes across jobs

--- a/dynolog/src/LibkinetoTypes.h
+++ b/dynolog/src/LibkinetoTypes.h
@@ -25,6 +25,7 @@ struct GpuProfilerResult {
   std::vector<int32_t> activityProfilersTriggered;
   int32_t eventProfilersBusy;
   int32_t activityProfilersBusy;
+  bool manifoldChromeTrace;
 };
 
 } // namespace dynolog


### PR DESCRIPTION
Summary:
We added a few modifications to the code where the registration code for ondemand can idenitify the IPC channel that the Kineto process used. This information is then added to profiler results to provide clients like Dyno CLI a good signal to indicate if a given trace generated by on-demand tracing will have been uploaded to Manifold.

OSS pytorch running on Mast like Conda on Mast will have this set to false indicating that the kineto runtime in those workloads does not have the manifold driver to upload files to object storage.

Differential Revision: D86722300


