### PR TITLE
Add LBR_PMC_FREEZE CPU feature detection for AMD

### DIFF
--- a/hbt/src/common/System.cpp
+++ b/hbt/src/common/System.cpp
@@ -18,6 +18,10 @@
 #include <system_error>
 #include <thread>
 
+#if defined(__i386__) || defined(__x86_64__)
+#include <cpuid.h>
+#endif
+
 namespace facebook::hbt {
 
 constexpr const char* kArmMidrFile =
@@ -412,6 +416,25 @@ CpuInfo readCpu(std::ifstream& s) {
   return CpuInfo(vendor_id, cpu_family, cpu_model, cpu_step);
 }
 
+#if defined(__x86_64__)
+CpuFeatures detectCpuFeaturesX86(const std::string& vendor_id) {
+  CpuFeatures features;
+  if (vendor_id != "AuthenticAMD") {
+    return features;
+  }
+
+  unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+  if (__get_cpuid(0x80000000, &eax, &ebx, &ecx, &edx) && eax >= 0x80000022) {
+    __cpuid_count(0x80000022, 0, eax, ebx, ecx, edx);
+    features.amd_perfmon_v2 = eax & (1u << 0);
+    features.amd_lbr_v2 = eax & (1u << 1);
+    features.amd_lbr_pmc_freeze = eax & (1u << 2);
+  }
+
+  return features;
+}
+#endif
+
 CpuInfo readCpuArm() {
   std::string vendor_id;
   uint32_t cpu_family = 0, cpu_model = 0, cpu_step = 0;
@@ -464,8 +487,21 @@ CpuInfo CpuInfo::load() {
   std::ifstream s("/proc/cpuinfo");
 
   // Only read CPU 0.
-  return readCpu(s);
+  auto info = readCpu(s);
+#if defined(__x86_64__)
+  info.features = detectCpuFeaturesX86(info.vendor_id);
 #endif
+  return info;
+#endif
+}
+
+std::ostream& operator<<(std::ostream& os, const CpuFeatures& features) {
+  os << fmt::format(
+      "<CpuFeatures amd_perfmon_v2: {} amd_lbr_v2: {} amd_lbr_pmc_freeze: {}>",
+      features.amd_perfmon_v2,
+      features.amd_lbr_v2,
+      features.amd_lbr_pmc_freeze);
+  return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const CpuInfo& cpu_info) {
@@ -477,6 +513,7 @@ std::ostream& operator<<(std::ostream& os, const CpuInfo& cpu_info) {
       fmt::underlying(cpu_info.cpu_arch),
       cpu_info.cpu_model_num,
       cpu_info.cpu_step_num);
+  os << " " << cpu_info.features;
   return os;
 }
 

--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -296,6 +296,14 @@ struct CpuSet {
 
 std::ostream& operator<<(std::ostream& os, const CpuSet& cpu_set);
 
+struct CpuFeatures {
+  bool amd_perfmon_v2 = false;
+  bool amd_lbr_v2 = false;
+  bool amd_lbr_pmc_freeze = false;
+};
+
+std::ostream& operator<<(std::ostream& os, const CpuFeatures& features);
+
 struct CpuInfo {
   perf_event::CpuFamily cpu_family;
   perf_event::CpuArch cpu_arch;
@@ -306,12 +314,15 @@ struct CpuInfo {
   uint32_t cpu_model_num;
   uint32_t cpu_step_num;
 
+  CpuFeatures features;
+
   CpuInfo(
       std::string vendor_id,
       uint32_t cpu_family_num,
       uint32_t cpu_model_num,
       uint32_t cpu_step_num,
-      uint32_t vendor_id_int = 0)
+      uint32_t vendor_id_int = 0,
+      CpuFeatures features = {})
       : cpu_family(perf_event::makeCpuFamily(cpu_family_num)),
         cpu_arch(
             perf_event::makeCpuArch(
@@ -323,7 +334,8 @@ struct CpuInfo {
         vendor_id(std::move(vendor_id)),
         cpu_family_num(cpu_family_num),
         cpu_model_num(cpu_model_num),
-        cpu_step_num(cpu_step_num) {}
+        cpu_step_num(cpu_step_num),
+        features(features) {}
 
   static CpuInfo load();
 

--- a/hbt/src/common/tests/SystemTest.cpp
+++ b/hbt/src/common/tests/SystemTest.cpp
@@ -287,6 +287,22 @@ TEST(SystemTest, CpuInfoTest) {
   HBT_LOG_INFO() << "CpuInfo = " << cpu_info;
 }
 
+TEST(SystemTest, CpuFeaturesTest) {
+  auto cpu_info = CpuInfo::load();
+  HBT_LOG_INFO() << "CpuFeatures = " << cpu_info.features;
+  if (cpu_info.vendor_id == "AuthenticAMD") {
+    // Verify feature hierarchy: lbr_pmc_freeze => lbr_v2 => perfmon_v2
+    EXPECT_TRUE(
+        !cpu_info.features.amd_lbr_pmc_freeze || cpu_info.features.amd_lbr_v2);
+    EXPECT_TRUE(
+        !cpu_info.features.amd_lbr_v2 || cpu_info.features.amd_perfmon_v2);
+  } else {
+    EXPECT_FALSE(cpu_info.features.amd_perfmon_v2);
+    EXPECT_FALSE(cpu_info.features.amd_lbr_v2);
+    EXPECT_FALSE(cpu_info.features.amd_lbr_pmc_freeze);
+  }
+}
+
 TEST(SystemTest, GetHostNameTest) {
   auto hostname = getHostName();
   EXPECT_GT(hostname.size(), 0);


### PR DESCRIPTION
Summary:
Add CPUID-based detection of AMD Extended Performance Monitoring features (CPUID leaf 0x80000022) to HBT CpuInfo. This enables dynolog to report whether LBR_PMC_FREEZE is supported on AMD hosts, which is required for zero-skid LBR and call stack collection for CSSPGO on Bergamo (Zen4) hosts.

- Add CpuFeatures with amd_perfmon_v2, amd_lbr_v2, and amd_lbr_pmc_freeze flags
- Implement detectCpuFeaturesX86() using CPUID leaf 0x80000022
- Integrate feature detection into CpuInfo::load() on AMD platforms
- Add operator<< for CpuFeatures for logging/debugging
- Add CpuFeaturesTest to verify feature detection works on non-AMD and AMD hosts

https://github.com/torvalds/linux/blob/254f49634ee16a731174d2ae34bc50bd5f45e731/arch/x86/kernel/cpu/scattered.c#L66-L68:
```
	{ X86_FEATURE_PERFMON_V2,		CPUID_EAX,  0, 0x80000022, 0 },
	{ X86_FEATURE_AMD_LBR_V2,		CPUID_EAX,  1, 0x80000022, 0 },
	{ X86_FEATURE_AMD_LBR_PMC_FREEZE,	CPUID_EAX,  2, 0x80000022, 0 },
```

Differential Revision: D102532861


