### PR TITLE
Implement configurable OtlpLogger with GPU name collection

### DIFF
--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -28,6 +28,9 @@
 #ifdef USE_PROMETHEUS
 #include "dynolog/src/PrometheusLogger.h"
 #endif
+#ifdef USE_OTEL
+#include "dynolog/src/OtlpLogger.h"
+#endif
 
 using namespace dynolog;
 using json = nlohmann::json;
@@ -41,6 +44,12 @@ DEFINE_bool(use_prometheus, false, "Emit metrics to Prometheus");
 DEFINE_bool(use_fbrelay, false, "Emit metrics to FB Relay on Lab machines");
 DEFINE_bool(use_ODS, false, "Emit metrics to ODS through ODS logger");
 DEFINE_bool(use_scuba, false, "Emit metrics to Scuba through Scuba logger");
+#ifdef USE_OTEL
+DEFINE_bool(
+    use_otel,
+    false,
+    "Emit metrics via OTLP to an OpenTelemetry collector");
+#endif
 DEFINE_int32(
     kernel_monitor_reporting_interval_s,
     60,
@@ -82,6 +91,11 @@ std::unique_ptr<Logger> getLogger(const std::string& scribe_category = "") {
   if (FLAGS_use_scuba && !scribe_category.empty()) {
     loggers.push_back(std::make_unique<ScubaLogger>(scribe_category));
   }
+#ifdef USE_OTEL
+  if (FLAGS_use_otel) {
+    loggers.push_back(std::make_unique<OtlpLogger>());
+  }
+#endif
   return std::make_unique<CompositeLogger>(std::move(loggers));
 }
 

--- a/dynolog/src/OtlpLogger.cpp
+++ b/dynolog/src/OtlpLogger.cpp
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/OtlpLogger.h"
+
+#ifdef USE_OTEL
+
+#include <opentelemetry/exporters/otlp/otlp_http_log_record_exporter_factory.h>
+#include <opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h>
+#include <opentelemetry/sdk/logs/batch_log_record_processor_factory.h>
+#include <opentelemetry/sdk/logs/batch_log_record_processor_options.h>
+#include <opentelemetry/sdk/logs/logger_provider_factory.h>
+#include <opentelemetry/sdk/resource/resource.h>
+
+#include <glog/logging.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+
+namespace logs_sdk = opentelemetry::v1::sdk::logs;
+namespace otlp = opentelemetry::v1::exporter::otlp;
+namespace resource = opentelemetry::v1::sdk::resource;
+
+DEFINE_string(
+    otel_endpoint,
+    "http://localhost:4318",
+    "OTLP HTTP endpoint for OpenTelemetry export");
+
+DEFINE_string(
+    otel_resource_env_file,
+    "",
+    "Path to a KEY=VALUE file with additional OTLP resource attributes "
+    "(keys are lowercased before being set). "
+    "Empty means disabled.");
+
+DEFINE_string(
+    otel_resource_attrs,
+    "",
+    "Comma-separated KEY=VALUE pairs to set as OTLP resource attributes. "
+    "These are set in addition to host_name.");
+
+DEFINE_string(
+    otel_metric_mappings_file,
+    "",
+    "Path to a CSV file defining DCGM metric name mappings. Each line is:\n"
+    "  dcgm_name,output_name,scale_factor   (numeric metrics)\n"
+    "  dcgm_name,output_name                (string metrics, no scale)\n"
+    "When empty, built-in default mappings are used (pass-through).");
+
+namespace dynolog {
+
+namespace {
+
+// Parse the metric mappings file. Returns true if file was loaded.
+// Populates numeric_mappings (3-field lines) and string_mappings (2-field
+// lines).
+bool loadMappingsFile(
+    const std::string& path,
+    std::unordered_map<std::string, MetricMapping>& numeric_mappings,
+    std::unordered_map<std::string, std::string>& string_mappings) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    LOG(WARNING) << "Could not open otel_metric_mappings_file: " << path;
+    return false;
+  }
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+    // Split on commas: dcgm_name,output_name[,scale_factor]
+    std::stringstream ss(line);
+    std::string dcgm_name, output_name, scale_str;
+    if (!std::getline(ss, dcgm_name, ',') ||
+        !std::getline(ss, output_name, ',')) {
+      continue;
+    }
+    if (std::getline(ss, scale_str, ',') && !scale_str.empty()) {
+      try {
+        double scale = std::stod(scale_str);
+        numeric_mappings[dcgm_name] = {output_name, scale};
+      } catch (const std::exception&) {
+        LOG(WARNING) << "Invalid scale in mappings file: " << line;
+      }
+    } else {
+      string_mappings[dcgm_name] = output_name;
+    }
+  }
+  LOG(INFO) << "Loaded " << numeric_mappings.size() << " numeric and "
+            << string_mappings.size() << " string metric mappings from "
+            << path;
+  return true;
+}
+
+} // namespace
+
+const std::unordered_map<std::string, std::string>& getStringMappings() {
+  static const auto mappings = [] {
+    std::unordered_map<std::string, std::string> m;
+    if (!FLAGS_otel_metric_mappings_file.empty()) {
+      std::unordered_map<std::string, MetricMapping> unused;
+      loadMappingsFile(FLAGS_otel_metric_mappings_file, unused, m);
+    }
+    // Default: pass-through (no renaming) when no file is provided.
+    return m;
+  }();
+  return mappings;
+}
+
+const std::unordered_map<std::string, MetricMapping>& getMetricMappings() {
+  static const auto mappings = [] {
+    std::unordered_map<std::string, MetricMapping> m;
+    if (!FLAGS_otel_metric_mappings_file.empty()) {
+      std::unordered_map<std::string, std::string> unused;
+      loadMappingsFile(FLAGS_otel_metric_mappings_file, m, unused);
+    }
+    // Default: pass-through (no renaming) when no file is provided.
+    return m;
+  }();
+  return mappings;
+}
+
+OtlpManager::OtlpManager() {
+  std::string endpoint = FLAGS_otel_endpoint;
+  const char* env_endpoint = std::getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  if (env_endpoint) {
+    endpoint = env_endpoint;
+  }
+  // Strip trailing slash to avoid double-slash in URL
+  if (!endpoint.empty() && endpoint.back() == '/') {
+    endpoint.pop_back();
+  }
+
+  otlp::OtlpHttpLogRecordExporterOptions exporter_opts;
+  exporter_opts.url = endpoint + "/v1/logs";
+  exporter_opts.content_type = otlp::HttpRequestContentType::kBinary;
+  exporter_opts.ssl_insecure_skip_verify = true;
+  auto exporter = otlp::OtlpHttpLogRecordExporterFactory::Create(exporter_opts);
+
+  logs_sdk::BatchLogRecordProcessorOptions processor_opts;
+  processor_opts.max_queue_size = 2048;
+  processor_opts.schedule_delay_millis = std::chrono::milliseconds(5000);
+  processor_opts.max_export_batch_size = 512;
+  auto processor = logs_sdk::BatchLogRecordProcessorFactory::Create(
+      std::move(exporter), processor_opts);
+
+  // Resolve hostname: prefer K8S_NODE_NAME env var (Downward API) over
+  // gethostname() which returns the pod name in containerized environments.
+  std::string hostname;
+  const char* node_name = std::getenv("K8S_NODE_NAME");
+  if (node_name && node_name[0] != '\0') {
+    hostname = node_name;
+  } else {
+    char hostbuf[256];
+    if (::gethostname(hostbuf, sizeof(hostbuf)) == 0) {
+      hostbuf[sizeof(hostbuf) - 1] = '\0';
+      hostname = hostbuf;
+    } else {
+      hostname = "unknown";
+    }
+  }
+
+  // Build resource attributes: start with built-in attrs, then layer on
+  // --otel_resource_attrs (flag), then --otel_resource_env_file (file).
+  // Later sources can override earlier ones.
+  auto resource_attrs = resource::ResourceAttributes{
+      {"service.name", "dynolog"},
+      {"host_name", hostname},
+  };
+
+  // Helper: lowercase a string for attribute key normalization.
+  auto toLower = [](std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+  };
+
+  // Parse --otel_resource_attrs flag (comma-separated KEY=VALUE pairs).
+  if (!FLAGS_otel_resource_attrs.empty()) {
+    std::stringstream ss(FLAGS_otel_resource_attrs);
+    std::string pair;
+    while (std::getline(ss, pair, ',')) {
+      auto pos = pair.find('=');
+      if (pos != std::string::npos && pos + 1 <= pair.size()) {
+        resource_attrs.SetAttribute(
+            toLower(pair.substr(0, pos)), pair.substr(pos + 1));
+      }
+    }
+  }
+
+  // Parse --otel_resource_env_file (KEY=VALUE lines, one per line).
+  // Typically written by an init container that reads platform-specific
+  // metadata (e.g., K8s node labels). Keys are lowercased.
+  if (!FLAGS_otel_resource_env_file.empty()) {
+    std::ifstream meta_file(FLAGS_otel_resource_env_file);
+    if (meta_file.is_open()) {
+      std::string line;
+      while (std::getline(meta_file, line)) {
+        auto pos = line.find('=');
+        if (pos != std::string::npos && pos + 1 <= line.size()) {
+          auto val = line.substr(pos + 1);
+          if (!val.empty()) {
+            resource_attrs.SetAttribute(toLower(line.substr(0, pos)), val);
+          }
+        }
+      }
+    } else {
+      LOG(WARNING) << "Could not open otel_resource_env_file: "
+                   << FLAGS_otel_resource_env_file;
+    }
+  }
+
+  auto res = resource::Resource::Create(resource_attrs);
+
+  provider_ =
+      logs_sdk::LoggerProviderFactory::Create(std::move(processor), res);
+  logger_ = provider_->GetLogger("dynolog", "dynolog", "1.0.0");
+
+  LOG(INFO) << "OTel OTLP logger initialized, endpoint=" << exporter_opts.url
+            << ", host_name=" << hostname;
+  for (const auto& [key, val] : res.GetAttributes()) {
+    // val is opentelemetry::sdk::common::OwnedAttributeValue
+    if (auto* s = std::get_if<std::string>(&val)) {
+      LOG(INFO) << "  resource attr: " << key << "=" << *s;
+    }
+  }
+}
+
+OtlpManager::~OtlpManager() {
+  if (provider_) {
+    provider_->ForceFlush();
+    provider_->Shutdown();
+  }
+}
+
+// static
+std::shared_ptr<OtlpManager> OtlpManager::singleton() {
+  static auto manager = std::make_shared<OtlpManager>();
+  return manager;
+}
+
+void OtlpManager::emitLog(
+    Logger::Timestamp ts,
+    const std::unordered_map<std::string, double>& numeric_attrs,
+    const std::unordered_map<std::string, int64_t>& int_attrs,
+    const std::unordered_map<std::string, std::string>& string_attrs) {
+  if (!logger_) {
+    return;
+  }
+
+  auto record = logger_->CreateLogRecord();
+  if (!record) {
+    return;
+  }
+
+  record->SetTimestamp(opentelemetry::common::SystemTimestamp(ts));
+
+  for (const auto& [key, val] : numeric_attrs) {
+    record->SetAttribute(key, val);
+  }
+  for (const auto& [key, val] : int_attrs) {
+    record->SetAttribute(key, val);
+  }
+  for (const auto& [key, val] : string_attrs) {
+    record->SetAttribute(key, val);
+  }
+
+  logger_->EmitLogRecord(std::move(record));
+}
+
+void OtlpLogger::setTimestamp(Timestamp ts) {
+  ts_ = ts;
+}
+
+void OtlpLogger::logInt(const std::string& key, int64_t val) {
+  int_kvs_[key] = val;
+}
+
+void OtlpLogger::logFloat(const std::string& key, float val) {
+  float_kvs_[key] = static_cast<double>(val);
+}
+
+void OtlpLogger::logUint(const std::string& key, uint64_t val) {
+  int_kvs_[key] = static_cast<int64_t>(val);
+}
+
+void OtlpLogger::logStr(const std::string& key, const std::string& val) {
+  string_kvs_[key] = val;
+}
+
+void OtlpLogger::finalize() {
+  const auto& mappings = getMetricMappings();
+
+  std::unordered_map<std::string, double> mapped_floats;
+  std::unordered_map<std::string, int64_t> mapped_ints;
+
+  for (const auto& [key, val] : float_kvs_) {
+    auto it = mappings.find(key);
+    if (it != mappings.end()) {
+      mapped_floats[it->second.output_name] = val * it->second.scale_factor;
+    } else {
+      mapped_floats[key] = val;
+    }
+  }
+
+  for (const auto& [key, val] : int_kvs_) {
+    auto it = mappings.find(key);
+    if (it != mappings.end()) {
+      mapped_ints[it->second.output_name] =
+          static_cast<int64_t>(val * it->second.scale_factor);
+    } else {
+      mapped_ints[key] = val;
+    }
+  }
+
+  // Apply string key mappings.
+  const auto& str_mappings = getStringMappings();
+  std::unordered_map<std::string, std::string> mapped_strings;
+  for (const auto& [key, val] : string_kvs_) {
+    auto it = str_mappings.find(key);
+    if (it != str_mappings.end()) {
+      mapped_strings[it->second] = val;
+    } else {
+      mapped_strings[key] = val;
+    }
+  }
+
+  OtlpManager::singleton()->emitLog(
+      ts_, mapped_floats, mapped_ints, mapped_strings);
+
+  float_kvs_.clear();
+  int_kvs_.clear();
+  string_kvs_.clear();
+}
+
+} // namespace dynolog
+#endif // USE_OTEL

