### PR TITLE
Populate sample_time attribute on OTel log records

### DIFF
--- a/dynolog/src/OtlpLogger.cpp
+++ b/dynolog/src/OtlpLogger.cpp
@@ -259,6 +259,11 @@ void OtlpManager::emitLog(
   }
 
   record->SetTimestamp(opentelemetry::common::SystemTimestamp(ts));
+  record->SetAttribute(
+      "sample_time",
+      static_cast<int64_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                               ts.time_since_epoch())
+                               .count()));
 
   for (const auto& [key, val] : numeric_attrs) {
     record->SetAttribute(key, val);


### PR DESCRIPTION
Summary: Add a sample_time column in addition to timestamp column for OtlpLogger.

Reviewed By: bigzachattack

Differential Revision: D105042601


