### PR TITLE
Add ref count to allow same thread to register multiple times (#559)

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -67,7 +67,9 @@ int BPerfPerThreadReader::enable() {
       break;
     }
     close(idx_fd);
+    idx_fd = -1;
     close(data_fd_);
+    data_fd_ = -1;
   }
 
   if (idx_fd < 0 || data_fd_ < 0) {
@@ -91,15 +93,6 @@ int BPerfPerThreadReader::enable() {
     goto error;
   }
 
-  if (::bpf_map_lookup_elem(idx_fd, &tid_fd, &idx) == 0) {
-    // We haven't registered this tid yet. If the tid is already added,
-    // it must be added by a different instance of BPerfPerThreadReader
-    // for the same thread. BPerfPerThreadReader does not support two
-    // instances for the same thread, so we abort this enable().
-    HBT_LOG_ERROR() << "cannot register the same thread twice";
-    goto error;
-  }
-
   mmap_ptr_ = mmap(nullptr, mmap_size_, PROT_READ, MAP_SHARED, data_fd_, 0);
 
   if (mmap_ptr_ == MAP_FAILED) {
@@ -107,6 +100,10 @@ int BPerfPerThreadReader::enable() {
     goto error;
   }
 
+  if (idx_fd < 0) {
+    HBT_LOG_ERROR() << "idx map is missing: " << idx_fd;
+    goto error;
+  }
   err = ::bpf_map_lookup_elem(idx_fd, &tid_fd, &idx);
 
   if (err != 0) {
@@ -123,7 +120,9 @@ int BPerfPerThreadReader::enable() {
   metadata = (struct bperf_thread_metadata*)mmap_ptr_;
 
   ::close(tid_fd);
+  tid_fd = -1;
   ::close(idx_fd);
+  idx_fd = -1;
 
   // Detect whether the leader's layout includes cumulative_sched_delay_ns.
   // metadata->thread_data_size is the leader's sizeof(bperf_thread_data);

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -124,6 +124,19 @@ struct bperf_thread_data {
    */
   __u64 cumulative_sched_delay_ns;
 
+  /* Reference count of mmap registrations from the same task.
+   * Bumped by bperf_register_thread on each successful mmap; decremented
+   * by bperf_unregister_thread on each mmap close. The idx slot is
+   * recycled only when this count drops to zero, allowing the same
+   * thread to register itself multiple times (e.g. via multiple
+   * BPerfPerThreadReader instances).
+   *
+   * Only modified by the registering / unregistering thread itself
+   * (mmap / munmap run synchronously in that thread's context), so no
+   * atomic op is needed.
+   */
+  __u32 ref_count;
+
   struct bperf_perf_event_data events[];
 };
 

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -87,6 +87,7 @@ static __always_inline __u64 event_prev_count(struct perf_event *event) {
 static void bperf_thread_data_init(struct bperf_thread_data *data) {
   int i;
   data->lock = 1;
+  data->ref_count = 1;
   data->runtime_until_offset_update = 0;
   data->cumulative_sched_delay_ns = 0;
   for (i = 0; i < BPERF_MAX_GROUP_SIZE && i < event_cnt; i++) {
@@ -330,9 +331,29 @@ int BPF_PROG(bperf_register_thread, struct bpf_map *map) {
   task = bpf_get_current_task_btf();
 
   task_idx = bpf_task_storage_get(&per_thread_idx, task, 0, 0);
-  if (task_idx)
-    // this thread has already been registered
+  if (task_idx) {
+    /* This thread has already been registered. Bump the ref count
+     * on the existing per-thread data slot so a later munmap from
+     * one of the registrations does not free a slot still in use
+     * by another. ref_count is only ever modified by the registering
+     * / unregistering thread itself, so no atomic is needed.
+     */
+    int existing_idx = *task_idx;
+    data = bpf_map_lookup_elem(&per_thread_data, &existing_idx);
+    if (!data) {
+      /* Should never happen: a task_idx entry exists but its data
+       * slot does not. Indicates the per_thread_data map is out of
+       * sync with per_thread_idx.
+       */
+      return 0;
+    }
+    if (data->ref_count == (__u32)~0u) {
+      /* About to overflow; reject this registration. */
+      return 0;
+    }
+    data->ref_count += 1;
     return 0;
+  }
 
   bpf_spin_lock(&idx_allocator_lock);
   idx = request_idx();
@@ -372,10 +393,40 @@ int BPF_PROG(bperf_unregister_thread, struct vm_area_struct *vma) {
   if (!idx)
     return 0;
 
+  /* Drop one reference. Only release the idx slot once the last
+   * registration for this task is going away. ref_count is only
+   * touched by the same thread that owns the registration, so a
+   * plain decrement is safe.
+   */
+  int task_idx = *idx;
+  struct bperf_thread_data *data =
+      bpf_map_lookup_elem(&per_thread_data, &task_idx);
+  if (!data) {
+    /* Should never happen: a task_idx entry exists but its data
+     * slot does not.
+     */
+    return 0;
+  }
+
+  if (data->ref_count == 0) {
+    /* Defensive: nothing to release (e.g. a prior register was
+     * rejected due to overflow). Keep the slot allocated so we
+     * don't double-free. Should not be hit unless register/unregister
+     * have gotten out of balance.
+     */
+    return 0;
+  }
+
+  data->ref_count -= 1;
+  if (data->ref_count > 0) {
+    /* Other registrations still hold a reference. */
+    return 0;
+  }
+
   bpf_task_storage_delete(&per_thread_idx, task);
 
   bpf_spin_lock(&idx_allocator_lock);
-  reclaim_idx(*idx);
+  reclaim_idx(task_idx);
   bpf_spin_unlock(&idx_allocator_lock);
 
   return 0;


### PR DESCRIPTION
Summary:

Today, BPerfPerThreadReader::enable() refuses to register the calling thread if another instance has already registered it for the same pin. That makes it impossible for two BPerfThreadDynoPerfCounter instances on the same thread to coexist.

This change:
- Adds a `ref_count` field to `struct bperf_thread_data`, appended after the existing fields. Only modified by the registering / unregistering thread itself (mmap / munmap run synchronously in that thread's context), so no atomic op is needed.
- In the BPF program (`bperf_leader_cgroup.bpf.c`):
  - `bperf_thread_data_init` now sets `ref_count = 1`.
  - `bperf_register_thread` (fentry on `array_map_mmap`): when the thread already has an idx, bumps the existing slot's ref_count instead of returning early. The bump is rejected (no wrap) when the field is already at UINT32_MAX.
  - `bperf_unregister_thread` (fentry on `bpf_map_mmap_close`): plain decrement; the slot is reclaimed and the per-task storage entry deleted only when the count drops to zero. A defensive "already 0" guard prevents double-free if a previously-rejected register's munmap fires.
- In BPerfPerThreadReader: removed the early-return that aborted on a duplicate registration. The mmap is allowed to proceed and the BPF program transparently bumps the ref count.
- Extends BPerfDynoPerfCounterProbe with a `--mode=<single|multi>` flag. The new `multi` mode opens many BPerfThreadDynoPerfCounters on the same thread, enables and reads each, then disables them — exercising the same-thread multi-registration path end-to-end.
- Threads the mode through ThreadBPerfMonitor and adds a `thread_bperf_multi_counter` test plan that runs the probe in multi mode with BPerf enabled at both cgroup and thread levels and asserts all operations succeed.

Reviewed By: liu-song-6

Differential Revision: D105400404