--- a/dynolog/src/OtlpLogger.h
+++ b/dynolog/src/OtlpLogger.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "dynolog/src/Logger.h"
+
+#ifdef USE_OTEL
+
+#include <opentelemetry/logs/provider.h>
+#include <opentelemetry/sdk/logs/logger_provider.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+DECLARE_string(otel_endpoint);
+DECLARE_string(otel_resource_env_file);
+DECLARE_string(otel_resource_attrs);
+DECLARE_string(otel_metric_mappings_file);
+
+namespace dynolog {
+
+// Holds a metric name mapping with optional scale factor.
+struct MetricMapping {
+  std::string output_name;
+  double scale_factor{}; // 1.0 = pass-through, 100.0 = percentage conversion
+};
+
+// Returns the DCGM -> output name mapping tables (loaded from
+// --otel_metric_mappings_file, or empty if not configured).
+const std::unordered_map<std::string, MetricMapping>& getMetricMappings();
+const std::unordered_map<std::string, std::string>& getStringMappings();
+
+// Singleton that owns the OTel SDK stack:
+// LoggerProvider -> BatchLogRecordProcessor -> OtlpHttpLogRecordExporter
+class OtlpManager {
+ public:
+  OtlpManager();
+  ~OtlpManager();
+  OtlpManager(const OtlpManager&) = delete;
+  OtlpManager& operator=(const OtlpManager&) = delete;
+  OtlpManager(OtlpManager&&) = delete;
+  OtlpManager& operator=(OtlpManager&&) = delete;
+
+  void emitLog(
+      Logger::Timestamp ts,
+      const std::unordered_map<std::string, double>& numeric_attrs,
+      const std::unordered_map<std::string, int64_t>& int_attrs,
+      const std::unordered_map<std::string, std::string>& string_attrs);
+
+  static std::shared_ptr<OtlpManager> singleton();
+
+ private:
+  opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> logger_;
+  std::shared_ptr<opentelemetry::sdk::logs::LoggerProvider> provider_;
+};
+
+// Per-cycle logger that buffers metrics and emits one LogRecord per finalize().
+// Each LogRecord represents one GPU device snapshot.
+class OtlpLogger : public Logger {
+ public:
+  OtlpLogger() = default;
+
+  void setTimestamp(Timestamp ts) override;
+  void logInt(const std::string& key, int64_t val) override;
+  void logFloat(const std::string& key, float val) override;
+  void logUint(const std::string& key, uint64_t val) override;
+  void logStr(const std::string& key, const std::string& val) override;
+  void finalize() override;
+
+ private:
+  Timestamp ts_;
+  std::unordered_map<std::string, double> float_kvs_;
+  std::unordered_map<std::string, int64_t> int_kvs_;
+  std::unordered_map<std::string, std::string> string_kvs_;
+
+  friend class OtlpLoggerTest_ScaleTransformBuffering_Test;
+  friend class OtlpLoggerTest_StringMappingAppliedOnFinalize_Test;
+  friend class OtlpLoggerTest_EmptyMetrics_Test;
+  friend class OtlpLoggerTest_UnmappedMetricsPassThrough_Test;
+  friend class OtlpLoggerTest_MultipleFinalizeCycles_Test;
+  friend class OtlpLoggerTest_IntPreservation_Test;
+};
+
+} // namespace dynolog
+#endif // USE_OTEL

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -56,7 +56,8 @@ std::unordered_map<unsigned short, std::string> FieldIdToName{
     {DCGM_FI_DEV_MINOR_NUMBER, "minor_id"},
     {DCGM_FI_DEV_GPU_UTIL, "gpu_device_utilization"},
     {DCGM_FI_DEV_MEM_COPY_UTIL, "gpu_memory_utilization"},
-    {DCGM_FI_DEV_POWER_USAGE, "gpu_power_draw"}};
+    {DCGM_FI_DEV_POWER_USAGE, "gpu_power_draw"},
+    {DCGM_FI_DEV_NAME, "gpu_name"}};
 
 // Mapping of attribution environment variable name to scuba column name
 std::unordered_map<std::string, std::string> attributionEnvVarsToScubaColumns{
@@ -316,11 +317,13 @@ void DcgmGroupInfo::update() {
       LOG(INFO) << "Got " << dcgmValues.size() << " GPU records";
       metricsMapDouble_.clear();
       metricsMapInt_.clear();
+      metricsMapString_.clear();
       for (auto& [entity, readValues] : dcgmValues) {
         LOG(INFO) << "Got " << readValues.size()
                   << " values for entity: " << entity;
         std::unordered_map<std::string, double> metricsDouble;
         std::unordered_map<std::string, int64_t> metricsInt;
+        std::unordered_map<std::string, std::string> metricsString;
         // sample invalid caused by DCGM bug
         // field failed at query stage will have DCGM_*_BLANK value
         bool blank_value_field = false;
@@ -348,6 +351,8 @@ void DcgmGroupInfo::update() {
                 blank_value_field = true;
               }
               metricsInt[FieldIdToName[v.fieldId]] = v.value.i64;
+            } else if (v.fieldType == 's') {
+              metricsString[FieldIdToName[v.fieldId]] = v.value.str;
             }
           }
         }
