### PR TITLE
hbt/bperf: Export cumulative scheduling delay per thread

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -264,6 +264,7 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
       data->monoTime - raw_thread_data.offset_update_time;
   data->cpuTime =
       raw_thread_data.runtime_until_offset_update + time_after_offset_update;
+  data->schedDelay = raw_thread_data.cumulative_sched_delay_ns;
 
   for (i = 0; i < event_cnt_; i++) {
     data->values[i] = raw_event_data[i].output_value;

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -18,6 +18,8 @@ namespace facebook::hbt::perf_event {
 struct BPerfThreadData {
   __u64 cpuTime;
   __u64 monoTime;
+  // Cumulative runqueue wait (ns); see cumulative_sched_delay_ns in bperf.h.
+  __u64 schedDelay;
   struct bpf_perf_event_value values[BPERF_MAX_GROUP_SIZE];
 };
 

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -118,6 +118,12 @@ struct bperf_thread_data {
   /* runtime = runtime_until_offset_update + tsc_time - offset_time; */
   __u64 runtime_until_offset_update;
 
+  /* Snapshot of task->sched_info.run_delay (cumulative runqueue wait, ns).
+   * Same value as field 2 of /proc/<pid>/task/<tid>/schedstat. 0 on
+   * kernels without CONFIG_SCHED_INFO.
+   */
+  __u64 cumulative_sched_delay_ns;
+
   struct bperf_perf_event_data events[];
 };
 

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -88,6 +88,7 @@ static void bperf_thread_data_init(struct bperf_thread_data *data) {
   int i;
   data->lock = 1;
   data->runtime_until_offset_update = 0;
+  data->cumulative_sched_delay_ns = 0;
   for (i = 0; i < BPERF_MAX_GROUP_SIZE && i < event_cnt; i++) {
     data->events[i].output_value.counter = 0;
     data->events[i].output_value.enabled = 0;
@@ -98,6 +99,17 @@ static void bperf_thread_data_init(struct bperf_thread_data *data) {
 int __always_inline bperf_perf_event_index(struct perf_event *event);
 __always_inline struct bperf_thread_data* get_bperf_thread_data(struct task_struct *task);
 static int __always_inline bperf_update_thread_time(struct bperf_thread_data *data);
+
+/* Snapshot task->sched_info.run_delay into cumulative_sched_delay_ns.
+ * Caller bumps data->lock. CO-RE-guarded so the program still loads on
+ * kernels without CONFIG_SCHED_INFO (cumulative_sched_delay_ns stays 0).
+ */
+static __always_inline void snapshot_sched_delay(struct task_struct *task,
+                                                 struct bperf_thread_data *data) {
+  if (bpf_core_field_exists(task->sched_info)) {
+    data->cumulative_sched_delay_ns = task->sched_info.run_delay;
+  }
+}
 
 static void add_diff_to_task_accumulate(struct bpf_perf_event_value* diff_val, struct bperf_thread_data *data, __u64 now) {
   int i;
@@ -110,12 +122,14 @@ static void add_diff_to_task_accumulate(struct bpf_perf_event_value* diff_val, s
   }
 }
 
-static void update_task_offset(struct bperf_thread_data *data, __u64 now) {
+static void update_task_offset(struct bperf_thread_data *data,
+                               struct task_struct *task, __u64 now) {
   struct pe_data *pe_data;
   int i;
 
   data->lock += 1;
   data->offset_update_time = now;
+  snapshot_sched_delay(task, data);
   bperf_update_thread_time(data);
 
   for (i = 0; i < BPERF_MAX_GROUP_SIZE && i < event_cnt; i++) {
@@ -152,7 +166,7 @@ static void update_task_output(struct bpf_perf_event_value* diff_val, struct tas
   next_data = get_bperf_thread_data(next);
   if (!next_data)
     return;
-  update_task_offset(next_data, now);
+  update_task_offset(next_data, next, now);
 }
 
 static void update_cgroup_output(struct bpf_perf_event_value* diff_val,

--- a/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
+++ b/hbt/src/perf_event/tests/BPerfEventsGroupPerThreadTest.cpp
@@ -8,10 +8,16 @@
 #include "hbt/src/perf_event/BuiltinMetrics.h"
 
 #include <gtest/gtest.h>
+#include <sched.h>
 #include <sys/resource.h>
+#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
+#include <atomic>
 #include <chrono>
+#include <fstream>
+#include <optional>
+#include <string>
 #include <thread>
 
 using namespace facebook::hbt;
@@ -334,4 +340,109 @@ TEST(BPerfEventsGroupPerThreadTest, TestConcurrentReader) {
 
   EXPECT_EQ(successed, BPERF_MAX_THREAD_READER);
   EXPECT_EQ(failed, 1);
+}
+
+namespace {
+
+bool pinToCpu(int cpu) {
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  CPU_SET(cpu, &set);
+  return sched_setaffinity(0, sizeof(set), &set) == 0;
+}
+
+void spinUntil(const std::atomic<bool>& stop) {
+  volatile __u64 sink = 0;
+  while (!stop.load(std::memory_order_relaxed)) {
+    for (int i = 0; i < 10000; i++) {
+      sink += i;
+    }
+  }
+}
+
+// run_delay (field 2) from /proc/self/task/<tid>/schedstat; nullopt if
+// the file is absent (kernel built without CONFIG_SCHED_INFO).
+std::optional<__u64> readKernelRunDelayNs() {
+  pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+  std::ifstream f("/proc/self/task/" + std::to_string(tid) + "/schedstat");
+  if (!f) {
+    return std::nullopt;
+  }
+  __u64 run_time = 0, run_delay = 0, pcount = 0;
+  f >> run_time >> run_delay >> pcount;
+  return run_delay;
+}
+
+} // namespace
+
+TEST(BPerfEventsGroupPerThreadTest, TestSchedDelay) {
+  auto pmu_manager = makePmuDeviceManager();
+  auto pmu = pmu_manager->findPmuDeviceByName("generic_hardware");
+  auto ev_def = pmu_manager->findEventDef("cycles");
+  if (!ev_def) {
+    GTEST_SKIP() << "Cannot find event cycles";
+  }
+  auto ev_conf =
+      pmu->makeConf(ev_def->id, EventExtraAttr(), EventValueTransforms());
+
+  auto system = BPerfEventsGroup(EventConfs({ev_conf}), 0, true, "cycles");
+  ASSERT_EQ(system.open(), true);
+
+  if (!pinToCpu(0)) {
+    GTEST_SKIP() << "sched_setaffinity failed; skipping";
+  }
+
+  if (!readKernelRunDelayNs().has_value()) {
+    GTEST_SKIP() << "/proc/self/task/<tid>/schedstat absent; "
+                    "cannot cross-validate";
+  }
+
+  auto reader = createReader();
+
+  // Warmup so the reader sees at least one sched_switch_in before we read.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  // Invariant at each checkpoint: bperf <= kernel. bperf is read first; if
+  // the thread is preempted between the two reads, kernel run_delay grows
+  // ahead while our local snapshot stays the same.
+  BPerfThreadData before{};
+  ASSERT_EQ(reader->read(&before), 0);
+  __u64 kernelBefore = readKernelRunDelayNs().value_or(0);
+  GTEST_LOG_(INFO) << "[before] schedDelay = " << before.schedDelay
+                   << " kernel run_delay = " << kernelBefore;
+  EXPECT_LE(before.schedDelay, kernelBefore);
+
+  constexpr int kNumStressors = 4;
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> stressors;
+  stressors.reserve(kNumStressors);
+  for (int i = 0; i < kNumStressors; i++) {
+    stressors.emplace_back([&stop]() {
+      pinToCpu(0);
+      spinUntil(stop);
+    });
+  }
+
+  for (int i = 0; i < 20; i++) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  BPerfThreadData after{};
+  ASSERT_EQ(reader->read(&after), 0);
+  __u64 kernelAfter = readKernelRunDelayNs().value_or(0);
+  GTEST_LOG_(INFO) << "[after]  schedDelay = " << after.schedDelay
+                   << " kernel run_delay = " << kernelAfter;
+  EXPECT_LE(after.schedDelay, kernelAfter);
+
+  stop = true;
+  for (auto& t : stressors) {
+    t.join();
+  }
+
+  EXPECT_GT(after.schedDelay, before.schedDelay);
+  GTEST_LOG_(INFO) << "schedDelay grew by "
+                   << (after.schedDelay - before.schedDelay) << " ns";
+
+  reader->disable();
+  system.disable();
 }


### PR DESCRIPTION
Summary:
Adds a per-thread cumulative runqueue wait time metric to bperf,
exposed as `BPerfThreadData::schedDelay` (nanoseconds). It is a snapshot of the
kernel's `task->sched_info.run_delay` (the same counter that surfaces as second
field of `/proc/<pid>/task/<tid>/schedstat`).

The motivation is to have a high-bandwidth way per-thread to track accumulated
scheduling delays which can then be associated per request using folly's
RequestCostLightData infrastructure. More details are covered in the linked doc:
https://docs.google.com/document/d/1H1Sw1zoTxkHOKHZeQ4btU1Z65DeWNqI2bfqx1fU6uGI/edit?tab=t.0

The BPF leader program reads `task->sched_info.run_delay` via CO-RE
(`bpf_core_field_exists` + CO-RE reads) inside `update_task_offset`, which runs
on every `sched_switch_in` and on every `bperf_pmu_enable_exit` for the
registered task. Because both hooks fire after `sched_info_arrive()` has updated
`run_delay`, the snapshot reflects the kernel's just-updated value. On kernels
built without `CONFIG_SCHED_INFO`, `bpf_core_field_exists` evaluates to false at
load time; the read is skipped and `cumulative_sched_delay_ns` stays at 0.

The intermediate counter lives on the existing `bperf_thread_data` struct
(already mmap'd to user-space).

Differential Revision: D102657972


