### PR TITLE
Add ARM V3 software prefetch metrics to ODS (#535)

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -2947,6 +2947,43 @@ void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics) {
           100'000'000,
           System::Permissions{},
           std::vector<std::string>{}));
+
+  // ARM software prefetch events (Neoverse V3 only)
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_PRF_SPEC",
+          "Software prefetch instructions speculatively executed",
+          "Counts software prefetch instructions (PRFM) that are "
+          "speculatively executed. ARMv8 PMU event PRF_SPEC (0x1020).",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "prf_spec",
+                   PmuType::armv8_pmuv3,
+                   "prf_spec",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_L1D_CACHE_REFILL_PRFM",
+          "L1D cache refills caused by software prefetch",
+          "Counts L1D cache refills caused by software prefetch instructions. "
+          "ARMv8 PMU event L1D_CACHE_REFILL_PRFM.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "l1d_cache_refill_prfm",
+                   PmuType::armv8_pmuv3,
+                   "l1d_cache_refill_prfm",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
 }
 
 void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics) {


### PR DESCRIPTION
Summary:

Add software prefetch metrics for ARM Neoverse V3 using PMU events PRF_SPEC and L1D_CACHE_REFILL_PRFM.

Two new ODS metrics:
- sw_prefetch_total: total software prefetch instructions (PRF_SPEC, raw count per interval)
- inefficient_sw_prefetch: wasted prefetches, computed as PRF_SPEC - L1D_CACHE_REFILL_PRFM

Efficient prefetches are those that caused an L1D cache refill (brought new data into L1). Everything else is wasted: either squashed by speculation (never committed) or redundant (data was already in L1D cache).

**These counters only exist on Neoverse V3 (not V2).**

Reviewed By: yaoz08

Differential Revision: D101218002