@@ -355,6 +360,7 @@ void DcgmGroupInfo::update() {
         rpcStatus_ = blank_value_field ? 0 : 1;
         metricsMapDouble_[entity.m_entityId] = metricsDouble;
         metricsMapInt_[entity.m_entityId] = metricsInt;
+        metricsMapString_[entity.m_entityId] = metricsString;
       }
 
       if (FLAGS_enable_env_var_attribution) {
@@ -393,6 +399,11 @@ void DcgmGroupInfo::log(Logger& logger) {
     }
     if (envMetadataMapString_.find(index) != envMetadataMapString_.end()) {
       for (const auto& [key, val] : envMetadataMapString_[index]) {
+        logger.logStr(key, val);
+      }
+    }
+    if (metricsMapString_.find(index) != metricsMapString_.end()) {
+      for (const auto& [key, val] : metricsMapString_[index]) {
         logger.logStr(key, val);
       }
     }

--- a/dynolog/src/gpumon/DcgmGroupInfo.h
+++ b/dynolog/src/gpumon/DcgmGroupInfo.h
@@ -20,7 +20,7 @@ namespace dynolog::gpumon {
 DECLARE_string(dcgm_fields);
 
 constexpr char kDcgmDefaultFieldIds[] =
-    "100,155,204,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012";
+    "50,100,155,204,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012";
 class DcgmGroupInfo {
  public:
   ~DcgmGroupInfo();
@@ -76,6 +76,8 @@ class DcgmGroupInfo {
   // and their values for the pid running on that gpu (if it exists).
   std::unordered_map<int, std::unordered_map<std::string, std::string>>
       envMetadataMapString_;
+  std::unordered_map<int, std::unordered_map<std::string, std::string>>
+      metricsMapString_;
   std::vector<dcgmFieldGrp_t> fieldGroupIds_;
   std::mutex profLock_;
   std::chrono::seconds profPauseTimer_;

--- a/dynolog/tests/OtlpLoggerTest.cpp
+++ b/dynolog/tests/OtlpLoggerTest.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#ifndef USE_OTEL
+
+TEST(OtlpLoggerTest, Disabled) {
+  GTEST_SKIP() << "USE_OTEL not defined";
+}
+
+#else
+#include "dynolog/src/OtlpLogger.h"
+
+#include <cstdio>
+#include <fstream>
+
+namespace dynolog {
+
+// Write a temporary mappings file and set the flag before the static
+// initializers in getMetricMappings()/getStringMappings() run.
+// This fixture must be used for all tests that depend on mappings.
+class OtlpLoggerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // Create a temp mappings file with a representative subset.
+    tmpFile_ = std::tmpnam(nullptr);
+    std::ofstream f(tmpFile_);
+    f << "# Test mappings\n";
+    f << "gpu_device_utilization,accelerator_utilization,100.0\n";
+    f << "gpu_frequency_mhz,compute_unit_frequency_mhz,1.0\n";
+    f << "sm_active_ratio,compute_unit_utilization,100.0\n";
+    f << "gpu_power_draw,accelerator_power_usage_w,1.0\n";
+    f << "device,device_id,1.0\n";
+    f << "gpu_name,accelerator_model\n";
+    f.close();
+    FLAGS_otel_metric_mappings_file = tmpFile_;
+  }
+
+  static void TearDownTestSuite() {
+    std::remove(tmpFile_.c_str());
+  }
+
+  static std::string tmpFile_;
+};
+
+std::string OtlpLoggerTest::tmpFile_;
+
+TEST_F(OtlpLoggerTest, NumericMappingsLoadedFromFile) {
+  const auto& mappings = getMetricMappings();
+
+  // Verify mappings loaded from file.
+  EXPECT_EQ(mappings.size(), 5u);
+
+  auto it = mappings.find("gpu_device_utilization");
+  ASSERT_NE(it, mappings.end());
+  EXPECT_EQ(it->second.output_name, "accelerator_utilization");
+  EXPECT_DOUBLE_EQ(it->second.scale_factor, 100.0);
+
+  it = mappings.find("gpu_frequency_mhz");
+  ASSERT_NE(it, mappings.end());
+  EXPECT_EQ(it->second.output_name, "compute_unit_frequency_mhz");
+  EXPECT_DOUBLE_EQ(it->second.scale_factor, 1.0);
+
+  it = mappings.find("device");
+  ASSERT_NE(it, mappings.end());
+  EXPECT_EQ(it->second.output_name, "device_id");
+}
+
+TEST_F(OtlpLoggerTest, StringMappingsLoadedFromFile) {
+  const auto& mappings = getStringMappings();
+
+  EXPECT_EQ(mappings.size(), 1u);
+  auto it = mappings.find("gpu_name");
+  ASSERT_NE(it, mappings.end());
+  EXPECT_EQ(it->second, "accelerator_model");
+}
+
+TEST_F(OtlpLoggerTest, ScaleTransformBuffering) {
+  OtlpLogger logger;
+  logger.logFloat("gpu_device_utilization", 0.75f);
+  logger.logInt("gpu_frequency_mhz", 1500);
+
+  EXPECT_DOUBLE_EQ(logger.float_kvs_.at("gpu_device_utilization"), 0.75);
+  EXPECT_EQ(logger.int_kvs_.at("gpu_frequency_mhz"), 1500);
+
+  logger.finalize();
+  EXPECT_TRUE(logger.float_kvs_.empty());
+  EXPECT_TRUE(logger.int_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, StringMappingAppliedOnFinalize) {
+  OtlpLogger logger;
+  logger.logStr("gpu_name", "NVIDIA GB300");
+  logger.logStr("unmapped_key", "some_value");
+
+  logger.finalize();
+  EXPECT_TRUE(logger.string_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, EmptyMetrics) {
+  OtlpLogger logger;
+  logger.setTimestamp(std::chrono::system_clock::now());
+  logger.finalize();
+  EXPECT_TRUE(logger.float_kvs_.empty());
+  EXPECT_TRUE(logger.int_kvs_.empty());
+  EXPECT_TRUE(logger.string_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, UnmappedMetricsPassThrough) {
+  OtlpLogger logger;
+  logger.logFloat("unknown_metric", 42.0f);
+  logger.logStr("custom_tag", "value");
+
+  EXPECT_EQ(logger.float_kvs_.size(), 1u);
+  EXPECT_DOUBLE_EQ(logger.float_kvs_.at("unknown_metric"), 42.0);
+  EXPECT_EQ(logger.string_kvs_.at("custom_tag"), "value");
+
+  logger.finalize();
+  EXPECT_TRUE(logger.float_kvs_.empty());
+  EXPECT_TRUE(logger.string_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, MultipleFinalizeCycles) {
+  OtlpLogger logger;
+
+  logger.logFloat("gpu_device_utilization", 0.5f);
+  logger.logStr("gpu_name", "NVIDIA H100");
+  logger.finalize();
+  EXPECT_TRUE(logger.float_kvs_.empty());
+  EXPECT_TRUE(logger.string_kvs_.empty());
+
+  logger.logFloat("gpu_device_utilization", 0.9f);
+  logger.logStr("gpu_name", "NVIDIA H100");
+  EXPECT_NEAR(logger.float_kvs_.at("gpu_device_utilization"), 0.9, 1e-6);
+  EXPECT_EQ(logger.string_kvs_.at("gpu_name"), "NVIDIA H100");
+  logger.finalize();
+  EXPECT_TRUE(logger.float_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, IntPreservation) {
+  OtlpLogger logger;
+  logger.logInt("gpu_frequency_mhz", 1500);
+  logger.logUint("some_counter", 42);
+
+  EXPECT_EQ(logger.int_kvs_.at("gpu_frequency_mhz"), 1500);
+  EXPECT_EQ(logger.int_kvs_.at("some_counter"), 42);
+
+  logger.finalize();
+  EXPECT_TRUE(logger.int_kvs_.empty());
+}
+
+TEST_F(OtlpLoggerTest, CommentsAndBlankLinesIgnored) {
+  // The temp file has a comment line — verify it didn't create a bad mapping.
+  const auto& mappings = getMetricMappings();
+  EXPECT_EQ(mappings.find("#"), mappings.end());
+  EXPECT_EQ(mappings.find("# Test mappings"), mappings.end());
+}
+
+} // namespace dynolog
+#endif // USE_OTEL


### PR DESCRIPTION
Summary:
Add OtlpLogger class emits OTLP LogRecords via the OTel C++ SDK Logs API. Each GPU device snapshot produces one LogRecord. Fully configurable via gflags—no hardcoded deployment-specific constants.

**Added gflags:**
- `--otel_resource_attrs`: comma-separated KEY=VALUE resource attributes
- `--otel_resource_env_file`: KEY=VALUE file for platform metadata
- `--otel_metric_mappings_file`: CSV file for DCGM metric name/scale mappings

**DcgmGroupInfo:**
- Adds `DCGM_FI_DEV_NAME` (field 50) string collection for GPU model.

**Architecture (mirrors PrometheusLogger two-tier pattern):**
1. **OtlpManager singleton:**
   - Owns LoggerProvider → BatchLogRecordProcessor → OtlpHttpLogRecordExporter.
   - Sets `fb.scribe.transport.category` resource attribute.
   - Calls ForceFlush/Shutdown on destruction.
   - Reads `OTEL_EXPORTER_OTLP_ENDPOINT` env var (default: `http://localhost:4318`).

2. **OtlpLogger per-cycle:**
   - Implements Logger interface.
   - Buffers float/int/string metrics separately (preserving int64_t precision for OTel SetAttribute).
   - Applies DCGM → Scuba column name mapping with scale transforms on finalize().
   - Emits one LogRecord per GPU device.

**Metric Mapping:**
- 16 DCGM metric mappings with scale factors.
- Unmapped metrics pass through with original names.
- Bytes-to-gbps conversion for NVLink/PCIe metrics deferred as TODO pending verification against prod NvidiaScribePublisher.

**Integration Details:**
- Moves the OTel `add_subdirectory()` in CMakeLists.txt to after `third_party/json` to avoid nlohmann_json target name conflicts.
- Adds `opentelemetry-cpp` to the internal `setup_dynolog_cmake.sh` script.

**Deployment Controls:**
- Gated by `USE_OTEL` compile flag and `--use_otel` runtime gflag.

Differential Revision: D102059978


