### PR TITLE
hbt/bperf: Gate schedDelay read on published thread_data_size

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -125,6 +125,14 @@ int BPerfPerThreadReader::enable() {
   ::close(tid_fd);
   ::close(idx_fd);
 
+  // Detect whether the leader's layout includes cumulative_sched_delay_ns.
+  // metadata->thread_data_size is the leader's sizeof(bperf_thread_data);
+  // it is large enough to cover the field iff the leader was built after
+  // the field was added.
+  sched_delay_supported_ = metadata->thread_data_size >=
+      offsetof(struct bperf_thread_data, cumulative_sched_delay_ns) +
+          sizeof(__u64);
+
   data_ = (struct bperf_thread_data*)((unsigned long long)mmap_ptr_ +
                                       idx * data_size_);
 
@@ -191,6 +199,7 @@ void BPerfPerThreadReader::disable() {
   dummy_pe_mmap_ = nullptr;
   ::close(dummy_pe_fd_);
   dummy_pe_fd_ = -1;
+  sched_delay_supported_ = false;
   enabled_ = false;
 }
 
@@ -264,7 +273,8 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
       data->monoTime - raw_thread_data.offset_update_time;
   data->cpuTime =
       raw_thread_data.runtime_until_offset_update + time_after_offset_update;
-  data->schedDelay = raw_thread_data.cumulative_sched_delay_ns;
+  data->schedDelay =
+      sched_delay_supported_ ? raw_thread_data.cumulative_sched_delay_ns : 0;
 
   for (i = 0; i < event_cnt_; i++) {
     data->values[i] = raw_event_data[i].output_value;

--- a/hbt/src/perf_event/BPerfPerThreadReader.h
+++ b/hbt/src/perf_event/BPerfPerThreadReader.h
@@ -59,6 +59,12 @@ class BPerfPerThreadReader {
   int dummy_pe_fd_ = -1;
   void* dummy_pe_mmap_ = nullptr;
   bool enabled_ = false;
+  // True when the leader's bperf_thread_data layout includes
+  // cumulative_sched_delay_ns. When false (old leader paired with a newer
+  // reader), the field's offset in the new struct overlaps the first PMC
+  // counter in the old layout, so reading it would return a misaligned
+  // PMC value. In that case read() returns schedDelay = 0.
+  bool sched_delay_supported_ = false;
   // Previous reading of event 0, used to detect when the lead exits
   __u64 prev_counter_zero_;
   bool leadExited(__u64 counter_zero);


### PR DESCRIPTION
Summary:
D102657972 added cumulative_sched_delay_ns to bperf_thread_data,
between runtime_until_offset_update and the events[] flexible array. A
user-space reader compiled against the new struct that opens a per_thread_data
map populated by an older leader (built before that diff) reads sizeof(NEW
struct) bytes from each slot — but in the old layout, those last 8 bytes are
events[0].output_value.counter (a PMC value), so BPerfThreadData::schedDelay
surfaces a misaligned PMC read instead of a runqueue-wait counter.

PMC reads themselves are unaffected because the reader computes events[i]
offsets from metadata->thread_data_size (the leader's reported sizeof). We use
the same field to gate the schedDelay read: if metadata->thread_data_size is too
small to cover cumulative_sched_delay_ns, the leader doesn't publish the field,
so we return schedDelay = 0 instead of a misinterpreted PMC value.

This method works for any future field additions too, such that they are not
misreported for older leader programs.

Differential Revision: D102801222


