### PR TITLE
Add Intel SPR/EMR TMA metrics to ODS (#539)

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -3260,6 +3260,83 @@ void addIntelCoreMetrics(std::shared_ptr<Metrics>& metrics) {
           100'000'000,
           System::Permissions{},
           std::vector<std::string>{}));
+
+  // Intel TOPDOWN fixed counters (SPR/EMR only)
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_TOPDOWN_SLOTS",
+          "Total pipeline slots available",
+          "Counts total pipeline slots available per cycle. "
+          "Uses the TOPDOWN.SLOTS fixed counter on SPR/EMR.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::SPR,
+               EventRefs{EventRef{
+                   "topdown_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.SLOTS",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::EMR,
+               EventRefs{EventRef{
+                   "topdown_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.SLOTS",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_TOPDOWN_BACKEND_BOUND_SLOTS",
+          "Pipeline slots stalled due to backend",
+          "Counts pipeline slots wasted because the backend could not "
+          "accept micro-ops. Uses TOPDOWN.BACKEND_BOUND_SLOTS on SPR/EMR.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::SPR,
+               EventRefs{EventRef{
+                   "topdown_backend_bound_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.BACKEND_BOUND_SLOTS",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::EMR,
+               EventRefs{EventRef{
+                   "topdown_backend_bound_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.BACKEND_BOUND_SLOTS",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_TOPDOWN_BAD_SPEC_SLOTS",
+          "Pipeline slots wasted due to bad speculation",
+          "Counts pipeline slots wasted due to incorrect speculation "
+          "(branch mispredictions, machine clears). Uses "
+          "TOPDOWN.BAD_SPEC_SLOTS on SPR/EMR.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::SPR,
+               EventRefs{EventRef{
+                   "topdown_bad_spec_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.BAD_SPEC_SLOTS",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::EMR,
+               EventRefs{EventRef{
+                   "topdown_bad_spec_slots",
+                   PmuType::cpu,
+                   "TOPDOWN.BAD_SPEC_SLOTS",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
 }
 
 void addUncoreMetrics([[maybe_unused]] std::shared_ptr<Metrics>& metrics) {

--- a/hbt/src/perf_event/json_events/generated/intel/emeraldrapids_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/emeraldrapids_core.cpp
@@ -77,7 +77,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.SLOTS",
@@ -90,7 +90,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -1176,7 +1175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event SW_PREFETCH_ACCESS.ANY is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "SW_PREFETCH_ACCESS.ANY",
@@ -1189,7 +1188,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -1971,7 +1969,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.BACKEND_BOUND_SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.BACKEND_BOUND_SLOTS",
@@ -1984,9 +1982,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.BAD_SPEC_SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.BAD_SPEC_SLOTS",
@@ -1999,7 +1996,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(

--- a/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
+++ b/hbt/src/perf_event/json_events/generated/intel/sapphirerapids_core.cpp
@@ -77,7 +77,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::nullopt // Errata
       ));
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.SLOTS",
@@ -90,7 +90,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -1176,7 +1175,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event SW_PREFETCH_ACCESS.ANY is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "SW_PREFETCH_ACCESS.ANY",
@@ -1189,7 +1188,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(
@@ -1971,7 +1969,7 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       ));
 #endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.BACKEND_BOUND_SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.BACKEND_BOUND_SLOTS",
@@ -1984,9 +1982,8 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
-#ifdef HBT_ADD_ALL_GENERATED_EVENTS
+  // Event TOPDOWN.BAD_SPEC_SLOTS is allowlisted
   pmu_manager.addEvent(std::make_shared<EventDef>(
       PmuType::cpu,
       "TOPDOWN.BAD_SPEC_SLOTS",
@@ -1999,7 +1996,6 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       EventDef::IntelFeatures{},
       std::nullopt // Errata
       ));
-#endif // HBT_ADD_ALL_GENERATED_EVENTS
 
 #ifdef HBT_ADD_ALL_GENERATED_EVENTS
   pmu_manager.addEvent(std::make_shared<EventDef>(


### PR DESCRIPTION
Summary:

Add TopDown Microarchitecture Analysis metrics for Intel hosts

TMA Level 1 formulas per Intel TMA methodology:
- backend_stalls_per_dispatch_slot_pct = TOPDOWN_BE_BOUND.ALL / TOPDOWN.SLOTS
- retiring_per_dispatch_slot_pct = UOPS_RETIRED.SLOTS / TOPDOWN.SLOTS
- bad_speculation_per_dispatch_slot_pct = TOPDOWN_BAD_SPEC.ALL / TOPDOWN.SLOTS
- frontend_stalls_per_dispatch_slot_pct = 100 - backend - bad_spec - retiring

Reviewed By: yaoz08

Differential Revision: D99750282


