### PR TITLE
K8s GPU attribution: pod identity and env vars (binary) (#556)

### DIFF
--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_definitions(-DDYNOLOG_VERSION=${DYNOLOG_VERSION} -DDYNOLOG_GIT_REV=${DYNOLOG
 
 message("Use Prometheus = ${USE_PROMETHEUS}")
 message("Use ODS Graph API = ${USE_ODS_GRAPH_API}")
+message("Use K8s pod-resources = ${USE_K8S_PODRESOURCES}")
 
 # our build script will first create a src/ dir where all source code will exist
 file(GLOB dynolog_src "*.h" "*.cpp")
@@ -49,6 +50,10 @@ target_link_libraries(dynolog_lib PUBLIC dynolog_ipcfabric_lib)
 # depends on ipcfabric
 add_subdirectory(tracing)
 target_link_libraries(dynolog_lib PUBLIC dynolog_ipcmonitor_lib)
+
+# K8s platform-discovery libs (no-op unless USE_K8S_PODRESOURCES=ON).
+# Must be added BEFORE gpumon so dynolog_dcgm_lib can link dynolog_k8s_lib.
+add_subdirectory(k8s)
 
 add_subdirectory(gpumon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_dcgm_lib "-ldl")

--- a/dynolog/src/OtlpLogger.cpp
+++ b/dynolog/src/OtlpLogger.cpp
@@ -224,8 +224,11 @@ OtlpManager::OtlpManager() {
   LOG(INFO) << "OTel OTLP logger initialized, endpoint=" << exporter_opts.url
             << ", host_name=" << hostname;
   for (const auto& [key, val] : res.GetAttributes()) {
-    // val is opentelemetry::sdk::common::OwnedAttributeValue
-    if (auto* s = std::get_if<std::string>(&val)) {
+    // val is opentelemetry::sdk::common::OwnedAttributeValue, which is a
+    // nostd::variant. Use the portable accessor so this works regardless of
+    // whether OTel is built with WITH_STL=ON (std::variant) or WITH_STL=OFF
+    // (absl::variant).
+    if (auto* s = opentelemetry::nostd::get_if<std::string>(&val)) {
       LOG(INFO) << "  resource attr: " << key << "=" << *s;
     }
   }

--- a/dynolog/src/gpumon/CMakeLists.txt
+++ b/dynolog/src/gpumon/CMakeLists.txt
@@ -24,4 +24,13 @@ target_link_libraries(dynolog_dcgm_lib PUBLIC glog::glog)
 target_link_libraries(dynolog_dcgm_lib PUBLIC nlohmann_json::nlohmann_json)
 target_link_libraries(dynolog_dcgm_lib PUBLIC pfs)
 
+# Optional: K8s pod-resources / API attribution. The K8s libraries themselves
+# are built (or skipped) by the parent CMakeLists.txt's add_subdirectory(k8s);
+# we only wire them into dynolog_dcgm_lib here when enabled, so DcgmGroupInfo
+# can call into them.
+if(USE_K8S_PODRESOURCES)
+    target_compile_definitions(dynolog_dcgm_lib PUBLIC USE_K8S_PODRESOURCES)
+    target_link_libraries(dynolog_dcgm_lib PUBLIC dynolog_k8s_lib)
+endif()
+
 add_subdirectory(amd)

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -20,6 +21,11 @@
 #include "dynolog/src/gpumon/Entity.h"
 #include "dynolog/src/gpumon/Utils.h"
 #include "dynolog/src/gpumon/dcgm_fields.h"
+
+#ifdef USE_K8S_PODRESOURCES
+#include "dynolog/src/k8s/K8sPodCache.h"
+#include "dynolog/src/k8s/PodResourcesClient.h"
+#endif
 
 namespace dynolog::gpumon {
 
@@ -62,20 +68,69 @@ std::unordered_map<unsigned short, std::string> FieldIdToName{
     {DCGM_FI_DEV_GPU_UTIL, "gpu_device_utilization"},
     {DCGM_FI_DEV_MEM_COPY_UTIL, "gpu_memory_utilization"},
     {DCGM_FI_DEV_POWER_USAGE, "gpu_power_draw"},
-    {DCGM_FI_DEV_NAME, "gpu_name"}};
+    {DCGM_FI_DEV_NAME, "gpu_name"},
+    {DCGM_FI_DEV_UUID, "gpu_uuid"}};
 
-// Mapping of attribution environment variable name to scuba column name
-std::unordered_map<std::string, std::string> attributionEnvVarsToScubaColumns{
-    {"SLURM_JOB_ID", "job_id"},
-    {"USER", "username"},
-    {"SLURM_JOB_ACCOUNT", "slurm_account"},
-    {"SLURM_JOB_PARTITION", "slurm_partition"}};
+// Mapping of attribution environment variable name to scuba column name.
+// Loaded once on first use:
+//   - From --env_attribution_mappings_file CSV, when set
+//   - Otherwise from getDefaultEnvAttributionMap() (Slurm built-in defaults)
+DEFINE_string(
+    env_attribution_mappings_file,
+    "",
+    "Path to a CSV file defining env-var → column-name attribution mappings. "
+    "Each non-empty, non-'#' line is: <env_var_name>,<output_column_name>. "
+    "When empty, the built-in Slurm default mapping is used.");
+
+const std::unordered_map<std::string, std::string>&
+getEnvAttributionMappings() {
+  static const auto mappings = [] {
+    if (!FLAGS_env_attribution_mappings_file.empty()) {
+      return loadEnvAttributionMap(FLAGS_env_attribution_mappings_file);
+    }
+    return getDefaultEnvAttributionMap();
+  }();
+  return mappings;
+}
 
 DEFINE_bool(
     enable_env_var_attribution,
     true,
     "Enable environment variable attribution for GPUs."
     "Currently this support SLURM job scheduler environment variables.");
+
+#ifdef USE_K8S_PODRESOURCES
+DEFINE_bool(
+    enable_pod_resources_attribution,
+    false,
+    "Enable kubelet pod-resources attribution: query the local kubelet's "
+    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
+    "pod_name, container_name) onto each GPU record by GPU UUID. "
+    "Requires DCGM_FI_DEV_UUID (54) in --dcgm_fields.");
+
+DEFINE_string(
+    pod_resources_socket,
+    "/var/lib/kubelet/pod-resources/kubelet.sock",
+    "Path to kubelet pod-resources gRPC unix socket.");
+
+DEFINE_string(
+    pod_resources_gpu_resource,
+    "nvidia.com/gpu",
+    "K8s extended resource name to filter for GPU device assignments.");
+
+namespace {
+::dynolog::k8s::PodResourcesClient* getPodResourcesClient() {
+  static auto client = std::make_unique<::dynolog::k8s::PodResourcesClient>(
+      FLAGS_pod_resources_socket, FLAGS_pod_resources_gpu_resource);
+  return client.get();
+}
+
+::dynolog::k8s::K8sPodCache* getK8sPodCache() {
+  static auto cache = std::make_unique<::dynolog::k8s::K8sPodCache>();
+  return cache.get();
+}
+} // namespace
+#endif // USE_K8S_PODRESOURCES
 
 static inline void printValue(dcgmFieldValue_v1 v) {
   VLOG(1) << "====================================";
@@ -370,11 +425,50 @@ void DcgmGroupInfo::update() {
 
       if (FLAGS_enable_env_var_attribution) {
         std::vector<pid_t> pids = getPidsOnGpu();
+        const auto& env_mappings = getEnvAttributionMappings();
         for (size_t device_id = 0; device_id < pids.size(); device_id++) {
-          envMetadataMapString_[device_id] = getMetadataForPid(
-              pids[device_id], attributionEnvVarsToScubaColumns);
+          envMetadataMapString_[device_id] =
+              getMetadataForPid(pids[device_id], env_mappings);
         }
       }
+
+#ifdef USE_K8S_PODRESOURCES
+      if (FLAGS_enable_pod_resources_attribution) {
+        // Phase 1b: kubelet pod-resources gives universal pod identity per
+        // GPU UUID. Join onto GPU records using DCGM_FI_DEV_UUID, which
+        // lands in metricsMapString_[device_id]["gpu_uuid"].
+        auto gpuPods = getPodResourcesClient()->listGpuPods();
+        const auto& env_mappings = getEnvAttributionMappings();
+        const auto& label_mappings =
+            ::dynolog::k8s::getDefaultLabelAttributionMap();
+        for (auto& [device_id, str_metrics] : metricsMapString_) {
+          auto uuid_it = str_metrics.find("gpu_uuid");
+          if (uuid_it == str_metrics.end() || uuid_it->second.empty()) {
+            continue;
+          }
+          auto pod_it = gpuPods.find(uuid_it->second);
+          if (pod_it == gpuPods.end()) {
+            continue;
+          }
+          auto& env = envMetadataMapString_[device_id];
+          env["pod_namespace"] = pod_it->second.pod_namespace;
+          env["pod_name"] = pod_it->second.pod_name;
+          env["container_name"] = pod_it->second.container_name;
+
+          // Phase 1c: enrich with env vars + labels + ownerRefs from the
+          // K8s pod spec. Cached per pod, refreshed on TTL.
+          auto attrs = getK8sPodCache()->lookupAttribution(
+              pod_it->second.pod_namespace,
+              pod_it->second.pod_name,
+              pod_it->second.container_name,
+              env_mappings,
+              label_mappings);
+          for (auto& [k, v] : attrs) {
+            env[k] = std::move(v);
+          }
+        }
+      }
+#endif // USE_K8S_PODRESOURCES
     }
   }
 

--- a/dynolog/src/gpumon/Utils.cpp
+++ b/dynolog/src/gpumon/Utils.cpp
@@ -11,6 +11,8 @@
 #include <cstdio>
 #include <fstream>
 #include <optional>
+#include <sstream>
+#include <unordered_set>
 #include "pfs/procfs.hpp"
 
 namespace dynolog {
@@ -73,6 +75,71 @@ std::unordered_map<std::string, std::string> getMetadataForPid(
     LOG(WARNING) << "Could not read env for pid " << pid << ": " << e.what();
   }
   return varsMap;
+}
+
+const std::unordered_map<std::string, std::string>&
+getDefaultEnvAttributionMap() {
+  // Used on bare-metal Slurm hosts when no --env_attribution_mappings_file
+  // is provided. Mirrors the historical hardcoded mapping in
+  // DcgmGroupInfo.cpp so non-K8s deployments behave identically.
+  static const std::unordered_map<std::string, std::string> kDefault = {
+      {"SLURM_JOB_ID", "job_id"},
+      {"USER", "username"},
+      {"SLURM_JOB_ACCOUNT", "slurm_account"},
+      {"SLURM_JOB_PARTITION", "slurm_partition"},
+  };
+  return kDefault;
+}
+
+std::unordered_map<std::string, std::string> loadEnvAttributionMap(
+    const std::string& path) {
+  std::unordered_map<std::string, std::string> result;
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    LOG(WARNING) << "Could not open env_attribution_mappings_file: " << path
+                 << "; falling back to built-in default map";
+    return getDefaultEnvAttributionMap();
+  }
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+    // Split on first comma: env_var_name,output_column_name
+    auto pos = line.find(',');
+    if (pos == std::string::npos || pos == 0 || pos + 1 >= line.size()) {
+      LOG(WARNING) << "Skipping malformed env-attribution line: " << line;
+      continue;
+    }
+    std::string env_key = line.substr(0, pos);
+    std::string column = line.substr(pos + 1);
+    // Trim leading + trailing whitespace/CR (handles CRLF input and
+    // tolerates user-friendly spacing around the comma separator).
+    auto isWs = [](char c) {
+      return c == '\r' || c == '\n' || c == ' ' || c == '\t';
+    };
+    auto trim = [&](std::string& s) {
+      while (!s.empty() && isWs(s.back())) {
+        s.pop_back();
+      }
+      size_t i = 0;
+      while (i < s.size() && isWs(s[i])) {
+        ++i;
+      }
+      if (i > 0) {
+        s.erase(0, i);
+      }
+    };
+    trim(env_key);
+    trim(column);
+    if (env_key.empty() || column.empty()) {
+      continue;
+    }
+    result[env_key] = column;
+  }
+  LOG(INFO) << "Loaded " << result.size() << " env-attribution mappings from "
+            << path;
+  return result;
 }
 
 } // namespace dynolog

--- a/dynolog/src/gpumon/Utils.h
+++ b/dynolog/src/gpumon/Utils.h
@@ -23,4 +23,16 @@ std::unordered_map<std::string, std::string> getMetadataForPid(
     pid_t pid,
     const std::unordered_map<std::string, std::string>& keysMap);
 
+// Built-in default env-attribution map, used on bare-metal Slurm when
+// no --env_attribution_mappings_file is supplied.
+const std::unordered_map<std::string, std::string>&
+getDefaultEnvAttributionMap();
+
+// Loads a 2-column CSV of <env_var_name>,<output_column_name> rows.
+// Lines beginning with '#' and empty lines are ignored.
+// Returns the loaded map; on failure, returns the built-in default map and
+// logs a warning.
+std::unordered_map<std::string, std::string> loadEnvAttributionMap(
+    const std::string& path);
+
 } // namespace dynolog

--- a/dynolog/src/k8s/CMakeLists.txt
+++ b/dynolog/src/k8s/CMakeLists.txt
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# K8s platform-discovery libraries used by dynolog. Built only when
+# USE_K8S_PODRESOURCES=ON; otherwise this directory is empty for the
+# OSS CMake build.
+
+if(NOT USE_K8S_PODRESOURCES)
+    return()
+endif()
+
+# Generate C++ + gRPC stubs from the vendored kubelet pod-resources v1
+# proto. Requires protobuf-compiler with the gRPC plugin.
+find_package(Protobuf REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
+find_package(CURL REQUIRED)
+
+set(_kubelet_proto
+    ${CMAKE_CURRENT_SOURCE_DIR}/kubelet_podresources/api.proto)
+set(_kubelet_proto_outdir
+    ${CMAKE_CURRENT_BINARY_DIR}/kubelet_podresources)
+file(MAKE_DIRECTORY ${_kubelet_proto_outdir})
+
+set(_kubelet_pb_h    ${_kubelet_proto_outdir}/api.pb.h)
+set(_kubelet_pb_cc   ${_kubelet_proto_outdir}/api.pb.cc)
+set(_kubelet_grpc_h  ${_kubelet_proto_outdir}/api.grpc.pb.h)
+set(_kubelet_grpc_cc ${_kubelet_proto_outdir}/api.grpc.pb.cc)
+
+get_target_property(_protoc_exec protobuf::protoc LOCATION)
+get_target_property(_grpc_cpp_plugin gRPC::grpc_cpp_plugin LOCATION)
+
+add_custom_command(
+    OUTPUT
+        ${_kubelet_pb_h} ${_kubelet_pb_cc}
+        ${_kubelet_grpc_h} ${_kubelet_grpc_cc}
+    COMMAND ${_protoc_exec}
+        --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/kubelet_podresources
+        --cpp_out=${_kubelet_proto_outdir}
+        --grpc_out=${_kubelet_proto_outdir}
+        --plugin=protoc-gen-grpc=${_grpc_cpp_plugin}
+        ${_kubelet_proto}
+    DEPENDS ${_kubelet_proto} protobuf::protoc gRPC::grpc_cpp_plugin
+    COMMENT "Generating C++/gRPC stubs from kubelet podresources api.proto"
+    VERBATIM
+)
+
+add_library(dynolog_kubelet_podresources_lib
+    ${_kubelet_pb_cc} ${_kubelet_grpc_cc})
+target_include_directories(dynolog_kubelet_podresources_lib PUBLIC
+    # ${CMAKE_BINARY_DIR} so consumers can include the generated header
+    # with its full BUCK-style path:
+    #   "dynolog/src/k8s/kubelet_podresources/api.grpc.pb.h"
+    ${CMAKE_BINARY_DIR}
+    # ${CMAKE_CURRENT_BINARY_DIR} so the generated .pb.cc / .grpc.pb.cc
+    # can include their own short-form siblings (e.g. "api.pb.h").
+    ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(dynolog_kubelet_podresources_lib PUBLIC
+    protobuf::libprotobuf
+    gRPC::grpc++)
+
+# K8s integration library: PodResourcesClient (gRPC over kubelet socket)
+# and K8sPodCache (HTTP+JSON to the K8s API).
+add_library(dynolog_k8s_lib
+    PodResourcesClient.cpp PodResourcesClient.h
+    K8sPodCache.cpp        K8sPodCache.h
+)
+target_include_directories(dynolog_k8s_lib INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(dynolog_k8s_lib PUBLIC
+    glog::glog
+    gflags::gflags
+    nlohmann_json::nlohmann_json
+    dynolog_kubelet_podresources_lib
+    gRPC::grpc++
+    CURL::libcurl)

--- a/dynolog/src/k8s/K8sPodCache.cpp
+++ b/dynolog/src/k8s/K8sPodCache.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/k8s/K8sPodCache.h"
+
+#include <curl/curl.h> // @manual=fbsource//third-party/curl:curl
+#include <glog/logging.h>
+#include <nlohmann/json.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <utility>
+
+namespace dynolog::k8s {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::string readFile(const std::string& path) {
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    return {};
+  }
+  std::stringstream buf;
+  buf << f.rdbuf();
+  return buf.str();
+}
+
+std::string trim(const std::string& s) {
+  size_t b = s.find_first_not_of(" \t\r\n");
+  if (b == std::string::npos) {
+    return {};
+  }
+  size_t e = s.find_last_not_of(" \t\r\n");
+  return s.substr(b, e - b + 1);
+}
+
+size_t curlWrite(char* ptr, size_t size, size_t nmemb, void* userdata) {
+  auto* out = static_cast<std::string*>(userdata);
+  out->append(ptr, size * nmemb);
+  return size * nmemb;
+}
+
+// Resolve K8s Downward-API fieldRefs we can answer from data we already
+// have, without making additional API calls.
+std::string resolveFieldRef(
+    const std::string& fieldPath,
+    const std::string& podNamespace,
+    const std::string& podName,
+    const std::string& podUid) {
+  if (fieldPath == "metadata.name") {
+    return podName;
+  }
+  if (fieldPath == "metadata.namespace") {
+    return podNamespace;
+  }
+  if (fieldPath == "metadata.uid") {
+    return podUid;
+  }
+  if (fieldPath == "spec.nodeName") {
+    if (const char* n = std::getenv("K8S_NODE_NAME"); n) {
+      return n;
+    }
+  }
+  // status.podIP and status.hostIP could be resolved from the pod-spec
+  // response itself, but we don't currently extract them. Skip.
+  return {};
+}
+
+} // namespace
+
+const K8sPodCache::LabelKeyMap& getDefaultLabelAttributionMap() {
+  // Selected K8s labels that are useful for GPU job attribution on CKS.
+  // Adding more is cheap — they all come from the same pod GET response.
+  static const K8sPodCache::LabelKeyMap kLabels = {
+      {"mkube.meta.com/workload-name", "mkube_workload_name"},
+      {"kueue.x-k8s.io/queue-name", "kueue_queue_name"},
+      {"kueue.x-k8s.io/priority-class", "kueue_priority_class"},
+      {"app.kubernetes.io/component", "app_component"},
+  };
+  return kLabels;
+}
+
+struct K8sPodCache::Entry {
+  using Clock = std::chrono::steady_clock;
+  Clock::time_point fetched_at;
+  bool ok = false;
+  // Resolved per-container env vars: container_name -> (env_name -> value).
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      env_by_container;
+  std::unordered_map<std::string, std::string> labels;
+  std::string controller_kind;
+  std::string controller_name;
+};
+
+struct K8sPodCache::Impl {
+  explicit Impl(Options opts) : opts_(std::move(opts)) {
+    if (!std::filesystem::exists(opts_.tokenPath)) {
+      LOG(WARNING) << "K8sPodCache: serviceaccount token not present at "
+                   << opts_.tokenPath
+                   << "; pod-spec fetches will fail until it appears.";
+    }
+  }
+
+  // Re-read the projected ServiceAccount token from disk on every fetch.
+  // K8s rotates these tokens (typically every ~hour); caching the value
+  // would cause silent 401s after rotation. The file lives on tmpfs so
+  // the cost is negligible.
+  std::string readToken() {
+    return trim(readFile(opts_.tokenPath));
+  }
+
+  // Fetch + parse pod spec; populate entry. Returns true on success.
+  bool fetchPod(const std::string& ns, const std::string& name, Entry& out) {
+    std::string url =
+        opts_.apiBase + "/api/v1/namespaces/" + ns + "/pods/" + name;
+
+    std::string body;
+    long httpCode = 0;
+
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+      LOG(ERROR) << "K8sPodCache: curl_easy_init failed";
+      return false;
+    }
+
+    std::string token = readToken();
+    if (token.empty()) {
+      LOG(WARNING) << "K8sPodCache: empty serviceaccount token at "
+                   << opts_.tokenPath << "; skipping fetch for " << ns << "/"
+                   << name;
+      curl_easy_cleanup(curl);
+      return false;
+    }
+
+    struct curl_slist* headers = nullptr;
+    std::string authHeader = "Authorization: Bearer " + token;
+    headers = curl_slist_append(headers, authHeader.c_str());
+    headers = curl_slist_append(headers, "Accept: application/json");
+    if (headers == nullptr) {
+      LOG(WARNING) << "K8sPodCache: curl_slist_append failed for " << ns << "/"
+                   << name;
+      curl_easy_cleanup(curl);
+      return false;
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWrite);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, opts_.httpTimeoutMs);
+    if (!opts_.caPath.empty()) {
+      curl_easy_setopt(curl, CURLOPT_CAINFO, opts_.caPath.c_str());
+    }
+
+    auto rc = curl_easy_perform(curl);
+    if (rc == CURLE_OK) {
+      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+    } else {
+      LOG(WARNING) << "K8sPodCache: curl_easy_perform failed for " << ns << "/"
+                   << name << ": " << curl_easy_strerror(rc);
+    }
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (rc != CURLE_OK || httpCode < 200 || httpCode >= 300) {
+      LOG(WARNING) << "K8sPodCache: GET " << url
+                   << " returned http=" << httpCode;
+      return false;
+    }
+
+    try {
+      auto pod = json::parse(body);
+      const auto& meta = pod.at("metadata");
+      const auto& spec = pod.at("spec");
+
+      std::string podUid = meta.value("uid", "");
+
+      if (auto it = meta.find("labels"); it != meta.end() && it->is_object()) {
+        for (auto label = it->begin(); label != it->end(); ++label) {
+          if (label->is_string()) {
+            out.labels[label.key()] = label->get<std::string>();
+          }
+        }
+      }
+      if (auto refs = meta.find("ownerReferences");
+          refs != meta.end() && refs->is_array() && !refs->empty()) {
+        const auto& first = refs->at(0);
+        out.controller_kind = first.value("kind", "");
+        out.controller_name = first.value("name", "");
+      }
+
+      if (auto containers = spec.find("containers");
+          containers != spec.end() && containers->is_array()) {
+        for (const auto& c : *containers) {
+          std::string cname = c.value("name", "");
+          if (cname.empty()) {
+            continue;
+          }
+          auto& env_map = out.env_by_container[cname];
+          if (auto envIt = c.find("env");
+              envIt != c.end() && envIt->is_array()) {
+            for (const auto& e : *envIt) {
+              std::string ename = e.value("name", "");
+              if (ename.empty()) {
+                continue;
+              }
+              if (auto v = e.find("value"); v != e.end() && v->is_string()) {
+                env_map[ename] = v->get<std::string>();
+                continue;
+              }
+              if (auto vf = e.find("valueFrom");
+                  vf != e.end() && vf->is_object()) {
+                if (auto fr = vf->find("fieldRef");
+                    fr != vf->end() && fr->is_object()) {
+                  std::string fp = fr->value("fieldPath", "");
+                  std::string resolved = resolveFieldRef(fp, ns, name, podUid);
+                  if (!resolved.empty()) {
+                    env_map[ename] = std::move(resolved);
+                  }
+                }
+                // configMapKeyRef / secretKeyRef intentionally skipped.
+              }
+            }
+          }
+        }
+      }
+      out.ok = true;
+      return true;
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "K8sPodCache: failed to parse pod spec for " << ns << "/"
+                   << name << ": " << e.what();
+      return false;
+    }
+  }
+
+  std::unordered_map<std::string, std::string> lookupAttribution(
+      const std::string& ns,
+      const std::string& name,
+      const std::string& container,
+      const EnvKeyMap& envMap,
+      const LabelKeyMap& labelMap) {
+    std::unordered_map<std::string, std::string> result;
+    std::string key = ns + "/" + name;
+
+    bool needs_fetch = false;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = cache_.find(key);
+      if (it == cache_.end()) {
+        needs_fetch = true;
+      } else {
+        auto age = Entry::Clock::now() - it->second.fetched_at;
+        auto ttl = it->second.ok ? opts_.ttl : opts_.negativeTtl;
+        if (age >= ttl) {
+          needs_fetch = true;
+        }
+      }
+    }
+
+    if (needs_fetch) {
+      // Fetch outside the lock; concurrent fetches for the same key are
+      // tolerated (rare, and idempotent).
+      Entry fresh;
+      fresh.ok = fetchPod(ns, name, fresh);
+      // Stamp fetched_at AFTER the network call returns so the entry's
+      // recorded age reflects when the data was actually fresh, not when
+      // we started the (potentially slow) HTTP request.
+      fresh.fetched_at = Entry::Clock::now();
+      std::lock_guard<std::mutex> lk(mu_);
+      // insert_or_assign returns the iterator; reuse it so we don't
+      // re-find under the same lock.
+      auto [it, _] = cache_.insert_or_assign(key, std::move(fresh));
+      if (!it->second.ok) {
+        return result;
+      }
+      copyAttribution(it->second, container, envMap, labelMap, result);
+      return result;
+    }
+
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = cache_.find(key);
+    if (it == cache_.end() || !it->second.ok) {
+      return result;
+    }
+    copyAttribution(it->second, container, envMap, labelMap, result);
+    return result;
+  }
+
+  // Common projection from a cached Entry into the flat attribution map
+  // returned to the caller. Caller must already hold mu_ (if reading from
+  // cache_) or own the Entry (if just-inserted).
+  static void copyAttribution(
+      const Entry& entry,
+      const std::string& container,
+      const EnvKeyMap& envMap,
+      const LabelKeyMap& labelMap,
+      std::unordered_map<std::string, std::string>& result) {
+    // env vars: look up requested keys in this container's env map.
+    if (auto cit = entry.env_by_container.find(container);
+        cit != entry.env_by_container.end()) {
+      for (const auto& [env_key, column] : envMap) {
+        auto eit = cit->second.find(env_key);
+        if (eit != cit->second.end() && !eit->second.empty()) {
+          result[column] = eit->second;
+        }
+      }
+    }
+    // labels.
+    for (const auto& [label_key, column] : labelMap) {
+      auto lit = entry.labels.find(label_key);
+      if (lit != entry.labels.end() && !lit->second.empty()) {
+        result[column] = lit->second;
+      }
+    }
+    // owner refs.
+    if (!entry.controller_kind.empty()) {
+      result["controller_kind"] = entry.controller_kind;
+    }
+    if (!entry.controller_name.empty()) {
+      result["controller_name"] = entry.controller_name;
+    }
+  }
+
+  Options opts_;
+  std::mutex mu_;
+  std::unordered_map<std::string, Entry> cache_;
+};
+
+K8sPodCache::K8sPodCache() : K8sPodCache(Options{}) {}
+
+K8sPodCache::K8sPodCache(Options opts)
+    : impl_(std::make_unique<Impl>(std::move(opts))) {}
+
+K8sPodCache::~K8sPodCache() = default;
+
+std::unordered_map<std::string, std::string> K8sPodCache::lookupAttribution(
+    const std::string& podNamespace,
+    const std::string& podName,
+    const std::string& containerName,
+    const EnvKeyMap& envMap,
+    const LabelKeyMap& labelMap) {
+  return impl_->lookupAttribution(
+      podNamespace, podName, containerName, envMap, labelMap);
+}
+
+} // namespace dynolog::k8s

