### PR TITLE
Add DCGM standalone mode support for K8s deployment

### DIFF
--- a/dynolog/src/gpumon/DcgmApiStub.cpp
+++ b/dynolog/src/gpumon/DcgmApiStub.cpp
@@ -89,6 +89,9 @@ struct dcgmApi {
       void* userData);
   dcgmReturn_t (*dcgmShutdown)(){};
   dcgmReturn_t (*dcgmStopEmbedded)(dcgmHandle_t pDcgmHandle);
+  dcgmReturn_t (
+      *dcgmConnect)(const char* ipAddress, dcgmHandle_t* pDcgmHandle){};
+  dcgmReturn_t (*dcgmDisconnect)(dcgmHandle_t pDcgmHandle){};
   dcgmReturn_t (*dcgmProfGetSupportedMetricGroups)(
       dcgmHandle_t pDcgmHandle,
       dcgmProfGetMetricGroups_t* metricGroups);
@@ -185,6 +188,8 @@ dcgmApi* getDcgmAPI() {
     SETAPI(dcgmGetLatestValues_v2);
     SETAPI(dcgmShutdown);
     SETAPI(dcgmStopEmbedded);
+    SETAPI(dcgmConnect);
+    SETAPI(dcgmDisconnect);
     SETAPI(dcgmProfGetSupportedMetricGroups);
     if (api.dcgm_major_version < 3) {
       SETAPI(dcgmProfWatchFields);
@@ -367,6 +372,24 @@ dcgmReturn_t dcgmShutdown_stub() {
 dcgmReturn_t dcgmStopEmbedded_stub(dcgmHandle_t pDcgmHandle) {
   if (auto api = detail::getDcgmAPI(); api) {
     return api->dcgmStopEmbedded(pDcgmHandle);
+  }
+  log_missing_api(__func__);
+  return DCGM_ST_LIBRARY_NOT_FOUND;
+}
+
+dcgmReturn_t dcgmConnect_stub(
+    const char* ipAddress,
+    dcgmHandle_t* pDcgmHandle) {
+  if (auto api = detail::getDcgmAPI(); api) {
+    return api->dcgmConnect(ipAddress, pDcgmHandle);
+  }
+  log_missing_api(__func__);
+  return DCGM_ST_LIBRARY_NOT_FOUND;
+}
+
+dcgmReturn_t dcgmDisconnect_stub(dcgmHandle_t pDcgmHandle) {
+  if (auto api = detail::getDcgmAPI(); api) {
+    return api->dcgmDisconnect(pDcgmHandle);
   }
   log_missing_api(__func__);
   return DCGM_ST_LIBRARY_NOT_FOUND;

--- a/dynolog/src/gpumon/DcgmApiStub.h
+++ b/dynolog/src/gpumon/DcgmApiStub.h
@@ -177,6 +177,22 @@ dcgmReturn_t dcgmStartEmbedded_stub(
     dcgmHandle_t* pDcgmHandle);
 
 /**
+ * Connect to a stand-alone host engine process (nv-hostengine).
+ *
+ * @param ipAddress    IN: IP address with optional port (e.g.,
+ * "localhost:5555")
+ * @param pDcgmHandle OUT: DCGM Handle of the remote host engine
+ */
+dcgmReturn_t dcgmConnect_stub(const char* ipAddress, dcgmHandle_t* pDcgmHandle);
+
+/**
+ * Disconnect from a stand-alone host engine.
+ *
+ * @param pDcgmHandle IN: DCGM Handle from dcgmConnect
+ */
+dcgmReturn_t dcgmDisconnect_stub(dcgmHandle_t pDcgmHandle);
+
+/**
  * Request that DCGM start recording updates for a given field collection.
  *
  * Note that the first update of the field will not occur until the next field

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -27,6 +27,12 @@ DEFINE_string(
     kDcgmDefaultFieldIds,
     "The field ids to monitor on DCGM (GPUs), comma separated");
 
+DEFINE_string(
+    dcgm_standalone_address,
+    "",
+    "Connect to a standalone DCGM hostengine at this address "
+    "(e.g., localhost:5555). When empty, starts an embedded hostengine.");
+
 constexpr double maxKeepAgeSec = 2;
 constexpr int maxKeepSamples = 2;
 const std::string groupName = "DcgmGroupInfo";
@@ -149,12 +155,32 @@ void DcgmGroupInfo::init() {
   if (retCode_ = dcgmInit_stub(); retCode_ != DCGM_ST_OK) {
     errorCode_ = retCode_;
     LOG(ERROR) << "Failed to init dcgm, dcgmInit() returned: " << retCode_;
+    return;
   }
 
-  if (retCode_ = dcgmStartEmbedded_stub(DCGM_OPERATION_MODE_AUTO, &dcgmHandle_);
-      retCode_ != DCGM_ST_OK) {
-    errorCode_ = retCode_;
-    LOG(ERROR) << "Failed dcgmStartEmbedded() return: " << retCode_;
+  if (!FLAGS_dcgm_standalone_address.empty()) {
+    // Standalone mode: connect to an existing nv-hostengine
+    standaloneMode_ = true;
+    LOG(INFO) << "Connecting to standalone DCGM hostengine at "
+              << FLAGS_dcgm_standalone_address;
+    if (retCode_ = dcgmConnect_stub(
+            FLAGS_dcgm_standalone_address.c_str(), &dcgmHandle_);
+        retCode_ != DCGM_ST_OK) {
+      errorCode_ = retCode_;
+      LOG(ERROR) << "Failed dcgmConnect() to " << FLAGS_dcgm_standalone_address
+                 << ", return: " << retCode_;
+    } else {
+      LOG(INFO) << "Connected to standalone DCGM hostengine";
+    }
+  } else {
+    // Embedded mode: start an in-process hostengine
+    standaloneMode_ = false;
+    if (retCode_ =
+            dcgmStartEmbedded_stub(DCGM_OPERATION_MODE_AUTO, &dcgmHandle_);
+        retCode_ != DCGM_ST_OK) {
+      errorCode_ = retCode_;
+      LOG(ERROR) << "Failed dcgmStartEmbedded() return: " << retCode_;
+    }
   }
 }
 
@@ -440,11 +466,20 @@ DcgmGroupInfo::~DcgmGroupInfo() {
   } else {
     LOG(INFO) << "Destroyed group " << groupId_;
   }
-  if (retCode_ = dcgmStopEmbedded_stub(dcgmHandle_); retCode_ != DCGM_ST_OK) {
-    errorCode_ = retCode_;
-    LOG(ERROR) << "Failed dcgmStopEmbedded() return: " << retCode_;
+  if (standaloneMode_) {
+    if (retCode_ = dcgmDisconnect_stub(dcgmHandle_); retCode_ != DCGM_ST_OK) {
+      errorCode_ = retCode_;
+      LOG(ERROR) << "Failed dcgmDisconnect() return: " << retCode_;
+    } else {
+      LOG(INFO) << "Disconnected from standalone hostengine";
+    }
   } else {
-    LOG(INFO) << "Stopped embedded mode";
+    if (retCode_ = dcgmStopEmbedded_stub(dcgmHandle_); retCode_ != DCGM_ST_OK) {
+      errorCode_ = retCode_;
+      LOG(ERROR) << "Failed dcgmStopEmbedded() return: " << retCode_;
+    } else {
+      LOG(INFO) << "Stopped embedded mode";
+    }
   }
   if (retCode_ = dcgmShutdown_stub(); retCode_ != DCGM_ST_OK) {
     errorCode_ = retCode_;

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -61,6 +61,7 @@ class DcgmGroupInfo {
       1; // Default to 1, will be set to 0 when DCGM_INT64_BLANK is detected
   int deviceCount_ = 0;
   bool profEnabled_ = false;
+  bool standaloneMode_ = false;
   int updateIntervalMs_;
   dcgmReturn_t errorCode_{DCGM_ST_OK};
   dcgmReturn_t retCode_{DCGM_ST_OK};


### PR DESCRIPTION
Summary:
Add dcgmConnect/dcgmDisconnect support to dynolog DCGM API stub layer,
allowing dynolog to connect to an existing nv-hostengine instead of starting
an embedded one. This avoids profiling counter conflicts when running alongside
dcgm-exporter on K8s GPU nodes.

New flag: --dcgm_standalone_address (e.g., "localhost:5555")
When set, dynolog connects to the remote hostengine via dcgmConnect().
When empty (default), preserves existing embedded mode behavior.

Changes:
- DcgmApiStub.h/cpp: Add dcgmConnect_stub() and dcgmDisconnect_stub() wrappers,
  load dcgmConnect/dcgmDisconnect symbols via dlsym
- DcgmGroupInfo.h/cpp: Add --dcgm_standalone_address gflag, branch init() between
  dcgmConnect (standalone) and dcgmStartEmbedded (embedded), update destructor to
  call dcgmDisconnect vs dcgmStopEmbedded based on mode

Reviewed By: tooji

Differential Revision: D101063670


