### PR TITLE
Add ARM TopDown Level 1 slot-based TMA metrics to ODS (#533)

### DIFF
--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -133,6 +133,9 @@ constexpr PmuMsr kLsAnyFillsFromSysDramIoFar{
     .amdCore = {.event = 0x44, .unitMask = 0x40}};
 constexpr PmuMsr kLsSwPfDcFillsDramIoFar{
     .amdCore = {.event = 0x59, .unitMask = 0x40}};
+constexpr PmuMsr kLsSwPfDcFillsAll{
+    .amdCore = {.event = 0x59, .unitMask = 0xdf}};
+constexpr PmuMsr kLsInefSwPref{.amdCore = {.event = 0x52, .unitMask = 0x3}};
 constexpr PmuMsr kLsHwPfDcFillsDramIoFar{
     .amdCore = {.event = 0x5a, .unitMask = 0x40}};
 

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -2790,6 +2790,58 @@ void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics) {
           100'000'000,
           System::Permissions{},
           std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_STALL_FRONTEND",
+          "Frontend stalled cycles",
+          "Counts cycles where no operation is dispatched because the "
+          "frontend could not deliver an instruction. ARMv8 architectural "
+          "event STALL_FRONTEND (0x0023).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "stall_frontend",
+                   PmuType::armv8_pmuv3,
+                   "stall_frontend",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "stall_frontend",
+                   PmuType::armv8_pmuv3,
+                   "stall_frontend",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_STALL_BACKEND",
+          "Backend stalled cycles",
+          "Counts cycles where no operation is dispatched because the "
+          "backend is unable to accept operations. ARMv8 architectural "
+          "event STALL_BACKEND (0x0024).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "stall_backend",
+                   PmuType::armv8_pmuv3,
+                   "stall_backend",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "stall_backend",
+                   PmuType::armv8_pmuv3,
+                   "stall_backend",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
 }
 
 void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics) {

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -2842,6 +2842,107 @@ void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics) {
           100'000'000,
           System::Permissions{},
           std::vector<std::string>{}));
+
+  // ARM TopDown Level 1 slot-based events
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_OP_RETIRED",
+          "Operations architecturally executed",
+          "Counts micro-operations that are architecturally executed. "
+          "ARMv8 PMU event OP_RETIRED (0x003A).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "op_retired",
+                   PmuType::armv8_pmuv3,
+                   "op_retired",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "op_retired",
+                   PmuType::armv8_pmuv3,
+                   "op_retired",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_OP_SPEC",
+          "Operations speculatively executed",
+          "Counts micro-operations that are speculatively executed. "
+          "ARMv8 PMU event OP_SPEC (0x003B).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "op_spec",
+                   PmuType::armv8_pmuv3,
+                   "op_spec",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "op_spec",
+                   PmuType::armv8_pmuv3,
+                   "op_spec",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_STALL_SLOT_FRONTEND",
+          "Slot stalled due to frontend",
+          "Counts pipeline slots not used because the frontend could not "
+          "deliver an operation. ARMv8 PMU event STALL_SLOT_FRONTEND (0x003E).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "stall_slot_frontend",
+                   PmuType::armv8_pmuv3,
+                   "stall_slot_frontend",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "stall_slot_frontend",
+                   PmuType::armv8_pmuv3,
+                   "stall_slot_frontend",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_STALL_SLOT_BACKEND",
+          "Slot stalled due to backend",
+          "Counts pipeline slots not used because the backend could not "
+          "accept an operation. ARMv8 PMU event STALL_SLOT_BACKEND (0x003D).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "stall_slot_backend",
+                   PmuType::armv8_pmuv3,
+                   "stall_slot_backend",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "stall_slot_backend",
+                   PmuType::armv8_pmuv3,
+                   "stall_slot_backend",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
 }
 
 void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics) {


### PR DESCRIPTION
Summary:

Add ARM TopDown Level 1 metrics using slot-based PMU events (OP_RETIRED,
OP_SPEC, STALL_SLOT_FRONTEND, STALL_SLOT_BACKEND) for Neoverse V2/V3.

Metrics use per-dispatch-slot percentage formulas consistent with AMD TMA:
- frontend_stalls_per_dispatch_slot_pct = STALL_SLOT_FRONTEND / (PipelineWidth * CPU_CYCLES) * 100
- backend_stalls_per_dispatch_slot_pct = STALL_SLOT_BACKEND / (PipelineWidth * CPU_CYCLES) * 100
- bad_speculation_per_dispatch_slot_pct = (OP_SPEC - OP_RETIRED) / (PipelineWidth * CPU_CYCLES) * 100
- retiring_per_dispatch_slot_pct = OP_RETIRED / (PipelineWidth * CPU_CYCLES) * 100

Pipeline width = 8 for Neoverse V2
Pipeline width = 10 for Neoverse V3

Reviewed By: yaoz08

Differential Revision: D99747476


