### PR TITLE
atomatically verify the bperf leader prog is still running after rdpmc

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -498,7 +498,7 @@ int BPerfEventsGroup::preparePerThreadBPerf_(bperf_leader_cgroup* skel) {
   metadata->thread_data_size = sizeof(struct bperf_thread_data);
   metadata->event_data_size = sizeof(struct bperf_perf_event_data);
   metadata->event_cnt = skel->rodata->event_cnt;
-  metadata->flags = BPERF_FLAG_ENABLED;
+  metadata->flags = bperf_flags_set_enabled(metadata->flags);
 
   err = ::bpf_map__update_elem(
       skel->maps.per_thread_data,
@@ -859,7 +859,7 @@ void BPerfEventsGroup::disablePerThreadMetadata(
   char buf[BPERF_MAX_THREAD_DATA_SIZE] = {};
   auto* metadata = reinterpret_cast<struct bperf_thread_metadata*>(buf);
   if (::bpf_map_lookup_elem(map_fd, &zero, buf) == 0) {
-    metadata->flags &= ~BPERF_FLAG_ENABLED;
+    metadata->flags = bperf_flags_clear_enabled(metadata->flags);
     if (::bpf_map_update_elem(map_fd, &zero, buf, BPF_ANY)) {
       HBT_LOG_WARNING() << "failed to disable per-thread metadata";
     }

--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -213,7 +213,17 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
     return -1;
   }
 
-  if (!isLeaderRunning_()) {
+  // isLeaderRunning_() does a single atomic load of metadata->flags and
+  // gives us both the enabled-bit and a snapshot of the version counter
+  // from that same load. The writer bumps this version every time
+  // BPERF_FLAG_ENABLED changes, so we can detect below (after the
+  // do-while loop has finished reading from data_) whether the leader
+  // has been disabled in the meantime. If it has, anything we read from
+  // the mmapped data_ region (lock, tsc_param, raw_thread_data,
+  // raw_event_data) and the rdpmc results may be stale or invalid, so
+  // we bail out.
+  __u32 enabled_version = 0;
+  if (!isLeaderRunning_(&enabled_version)) {
     disable();
     return -1;
   }
@@ -235,6 +245,18 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
     }
     barrier();
   } while (lock != data_->lock);
+
+  // After all reads from data_ (including event data and rdpmc), verify
+  // that BPERF_FLAG_ENABLED has not been toggled since the initial flags
+  // snapshot above. This guards every value we sampled from the mmapped
+  // data_ region above; if a disable happened in between, those values
+  // (lock, tsc_param, raw_thread_data, raw_event_data) and the rdpmc
+  // results may be stale or invalid, so we bail out.
+  barrier();
+  if (flagsVersion_() != enabled_version) {
+    disable();
+    return -1;
+  }
 
   data->monoTime = (((__uint128_t)tsc * p.multi) >> p.shift) + p.offset +
       initial_clock_drift_;
@@ -272,12 +294,31 @@ bool BPerfPerThreadReader::leadExited(__u64 counter_zero) {
   return ret;
 }
 
-bool BPerfPerThreadReader::isLeaderRunning_() {
+bool BPerfPerThreadReader::isLeaderRunning_(__u32* version_out) {
   if (!mmap_ptr_) {
+    if (version_out) {
+      *version_out = 0;
+    }
     return false;
   }
   auto* metadata = (struct bperf_thread_metadata*)mmap_ptr_;
-  return metadata->flags & BPERF_FLAG_ENABLED;
+  // Single 32-bit load. From this one snapshot we derive both the
+  // enabled-bit and the version counter, so the caller cannot observe
+  // an inconsistent pair (e.g. enabled=true with a stale version that
+  // gets bumped immediately after).
+  const __u32 flags = metadata->flags;
+  if (version_out) {
+    *version_out = bperf_flags_version(flags);
+  }
+  return bperf_flags_is_enabled(flags);
+}
+
+__u32 BPerfPerThreadReader::flagsVersion_() {
+  if (!mmap_ptr_) {
+    return 0;
+  }
+  auto* metadata = (struct bperf_thread_metadata*)mmap_ptr_;
+  return bperf_flags_version(metadata->flags);
 }
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -60,8 +60,17 @@ class BPerfPerThreadReader {
   // Previous reading of event 0, used to detect when the lead exits
   __u64 prev_counter_zero_;
   bool leadExited(__u64 counter_zero);
-  // check if the bpf program supporting per-thread bperf is still running
-  bool isLeaderRunning_();
+  // Checks whether the bpf program supporting per-thread bperf is still
+  // running. If `version_out` is non-null, the 8-bit version stored in
+  // bits 0-7 of the metadata flags is written to it from the SAME
+  // atomic 32-bit load of `metadata->flags` that produced the return
+  // value, so the caller gets a consistent snapshot of both
+  // BPERF_FLAG_ENABLED and the version counter.
+  bool isLeaderRunning_(__u32* version_out = nullptr);
+  // returns the 8-bit version stored in the metadata flags. The version is
+  // bumped by the writer every time BPERF_FLAG_ENABLED changes, so readers
+  // can detect a flag transition that occurred between two reads.
+  __u32 flagsVersion_();
 };
 
 } // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -48,13 +48,57 @@ struct bperf_thread_metadata {
   __u32 thread_data_size; /* sizeof(bperf_thread_data) */
   __u32 event_data_size; /* sizeof(bperf_perf_event_data) */
   __u32 event_cnt;
-  /* notifies BPerfPerThreadReader that the BPF programs supporting per-thread
-   * BPerf event updates have been stopped. When disabled, the values in the
-   * per-thread BPF map are no longer being updated and should not be trusted.
+  /* Layout of `flags`:
+   *   bits 0-7  : 8-bit version counter, bumped on every change of
+   *               BPERF_FLAG_ENABLED.
+   *   bit 8     : BPERF_FLAG_ENABLED. Notifies BPerfPerThreadReader that
+   *               the BPF programs supporting per-thread BPerf event
+   *               updates have been stopped. When disabled, the values in
+   *               the per-thread BPF map are no longer being updated and
+   *               should not be trusted.
+   *
+   * The version allows readers to detect a transition of BPERF_FLAG_ENABLED
+   * that happened in between an earlier check and a subsequent rdpmc().
+   *
+   * Only one thread (the dynolog main thread) ever modifies `flags`,
+   * so the variable assignment does not need to be atomic. Use the
+   * bperf_flags_*() helpers below to keep the version counter in sync
+   * with BPERF_FLAG_ENABLED.
    */
-#define BPERF_FLAG_ENABLED (1 << 0)
+#define BPERF_FLAG_VERSION_MASK 0xFFu
+#define BPERF_FLAG_ENABLED (1u << 8)
   __u32 flags;
 };
+
+/* Returns the 8-bit version stored in bits 0-7 of `flags`. */
+static inline __u32 bperf_flags_version(__u32 flags) {
+  return flags & BPERF_FLAG_VERSION_MASK;
+}
+
+/* Returns true if BPERF_FLAG_ENABLED (bit 8) is set in `flags`. */
+static inline int bperf_flags_is_enabled(__u32 flags) {
+  return (flags & BPERF_FLAG_ENABLED) != 0;
+}
+
+/* Returns a new value of `flags` with BPERF_FLAG_ENABLED set and the
+ * version bumped by 1.
+ */
+static inline __u32 bperf_flags_set_enabled(__u32 flags) {
+  __u32 next_version =
+      (bperf_flags_version(flags) + 1u) & BPERF_FLAG_VERSION_MASK;
+  return (flags & ~(BPERF_FLAG_VERSION_MASK | BPERF_FLAG_ENABLED)) |
+      BPERF_FLAG_ENABLED | next_version;
+}
+
+/* Returns a new value of `flags` with BPERF_FLAG_ENABLED cleared and the
+ * version bumped by 1.
+ */
+static inline __u32 bperf_flags_clear_enabled(__u32 flags) {
+  __u32 next_version =
+      (bperf_flags_version(flags) + 1u) & BPERF_FLAG_VERSION_MASK;
+  return (flags & ~(BPERF_FLAG_VERSION_MASK | BPERF_FLAG_ENABLED)) |
+      next_version;
+}
 
 /* BPerfEventsGroup may have variable number of perf events.
  * Therefore, the bperf_thread_data used for each thread may


### PR DESCRIPTION
Summary:
add a 8 bits counter to bperf_thread_metadata.flag. we use this counter to check if the content of the flag has been modified 

it's hard to use the lock here, as if we want to update the lock from user space, it's not easy to guarantee the atomic lock bump and structure variables update.

if the per thread reader find the version has changed, simply discard the data read previously and return an error. this should only happen when dynolog explicitly disable BPerf, and is not in the usual code path.

NOTE: this breaks the backward compatibility to the old BPerfPerThreadReader, which should be fine at current stage

Differential Revision: D102078224


