### PR TITLE
Fix crash on machine with restricted /proc access

### DIFF
--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -114,9 +114,14 @@ void kernel_monitor_loop() {
     auto wakeup_timepoint =
         next_wakeup(FLAGS_kernel_monitor_reporting_interval_s);
 
-    kc.step();
-    kc.log(*logger);
-    logger->finalize();
+    try {
+      kc.step();
+      kc.log(*logger);
+      logger->finalize();
+    } catch (const std::system_error& e) {
+      LOG(ERROR) << "Kernel monitor error: " << e.what()
+                 << " (code=" << e.code() << "). Skipping cycle.";
+    }
 
     /* sleep override */
     std::this_thread::sleep_until(wakeup_timepoint);

--- a/dynolog/src/gpumon/Utils.cpp
+++ b/dynolog/src/gpumon/Utils.cpp
@@ -61,12 +61,16 @@ std::unordered_map<std::string, std::string> getMetadataForPid(
   if (pid < 0) {
     return varsMap;
   }
-  auto task = pfs::procfs().get_task(pid);
-  auto env = task.get_environ();
-  for (const auto& key : keysMap) {
-    if (auto val = env.find(key.first); val != env.end()) {
-      varsMap[key.second] = val->second;
+  try {
+    auto task = pfs::procfs().get_task(pid);
+    auto env = task.get_environ();
+    for (const auto& key : keysMap) {
+      if (auto val = env.find(key.first); val != env.end()) {
+        varsMap[key.second] = val->second;
+      }
     }
+  } catch (const std::system_error& e) {
+    LOG(WARNING) << "Could not read env for pid " << pid << ": " << e.what();
   }
   return varsMap;
 }


### PR DESCRIPTION
Summary:
Fix crash caused by an uncaught std::system_error
from the pfs library when reading /proc/<pid>/environ for GPU process attribution.

Root cause: getMetadataForPid() in Utils.cpp calls pfs::procfs().get_task(pid)
.get_environ() to read environment variables from GPU processes for job attribution
(SLURM/MAST env vars). The pfs library throws std::system_error("Couldn't open file")
when /proc/<pid>/environ is not readable.

Fixes:
- Utils.cpp: Wrap pfs calls in getMetadataForPid() with try-catch for
  std::system_error. On failure, logs a warning and returns empty attribution
  (GPU metrics still reported, just without job metadata).
- Main.cpp: Add try-catch around kernel_monitor_loop's step/log/finalize cycle
  as defensive hardening — KernelCollector also uses pfs to read /proc/stat and
  could throw on similarly restricted nodes.

Differential Revision: D102838702