--- a/dynolog/src/k8s/K8sPodCache.h
+++ b/dynolog/src/k8s/K8sPodCache.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace dynolog::k8s {
+
+// Caches enrichment data fetched from the K8s API for pods running on the
+// local node. Each entry corresponds to one pod (key: "<ns>/<name>"), and
+// stores a flat map of attribution columns (env vars + labels + owner refs)
+// already resolved per-container.
+//
+// Phase 1b's PodResourcesClient gives us (namespace, name, container) per
+// GPU. K8sPodCache then turns that into the actual attribution attributes
+// (mast_job, mast_owner, controller_kind, etc.) that land in the Scuba
+// row.
+//
+// Network access uses libcurl + the in-pod ServiceAccount bearer token and
+// CA cert at /var/run/secrets/kubernetes.io/serviceaccount/{token,ca.crt}.
+//
+// Cache semantics: per-pod TTL. A miss triggers a single GET; subsequent
+// lookups within ttl reuse the cached attributes. Stale entries are
+// re-fetched on next access. Failed lookups are negatively cached for a
+// short window to avoid hammering the API for pods that have been deleted.
+class K8sPodCache {
+ public:
+  struct Options {
+    // K8s API base URL. Inside a pod, kubernetes.default.svc resolves to
+    // the in-cluster API server.
+    std::string apiBase = "https://kubernetes.default.svc";
+    std::string tokenPath =
+        "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    std::string caPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+    // Per-pod cache TTL (seconds). Pod specs are immutable for the
+    // attributes we care about, so a long TTL is safe.
+    std::chrono::seconds ttl{300};
+    std::chrono::seconds negativeTtl{30};
+    long httpTimeoutMs = 2000;
+  };
+
+  // Map: env-var name (as it appears in pod spec) -> output column name.
+  // Same shape as the env-attribution CSV loaded by Utils.cpp.
+  using EnvKeyMap = std::unordered_map<std::string, std::string>;
+  // Map: K8s label key -> output column name. Hardcoded set of common
+  // attribution labels (mkube workload-name, kueue queue-name, etc.).
+  using LabelKeyMap = std::unordered_map<std::string, std::string>;
+
+  K8sPodCache();
+  explicit K8sPodCache(Options opts);
+  ~K8sPodCache();
+
+  K8sPodCache(const K8sPodCache&) = delete;
+  K8sPodCache& operator=(const K8sPodCache&) = delete;
+  K8sPodCache(K8sPodCache&&) = delete;
+  K8sPodCache& operator=(K8sPodCache&&) = delete;
+
+  // Returns attribution attributes for (ns, name, container).
+  // - Looks up env vars whose names appear in envMap, resolving them
+  //   from spec.containers[<container>].env (literal values + downward-API
+  //   fieldRefs we can resolve locally).
+  // - Looks up labels whose keys appear in labelMap.
+  // - Adds controller_kind + controller_name from
+  //   metadata.ownerReferences[0] when present.
+  // Returns empty map on cache miss / fetch failure.
+  std::unordered_map<std::string, std::string> lookupAttribution(
+      const std::string& podNamespace,
+      const std::string& podName,
+      const std::string& containerName,
+      const EnvKeyMap& envMap,
+      const LabelKeyMap& labelMap);
+
+ private:
+  struct Entry; // PIMPL-style; defined in .cpp
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+// Built-in default label-attribution map. Exposed for callers (DcgmGroupInfo).
+const K8sPodCache::LabelKeyMap& getDefaultLabelAttributionMap();
+
+} // namespace dynolog::k8s

--- a/dynolog/src/k8s/PodResourcesClient.cpp
+++ b/dynolog/src/k8s/PodResourcesClient.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/k8s/PodResourcesClient.h"
+
+#include <glog/logging.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+
+#include <atomic>
+#include <mutex>
+#include <utility>
+
+#include "dynolog/src/k8s/kubelet_podresources/api.grpc.pb.h"
+
+namespace dynolog::k8s {
+
+struct PodResourcesClient::Impl {
+  // Build a fresh channel + stub. Pure-local work; safe to call without
+  // holding mu_, then swap into place under the lock.
+  static std::pair<
+      std::shared_ptr<grpc::Channel>,
+      std::shared_ptr<v1::PodResourcesLister::Stub>>
+  buildChannelAndStub(const std::string& socketPath) {
+    // pod-resources socket is unauthenticated AF_UNIX — InsecureChannel.
+    auto channel = grpc::CreateChannel(
+        "unix://" + socketPath, grpc::InsecureChannelCredentials());
+    std::shared_ptr<v1::PodResourcesLister::Stub> stub =
+        v1::PodResourcesLister::NewStub(channel);
+    return {std::move(channel), std::move(stub)};
+  }
+
+  // Determine whether an RPC failure status warrants tearing down and
+  // rebuilding the gRPC channel. gRPC's own backoff/keepalive normally
+  // handles transient deadlines and busy peers; only force a reconnect
+  // when the channel itself looks broken (UNAVAILABLE / UNKNOWN), or
+  // after several consecutive failures of any kind.
+  bool shouldReconnect(grpc::StatusCode code) {
+    if (code == grpc::StatusCode::UNAVAILABLE ||
+        code == grpc::StatusCode::UNKNOWN) {
+      return true;
+    }
+    return ++consecutive_failures_ >= 3;
+  }
+
+  Impl(
+      std::string socketPath,
+      std::string nvidiaResourceName,
+      std::chrono::milliseconds rpcTimeout)
+      : socketPath_(std::move(socketPath)),
+        nvidiaResourceName_(std::move(nvidiaResourceName)),
+        rpcTimeout_(rpcTimeout) {
+    auto [ch, st] = buildChannelAndStub(socketPath_);
+    channel_ = std::move(ch);
+    stub_ = std::move(st);
+    LOG(INFO) << "PodResourcesClient: connected to unix://" << socketPath_;
+  }
+
+  std::unordered_map<std::string, PodInfo> listGpuPods() {
+    std::unordered_map<std::string, PodInfo> result;
+
+    // Snapshot the stub under the lock; do the RPC unlocked. Avoids
+    // serializing concurrent callers behind one in-flight List(). Using
+    // a shared_ptr keeps the snapshotted stub alive until the in-flight
+    // RPC completes, even if a concurrent caller swaps stub_ in a
+    // reconnect.
+    std::shared_ptr<v1::PodResourcesLister::Stub> stub;
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      stub = stub_;
+    }
+    if (stub == nullptr) {
+      LOG(ERROR) << "PodResourcesClient: stub is null";
+      return result;
+    }
+
+    grpc::ClientContext ctx;
+    ctx.set_deadline(std::chrono::system_clock::now() + rpcTimeout_);
+
+    v1::ListPodResourcesRequest req;
+    v1::ListPodResourcesResponse resp;
+
+    auto status = stub->List(&ctx, req, &resp);
+    if (!status.ok()) {
+      LOG(WARNING) << "PodResourcesClient: List() RPC failed: "
+                   << status.error_code() << " " << status.error_message();
+      if (shouldReconnect(status.error_code())) {
+        // Build the new channel + stub WITHOUT holding mu_ (DNS / channel
+        // creation can be slow); then swap atomically.
+        auto [ch, st] = buildChannelAndStub(socketPath_);
+        std::lock_guard<std::mutex> lock(mu_);
+        channel_ = std::move(ch);
+        stub_ = std::move(st);
+        consecutive_failures_ = 0;
+        LOG(INFO) << "PodResourcesClient: reconnected to unix://"
+                  << socketPath_;
+      }
+      return result;
+    }
+    consecutive_failures_ = 0;
+
+    int gpu_assignments = 0;
+    for (const auto& pod : resp.pod_resources()) {
+      for (const auto& container : pod.containers()) {
+        for (const auto& dev : container.devices()) {
+          if (dev.resource_name() != nvidiaResourceName_) {
+            continue;
+          }
+          for (const auto& uuid : dev.device_ids()) {
+            // device_ids for nvidia.com/gpu are the GPU UUIDs
+            // (e.g. "GPU-...."), which join with DCGM_FI_DEV_UUID.
+            result[uuid] = PodInfo{
+                .pod_namespace = pod.namespace_(),
+                .pod_name = pod.name(),
+                .container_name = container.name(),
+            };
+            gpu_assignments++;
+          }
+        }
+      }
+    }
+    VLOG(1) << "PodResourcesClient: List() returned "
+            << resp.pod_resources_size() << " pods, " << gpu_assignments
+            << " GPU device assignments";
+    return result;
+  }
+
+  const std::string socketPath_;
+  const std::string nvidiaResourceName_;
+  const std::chrono::milliseconds rpcTimeout_;
+  std::mutex mu_;
+  // Reconnect bookkeeping — atomic so it's safe to read/increment outside
+  // the channel-swap critical section.
+  std::atomic<int> consecutive_failures_{0};
+  std::shared_ptr<grpc::Channel> channel_;
+  std::shared_ptr<v1::PodResourcesLister::Stub> stub_;
+};
+
+PodResourcesClient::PodResourcesClient(
+    std::string socketPath,
+    std::string nvidiaResourceName,
+    std::chrono::milliseconds rpcTimeout)
+    : impl_(
+          std::make_unique<Impl>(
+              std::move(socketPath),
+              std::move(nvidiaResourceName),
+              rpcTimeout)) {}
+
+PodResourcesClient::~PodResourcesClient() = default;
+
+std::unordered_map<std::string, PodInfo> PodResourcesClient::listGpuPods() {
+  return impl_->listGpuPods();
+}
+
+} // namespace dynolog::k8s

