### PR TITLE
add enabled field in per thread metatdata for indicating bpf prog will stop (#530)

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -498,7 +498,7 @@ int BPerfEventsGroup::preparePerThreadBPerf_(bperf_leader_cgroup* skel) {
   metadata->thread_data_size = sizeof(struct bperf_thread_data);
   metadata->event_data_size = sizeof(struct bperf_perf_event_data);
   metadata->event_cnt = skel->rodata->event_cnt;
-  metadata->flags = 0;
+  metadata->flags = BPERF_FLAG_ENABLED;
 
   err = ::bpf_map__update_elem(
       skel->maps.per_thread_data,
@@ -820,6 +820,8 @@ error:
 }
 
 void BPerfEventsGroup::cleanupLinks() {
+  // stop register/unregister first to prevent new readers and
+  // avoid other modifiers of the bpf map
   if (register_thread_link_) {
     bpf_link__unpin(register_thread_link_);
     register_thread_link_ = nullptr;
@@ -828,6 +830,9 @@ void BPerfEventsGroup::cleanupLinks() {
     bpf_link__unpin(unregister_thread_link_);
     unregister_thread_link_ = nullptr;
   }
+
+  disablePerThreadMetadata(pin_name_, bpf_pinned_map_dir_);
+
   if (pmu_enable_exit_link_) {
     bpf_link__unpin(pmu_enable_exit_link_);
     pmu_enable_exit_link_ = nullptr;
@@ -841,12 +846,38 @@ void BPerfEventsGroup::cleanupLinks() {
   this->close();
 }
 
+void BPerfEventsGroup::disablePerThreadMetadata(
+    const std::string& pin_name,
+    const std::filesystem::path& bpf_pinned_map_dir) {
+  auto path = bpf_pinned_map_dir /
+      BPerfEventsGroup::perThreadArrayMapFileName(pin_name);
+  int map_fd = ::bpf_obj_get(path.c_str());
+  if (map_fd < 0) {
+    return;
+  }
+  int zero = 0;
+  char buf[BPERF_MAX_THREAD_DATA_SIZE] = {};
+  auto* metadata = reinterpret_cast<struct bperf_thread_metadata*>(buf);
+  if (::bpf_map_lookup_elem(map_fd, &zero, buf) == 0) {
+    metadata->flags &= ~BPERF_FLAG_ENABLED;
+    if (::bpf_map_update_elem(map_fd, &zero, buf, BPF_ANY)) {
+      HBT_LOG_WARNING() << "failed to disable per-thread metadata";
+    }
+  }
+  ::close(map_fd);
+}
+
 void BPerfEventsGroup::cleanupPinnedLinks(
     const std::string& pin_name,
     const std::filesystem::path& bpf_pinned_map_dir) {
+  // unlink register/unregister first to prevent new readers and
+  // avoid other modifiers of the bpf map
   ::unlink((bpf_pinned_map_dir / makePinPath(kRegisterLink, pin_name)).c_str());
   ::unlink(
       (bpf_pinned_map_dir / makePinPath(kUnregisterLink, pin_name)).c_str());
+
+  disablePerThreadMetadata(pin_name, bpf_pinned_map_dir);
+
   ::unlink(
       (bpf_pinned_map_dir / makePinPath(kPmuEnableExit, pin_name)).c_str());
   ::unlink(

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -66,7 +66,12 @@ class BPerfEventsGroup {
   // it will be called when we want to explicitly cleanup thread-level BPerf on
   // this host
   void cleanupLinks();
-  // Removes pinned BPF links from bpffs for the given pin_name in the
+  // sets the enabled field in per-thread metadata to 0, notifying
+  // BPerfPerThreadReader that per-thread BPerf data is no longer being updated.
+  static void disablePerThreadMetadata(
+      const std::string& pin_name,
+      const std::filesystem::path& bpf_pinned_map_dir);
+  // removes pinned BPF links from bpffs for the given pin_name in the
   // specified pinned map directory.
   static void cleanupPinnedLinks(
       const std::string& pin_name,

--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -114,6 +114,12 @@ int BPerfPerThreadReader::enable() {
     goto error;
   }
 
+  if (!isLeaderRunning_()) {
+    HBT_LOG_ERROR() << "per-thread bperf leader program is no longer running, "
+                    << "BPERF_FLAG_ENABLED is not set in metadata flags";
+    goto error;
+  }
+
   metadata = (struct bperf_thread_metadata*)mmap_ptr_;
 
   ::close(tid_fd);
@@ -207,6 +213,11 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
     return -1;
   }
 
+  if (!isLeaderRunning_()) {
+    disable();
+    return -1;
+  }
+
   do {
     lock = data_->lock;
     barrier();
@@ -232,9 +243,6 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
   data->cpuTime =
       raw_thread_data.runtime_until_offset_update + time_after_offset_update;
 
-  // TODO: Detect when the lead program stops. It is a bit tricky, as
-  //       it may look like current thread is always running.
-  //       This will be easier once with some perf event.
   for (i = 0; i < event_cnt_; i++) {
     data->values[i] = raw_event_data[i].output_value;
     data->values[i].enabled += time_after_offset_update;
@@ -262,6 +270,14 @@ bool BPerfPerThreadReader::leadExited(__u64 counter_zero) {
   ret = counter_zero == prev_counter_zero_;
   prev_counter_zero_ = counter_zero;
   return ret;
+}
+
+bool BPerfPerThreadReader::isLeaderRunning_() {
+  if (!mmap_ptr_) {
+    return false;
+  }
+  auto* metadata = (struct bperf_thread_metadata*)mmap_ptr_;
+  return metadata->flags & BPERF_FLAG_ENABLED;
 }
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -60,6 +60,8 @@ class BPerfPerThreadReader {
   // Previous reading of event 0, used to detect when the lead exits
   __u64 prev_counter_zero_;
   bool leadExited(__u64 counter_zero);
+  // check if the bpf program supporting per-thread bperf is still running
+  bool isLeaderRunning_();
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -48,6 +48,11 @@ struct bperf_thread_metadata {
   __u32 thread_data_size; /* sizeof(bperf_thread_data) */
   __u32 event_data_size; /* sizeof(bperf_perf_event_data) */
   __u32 event_cnt;
+  /* notifies BPerfPerThreadReader that the BPF programs supporting per-thread
+   * BPerf event updates have been stopped. When disabled, the values in the
+   * per-thread BPF map are no longer being updated and should not be trusted.
+   */
+#define BPERF_FLAG_ENABLED (1 << 0)
   __u32 flags;
 };
 
@@ -71,6 +76,10 @@ struct bperf_thread_data {
 
   struct bperf_perf_event_data events[];
 };
+
+#define BPERF_MAX_THREAD_DATA_SIZE    \
+  (sizeof(struct bperf_thread_data) + \
+   sizeof(struct bperf_perf_event_data) * BPERF_MAX_GROUP_SIZE)
 
 inline int bperf_roundup(int size, int align) {
   return (size + align - 1) / align * align;

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -264,8 +264,6 @@ struct {
   __type(value, idx_t);
 } per_thread_idx SEC(".maps");
 
-#define BPERF_MAX_THREAD_DATA_SIZE (sizeof(struct bperf_thread_data) + \
-                                    sizeof(struct bperf_perf_event_data) * BPERF_MAX_GROUP_SIZE)
 struct {
   __uint(type, BPF_MAP_TYPE_ARRAY);
   __uint(key_size, sizeof(int));


### PR DESCRIPTION
Summary:

This change adds a mechanism for BPerfEventsGroup to signal to BPerfPerThreadReader that the BPF programs supporting per-thread hardware counter updates have been stopped, so the reader knows its data is stale.

Reviewed By: liu-song-6

Differential Revision: D100034708
