### PR TITLE
Add opentelemetry-cpp dependency for OTLP export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = third_party/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git
 	branch = v1.0.2
+[submodule "third_party/opentelemetry-cpp"]
+	path = third_party/opentelemetry-cpp
+	url = https://github.com/open-telemetry/opentelemetry-cpp.git
+	branch = v1.21.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if(USE_PROMETHEUS)
   find_package(prometheus-cpp CONFIG REQUIRED)
 endif()
 
+option(USE_OTEL "Enable OTLP export via OpenTelemetry, requires
+libprotobuf-dev and libcurl4-openssl-dev on the system"
+OFF)
+
 file(READ "version.txt" DYNOLOG_VERSION)
 string(STRIP ${DYNOLOG_VERSION} DYNOLOG_VERSION)
 
@@ -75,6 +79,21 @@ target_link_libraries(dynolog_lib PUBLIC gflags::gflags)
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 add_subdirectory(third_party/json)
 target_link_libraries(dynolog_lib PUBLIC nlohmann_json::nlohmann_json)
+
+# OTel add_subdirectory placed after third_party/json so that
+# opentelemetry-cpp detects the existing nlohmann_json target
+# and after CMAKE_CXX_STANDARD is set.
+if(USE_OTEL)
+  set(WITH_OTLP_HTTP ON CACHE BOOL "")
+  set(WITH_OTLP_GRPC OFF CACHE BOOL "")
+  set(WITH_OTLP_FILE OFF CACHE BOOL "")
+  set(WITH_EXAMPLES OFF CACHE BOOL "")
+  set(BUILD_TESTING OFF CACHE BOOL "")
+  set(WITH_BENCHMARK OFF CACHE BOOL "")
+  set(WITH_PROMETHEUS OFF CACHE BOOL "")
+  set(OTELCPP_MAINTAINER_MODE OFF CACHE BOOL "")
+  add_subdirectory(third_party/opentelemetry-cpp)
+endif()
 
 add_subdirectory(third_party/pfs)
 target_include_directories(dynolog_lib PUBLIC third_party/pfs/include)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -28,6 +28,15 @@ if(USE_PROMETHEUS)
   target_link_libraries(dynolog_lib PRIVATE prometheus-cpp::pull)
 endif()
 
+if(USE_OTEL)
+  target_compile_definitions(dynolog_lib PRIVATE USE_OTEL)
+  target_link_libraries(dynolog_lib PRIVATE
+    opentelemetry_api
+    opentelemetry_sdk
+    opentelemetry_exporter_otlp_http_log
+    opentelemetry_logs)
+endif()
+
 target_link_libraries(dynolog_lib PUBLIC Monitor)
 target_link_libraries(dynolog_lib PUBLIC BuiltinMetrics)
 target_link_libraries(dynolog_lib PUBLIC metric_frame)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,12 +36,34 @@ then
   popd
 fi
 
+## Build with OpenTelemetry if enabled
+BUILD_OTEL="${BUILD_OTEL:-0}"
+USE_OTEL="OFF"
+if [ "${BUILD_OTEL}" -eq 1 ]; then
+  if ! pkg-config --exists protobuf 2>/dev/null; then
+    echo "Error: protobuf not found. Install with:"
+    echo "  apt-get install libprotobuf-dev protobuf-compiler  # Debian/Ubuntu"
+    echo "  dnf install protobuf-devel protobuf-compiler       # Fedora/RHEL"
+    exit 1
+  fi
+  if ! pkg-config --exists libcurl 2>/dev/null; then
+    echo "Error: libcurl not found. Install with:"
+    echo "  apt-get install libcurl4-openssl-dev               # Debian/Ubuntu"
+    echo "  dnf install libcurl-devel                          # Fedora/RHEL"
+    exit 1
+  fi
+  pushd ./third_party/opentelemetry-cpp
+  git submodule init && git submodule update
+  popd
+  USE_OTEL="ON"
+fi
+
 ## Build dynolog
 echo "Running cmake"
 mkdir -p build; cd build;
 
 # note we can build without ninja if not available on this system
-cmake "-DUSE_PROMETHEUS=${USE_PROMETHEUS}" \
+cmake "-DUSE_PROMETHEUS=${USE_PROMETHEUS}" "-DUSE_OTEL=${USE_OTEL}" \
   -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 

--- a/third_party/opentelemetry-cpp.submodule.txt
+++ b/third_party/opentelemetry-cpp.submodule.txt
@@ -1,0 +1,1 @@
+Subproject commit placeholder


### PR DESCRIPTION
Summary:
Add opentelemetry-cpp v1.21.0 as a dependency for both OSS (CMake) and internal (Buck) builds, gated by USE_OTEL.

OSS (CMake): git submodule + add_subdirectory() — the same pattern dynolog uses for glog, fmt, json, and other deps. Unlike prometheus-cpp (which is hostile to add_subdirectory due to global CMAKE_CXX_STANDARD overrides and bundled googletest conflicts), opentelemetry-cpp cleanly supports embedding. Transitive deps (protobuf, curl) are system prerequisites installed via apt/dnf, following the Apache Arrow approach.

Internal (Buck): deps on fbsource//third-party/opentelemetry-cpp:{api,sdk,exporters} added to the liblogger target with manual annotations. opentelemetry-cpp v1.21.0 is already vendored in fbsource.

Build with: BUILD_OTEL=1 ./scripts/build.sh

Reviewed By: tooji

Differential Revision: D101375025


