### PR TITLE
Use ARM LL cache miss reads for task mem_bw estimator (#561)

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -1644,6 +1644,10 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
           System::Permissions{},
           std::vector<std::string>{"topdown"}));
 
+  if (cpu_info.cpu_family == CpuFamily::ARM) {
+    addArmCoreMetrics(metrics);
+  }
+
   return metrics;
 }
 

--- a/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
+++ b/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
@@ -40,6 +40,21 @@ TEST_F(BuiltinMetricsTest, Init) {
   EXPECT_EQ(ipc_desc->event_refs_by_arch.at(std::nullopt).size(), 2);
 }
 
+TEST_F(BuiltinMetricsTest, ArmCpuIncludesArmCoreMetrics) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::ARM;
+  cpuInfo.cpu_arch = CpuArch::NEOVERSE_V2;
+  auto armMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  auto llCacheMissDesc = armMetrics->getMetricDesc("HW_CORE_LL_CACHE_MISS_RD");
+  ASSERT_NE(llCacheMissDesc, nullptr);
+
+  auto eventRefs = llCacheMissDesc->getEventRefs(cpuInfo);
+  ASSERT_TRUE(eventRefs.has_value());
+  ASSERT_EQ(eventRefs->size(), 1);
+  EXPECT_EQ(eventRefs->at(0).event_id, "ll_cache_miss_rd");
+}
+
 TEST_F(BuiltinMetricsTest, HwCacheEvents) {
   // -- test for hw cache events
   auto l1_dcache_load_hits = pmu_manager->findEventDef(


### PR DESCRIPTION
Summary:

Use HBT `ll_cache_miss_rd` for the task memory bandwidth estimator on Grace ARM. This avoids the ARM L3D events that do not count reliably, while preserving AMD Zen4/Zen5 `l2_fill_dram_resp` and the existing Intel `LONGEST_LAT_CACHE.MISS` path.

TwTaskMonitor now prepares HBT `HW_CORE_LL_CACHE_MISS_RD` through the regular `ll_cache_miss_rd` enabled key. No reducer publishes that key, so the task metric surface remains unchanged; the key exists only so `enableTaskMetricsEstimator()` can attach the selected event reader.

HBT `makeAvailableMetricsForCpu()` now includes ARM core metrics for ARM CPUs, which lets TwTaskMonitor resolve `HW_CORE_LL_CACHE_MISS_RD` from the shared HBT metrics set. Unit coverage verifies `ll_cache_miss_rd` is prepared but unpublished, and verifies the ARM HBT metric resolves to the expected perf event.

Differential Revision: D106548278


