### PR TITLE
Add AMD software prefetch metrics to ODS (#529)

### DIFF
--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -133,6 +133,9 @@ constexpr PmuMsr kLsAnyFillsFromSysDramIoFar{
     .amdCore = {.event = 0x44, .unitMask = 0x40}};
 constexpr PmuMsr kLsSwPfDcFillsDramIoFar{
     .amdCore = {.event = 0x59, .unitMask = 0x40}};
+constexpr PmuMsr kLsSwPfDcFillsAll{
+    .amdCore = {.event = 0x59, .unitMask = 0xdf}};
+constexpr PmuMsr kLsInefSwPref{.amdCore = {.event = 0x52, .unitMask = 0x3}};
 constexpr PmuMsr kLsHwPfDcFillsDramIoFar{
     .amdCore = {.event = 0x5a, .unitMask = 0x40}};
 


### PR DESCRIPTION
Summary:

Add two new AMD software prefetch metrics exported as raw counts:
- sw_prefetch_total: total SW prefetch DC fills from all sources (PMCx059, mask 0xdf)
- inefficient_sw_prefetch: ineffective SW prefetches that hit DC or MAB (PMCx052, mask 0x3)

Changes:
- Add kLsSwPfDcFillsAll (0x59/0xdf) and kLsInefSwPref (0x52/0x3) events in AmdEvents.h
- Add kCounterGroupSwPrefetchTotal and kCounterGroupInefficientSwPrefetch counter groups
- Bump MAX_AMD_CORE_PERF_COUNTER_GROUPS from 41 to 43
- Implement getSwPrefetchTotal and getInefficientSwPrefetch in CorePcmAmd
- Wire both metrics to ODS in Updater.cpp
- Add 7 unit tests

Differential Revision: D99178726
