### PR TITLE
Fix clang-diagnostic-unused-parameter in SimpleJsonServer.h

### DIFF
--- a/dynolog/src/rpc/SimpleJsonServer.h
+++ b/dynolog/src/rpc/SimpleJsonServer.h
@@ -50,7 +50,7 @@ class SimpleJsonServerBase {
   void loop() noexcept;
 
   // implement processing of request using the handler
-  virtual std::string processOneImpl(const std::string& request_str) {
+  virtual std::string processOneImpl(const std::string& /* request_str */) {
     return "";
   }
 


### PR DESCRIPTION
Summary:
## Summary:
Comment out unused parameter name `request_str` in the virtual base class method `processOneImpl` in `SimpleJsonServerBase`. This is a default implementation that returns an empty string — derived classes override it and use the parameter. Commenting out the name preserves API documentation while fixing the warning.

Reviewed By: yaoz08

Differential Revision: D100543302


