### PR TITLE
Export PmuTypeFromStr declaration in PmuEvent.h

### DIFF
--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -99,6 +99,7 @@ enum class PmuType : uint16_t {
 };
 
 std::string PmuTypeToStr(PmuType /*pmu_type*/);
+PmuType PmuTypeFromStr(const std::string& /*pmu_type_str*/);
 
 enum class ScaleUnit {
   Bytes, // Bytes


### PR DESCRIPTION
Summary:
Add declaration of PmuTypeFromStr() to PmuEvent.h alongside its counterpart
PmuTypeToStr(). The function was previously defined in PmuDevices.cpp with
external linkage but not declared in any header, requiring consumers to
forward-declare it.

Reviewed By: bigzachattack

Differential Revision: D104159674


