### PR TITLE
perf: Call reserver() to avoid unnecessary reallocation

### DIFF
--- a/dynolog/src/CPUTimeMonitor.cpp
+++ b/dynolog/src/CPUTimeMonitor.cpp
@@ -597,6 +597,7 @@ void CPUTimeMonitor::processProcUsage(
   auto& lastCpuTime = procCpuTimeLast_[level];
   auto& lastTickTime = procTimeLast_[level];
   MapSamplesT line;
+  line.reserve(targetToCpuSet_.size() * 5);
 
   for (const auto& [targetId, cpuSet] : targetToCpuSet_) {
     // Aggregate CpuTime over the target's assigned cores


### PR DESCRIPTION
Summary: This diff pre-allocates capacity for the `line` vector (of type `MapSamplesT`, i.e., `std::vector<std::pair<std::string, SampleVarT>>`) via `line.reserve(targetToCpuSet_.size() * 5)`. The size `targetToCpuSet_.size() * 5` is calculated based on the fact that each target in `targetToCpuSet_` can contribute up to 5 entries to the vector: 1 for CPUCoresUsage + 4 for breakdown metrics (idle, softirq, iowait, hardirq). This avoids repeated dynamic vector reallocations as elements are added during the loop iteration. The vector is local to the function and doesn't escape, so `reserve` is the appropriate choice over `folly::grow_capacity_by`.

Differential Revision: D101187982