--- a/dynolog/src/k8s/PodResourcesClient.h
+++ b/dynolog/src/k8s/PodResourcesClient.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace dynolog::k8s {
+
+// Per-GPU pod attribution returned by the kubelet pod-resources API.
+// Joined to GPU metrics on gpu_uuid (== the K8s device_id, also
+// DCGM_FI_DEV_UUID).
+struct PodInfo {
+  std::string pod_namespace;
+  std::string pod_name;
+  std::string container_name;
+};
+
+// Thin gRPC client for the kubelet pod-resources List RPC over a unix
+// domain socket (default /var/lib/kubelet/pod-resources/kubelet.sock).
+//
+// listGpuPods() issues one List() RPC, walks per-pod/per-container device
+// assignments, and returns a gpu_uuid -> PodInfo map for devices whose
+// resource_name matches the configured GPU resource (default
+// "nvidia.com/gpu"). Returns an empty map on RPC failure (logged).
+//
+// Thread-safe: a single mutex serializes RPC calls.
+class PodResourcesClient {
+ public:
+  explicit PodResourcesClient(
+      std::string socketPath,
+      std::string nvidiaResourceName = "nvidia.com/gpu",
+      std::chrono::milliseconds rpcTimeout = std::chrono::milliseconds(2000));
+  ~PodResourcesClient();
+
+  PodResourcesClient(const PodResourcesClient&) = delete;
+  PodResourcesClient& operator=(const PodResourcesClient&) = delete;
+  PodResourcesClient(PodResourcesClient&&) = delete;
+  PodResourcesClient& operator=(PodResourcesClient&&) = delete;
+
+  std::unordered_map<std::string, PodInfo> listGpuPods();
+
+ private:
+  // PIMPL keeps gRPC headers out of the public interface.
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dynolog::k8s

--- a/dynolog/src/k8s/kubelet_podresources/api.proto
+++ b/dynolog/src/k8s/kubelet_podresources/api.proto
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Vendored from upstream kubernetes/kubelet at
+//   staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto
+// Reduced to the messages dynolog actually uses (List RPC + per-container
+// device assignments). Gogoproto extensions stripped — they only affect Go
+// codegen and are no-ops for C++. The package name MUST stay "v1" so the
+// gRPC method path matches what kubelet's pod-resources socket serves
+// (v1.PodResourcesLister/List).
+
+syntax = "proto3";
+
+package v1;
+
+// PodResourcesLister is a service provided by the kubelet that exposes the
+// node resources (devices, CPUs, memory) consumed by pods and containers.
+service PodResourcesLister {
+  rpc List(ListPodResourcesRequest) returns (ListPodResourcesResponse) {}
+}
+
+// Empty request — kubelet returns every pod scheduled on the local node.
+message ListPodResourcesRequest {}
+
+message ListPodResourcesResponse {
+  repeated PodResources pod_resources = 1;
+}
+
+// PodResources contains information about the node resources assigned to a
+// pod.
+message PodResources {
+  string name = 1;
+  string namespace = 2;
+  repeated ContainerResources containers = 3;
+}
+
+message ContainerResources {
+  string name = 1;
+  repeated ContainerDevices devices = 2;
+}
+
+// ContainerDevices contains information about the devices assigned to a
+// container. resource_name is the K8s extended resource (e.g.
+// "nvidia.com/gpu"). device_ids holds the per-device identifiers — for NVIDIA
+// GPUs these are the UUIDs (e.g. "GPU-..."), which we join against
+// DCGM_FI_DEV_UUID.
+message ContainerDevices {
+  string resource_name = 1;
+  repeated string device_ids = 2;
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,12 +58,45 @@ if [ "${BUILD_OTEL}" -eq 1 ]; then
   USE_OTEL="ON"
 fi
 
+## Build with K8s pod-resources gRPC + K8s API HTTP attribution if enabled.
+## Requires protoc + grpc_cpp_plugin + grpc++ (C++ headers) + libcurl.
+BUILD_K8S_PODRESOURCES="${BUILD_K8S_PODRESOURCES:-0}"
+USE_K8S_PODRESOURCES="OFF"
+if [ "${BUILD_K8S_PODRESOURCES}" -eq 1 ]; then
+  if ! command -v protoc >/dev/null 2>&1; then
+    echo "Error: protoc not found. Install with:"
+    echo "  apt-get install protobuf-compiler                  # Debian/Ubuntu"
+    echo "  dnf install protobuf-compiler                      # Fedora/RHEL"
+    exit 1
+  fi
+  if ! command -v grpc_cpp_plugin >/dev/null 2>&1; then
+    echo "Error: grpc_cpp_plugin not found. Install with:"
+    echo "  apt-get install protobuf-compiler-grpc             # Debian/Ubuntu"
+    echo "  dnf install grpc-plugins                           # Fedora/RHEL"
+    exit 1
+  fi
+  if ! pkg-config --exists grpc++ 2>/dev/null; then
+    echo "Error: grpc++ not found. Install with:"
+    echo "  apt-get install libgrpc++-dev libprotobuf-dev      # Debian/Ubuntu"
+    echo "  dnf install grpc-devel grpc-cpp protobuf-devel     # Fedora/RHEL"
+    exit 1
+  fi
+  if ! pkg-config --exists libcurl 2>/dev/null; then
+    echo "Error: libcurl not found. Install with:"
+    echo "  apt-get install libcurl4-openssl-dev               # Debian/Ubuntu"
+    echo "  dnf install libcurl-devel                          # Fedora/RHEL"
+    exit 1
+  fi
+  USE_K8S_PODRESOURCES="ON"
+fi
+
 ## Build dynolog
 echo "Running cmake"
 mkdir -p build; cd build;
 
 # note we can build without ninja if not available on this system
 cmake "-DUSE_PROMETHEUS=${USE_PROMETHEUS}" "-DUSE_OTEL=${USE_OTEL}" \
+  "-DUSE_K8S_PODRESOURCES=${USE_K8S_PODRESOURCES}" \
   -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 


### PR DESCRIPTION
Summary:

Adds K8s pod attribution to dynolog so each per-GPU record can be
joined back to the pod that owns the GPU. Two new C++ libraries plus
small wiring in DcgmGroupInfo, all gated by
`--enable_pod_resources_attribution` (default OFF, no behavior change
when unset):

- `PodResourcesClient` — gRPC client for the kubelet pod-resources
  v1 `List` RPC over `unix:///var/lib/kubelet/pod-resources/kubelet.sock`.
  Each cycle, builds a GPU-UUID → (pod_namespace, pod_name,
  container_name) map and stamps those fields onto every GPU record.
  Universal coverage — works for any pod, regardless of its env
  shape. PIMPL keeps gRPC out of the public header. Channel reconnect
  on RPC failure is scoped to UNAVAILABLE / UNKNOWN (or 3 consecutive
  failures), not every transient deadline.

- `K8sPodCache` — libcurl + nlohmann/json client to
  `https://kubernetes.default.svc/api/v1/namespaces/{ns}/pods/{name}`
  using the in-pod ServiceAccount bearer token + CA. Per-pod TTL
  cache (default 5m positive / 30s negative). Resolves env vars from
  `pod.spec.containers[<name>].env` (literal `value` + Downward-API
  `fieldRef`; `configMapKeyRef` / `secretKeyRef` skipped),
  selected `metadata.labels`, and `metadata.ownerReferences[0]`.
  The bearer token is re-read from disk on every request to handle
  K8s token rotation; a stale cached token would otherwise cause
  silent 401s after rotation.

Adjacent changes:
- Generalize the previously hardcoded `attributionEnvVarsToScubaColumns`
  in DcgmGroupInfo into a CSV loader gated by
  `--env_attribution_mappings_file`. Slurm defaults preserved as
  built-in fallback for bare-metal Slurm; new keys are a CSV edit, no
  rebuild.
- OSS CMake: new `USE_K8S_PODRESOURCES` option (default OFF). When
  ON, generates the C++/gRPC stubs from the vendored kubelet
  pod-resources v1 proto and links curl / grpc++ / protobuf into
  `dynolog_dcgm_lib`. Wired behind `BUILD_K8S_PODRESOURCES=1` in
  `scripts/build.sh`, matching the existing `BUILD_OTEL` / `BUILD_PROMETHEUS`
  pattern.
- OtlpLogger.cpp portability fix: `std::get_if` →
  `opentelemetry::nostd::get_if` on the resource-attribute logging
  path so OSS CMake builds with `-DWITH_STL=OFF` (where
  `OwnedAttributeValue` is `absl::variant`) compile.

Reviewed By: bigzachattack

Differential Revision: D105244097


