### PR TITLE
Fix stale CPU sampling on CPUTimeMonitor target updates (#563)

### DIFF
--- a/dynolog/src/CPUTimeMonitor.cpp
+++ b/dynolog/src/CPUTimeMonitor.cpp
@@ -9,6 +9,7 @@
 #include <dynolog/src/metric_frame/MetricFrameTsUnit.h>
 
 #include <algorithm>
+#include <set>
 #include <utility>
 
 enum { IDX_MIN = 0, IDX_SEC = 1, IDX_HUNDRED_MS = 2 };
@@ -360,15 +361,19 @@ void CPUTimeMonitor::tick(TMask mask) {
   std::vector<::dynolog::CpuTime> cpuTimeData = readProcStat(readPerCore);
   TimePoint measureTime = std::chrono::steady_clock::now();
 
-  std::map<std::string, std::tuple<TimePoint, uint64_t>> cgroupCpuStats;
+  std::map<std::string, std::tuple<TimePoint, uint64_t, std::string>>
+      cgroupCpuStats;
   if (readCgroupStat_) {
     std::shared_lock lock(dataLock_);
     for (const auto& [targetId, path] : targetCgroupPaths_) {
       auto usage = readCgroupCpuStat(path);
       if (usage.has_value()) {
+        // Carry the sampled path so processing can drop the sample if the
+        // target's cgroup path changes before the unique lock is acquired.
         cgroupCpuStats.emplace(
             targetId,
-            std::make_tuple(std::chrono::steady_clock::now(), usage.value()));
+            std::make_tuple(
+                std::chrono::steady_clock::now(), usage.value(), path));
       }
     }
   }
@@ -420,33 +425,67 @@ void CPUTimeMonitor::registerTarget(
                      return a + " " + std::to_string(b);
                    })
             << ", path: " << path.value_or("(none)");
-  {
-    std::shared_lock lock(dataLock_);
-    if (targetToCpuSet_.find(targetId) != targetToCpuSet_.end()) {
+  std::unique_lock lock(dataLock_);
+
+  const auto it = targetToCpuSet_.find(targetId);
+  const bool isNew = it == targetToCpuSet_.end();
+  if (!isNew) {
+    const std::set<int64_t> currentCpuSet(it->second.begin(), it->second.end());
+    const std::set<int64_t> newCpuSet(cpuSet.begin(), cpuSet.end());
+    const bool cpuSetChanged = currentCpuSet != newCpuSet;
+    const auto pathIt = targetCgroupPaths_.find(targetId);
+    const bool cgroupPathChanged = path.has_value()
+        ? (pathIt == targetCgroupPaths_.end() || pathIt->second != path.value())
+        : (pathIt != targetCgroupPaths_.end());
+
+    if (!cpuSetChanged && !cgroupPathChanged) {
       LOG(INFO) << "Target is already registered, targetId: " << targetId;
       return;
     }
+
+    LOG(INFO) << "Update target, targetId: " << targetId;
+    // Reset baselines for whatever changed so the next sample reseeds.
+    const auto eraseBaselines = [&targetId](auto& baselines) {
+      for (auto& last : baselines) {
+        last.erase(targetId);
+      }
+    };
+    if (cpuSetChanged) {
+      eraseBaselines(procCpuTimeLast_);
+    }
+    if (cgroupPathChanged) {
+      eraseBaselines(cgroupUsageLast_);
+      eraseBaselines(cgroupTimeLast_);
+    }
   }
-  std::unique_lock lock(dataLock_);
+
+  // Shared write for new and updated targets; erase is a no-op when new.
   targetToCpuSet_[targetId] = cpuSet;
   if (!cpuSet.empty()) {
     targetsNeedPerCore_.insert(targetId);
-  }
-  for (auto& frame : procUsageMetricFrames_) {
-    frame.addSeries(
-        targetId,
-        std::make_shared<MetricSeries<double>>(
-            frame.maxLength(), targetId, ""));
-    addBreakdownSeries(frame, targetId);
-  }
-  for (auto& frame : cgroupUsageMetricFrames_) {
-    frame.addSeries(
-        targetId,
-        std::make_shared<MetricSeries<double>>(
-            frame.maxLength(), targetId, ""));
+  } else {
+    targetsNeedPerCore_.erase(targetId);
   }
   if (path.has_value()) {
     targetCgroupPaths_[targetId] = path.value();
+  } else {
+    targetCgroupPaths_.erase(targetId);
+  }
+
+  if (isNew) {
+    for (auto& frame : procUsageMetricFrames_) {
+      frame.addSeries(
+          targetId,
+          std::make_shared<MetricSeries<double>>(
+              frame.maxLength(), targetId, ""));
+      addBreakdownSeries(frame, targetId);
+    }
+    for (auto& frame : cgroupUsageMetricFrames_) {
+      frame.addSeries(
+          targetId,
+          std::make_shared<MetricSeries<double>>(
+              frame.maxLength(), targetId, ""));
+    }
   }
 }
 
@@ -459,6 +498,9 @@ void CPUTimeMonitor::deRegisterTarget(const std::string& targetId) {
     last.erase(targetId);
   }
   for (auto& last : cgroupUsageLast_) {
+    last.erase(targetId);
+  }
+  for (auto& last : cgroupTimeLast_) {
     last.erase(targetId);
   }
   for (auto& frame : procUsageMetricFrames_) {
@@ -721,7 +763,7 @@ void CPUTimeMonitor::processProcUsage(
 
 void CPUTimeMonitor::processCgroupUsage(
     int level,
-    const std::map<std::string, std::tuple<TimePoint, uint64_t>>&
+    const std::map<std::string, std::tuple<TimePoint, uint64_t, std::string>>&
         cgroupCpuStats,
     TimePoint tickTime,
     TMask mask) {
@@ -735,7 +777,15 @@ void CPUTimeMonitor::processCgroupUsage(
   MapSamplesT line;
 
   for (const auto& [targetId, cpuStat] : cgroupCpuStats) {
-    auto [readTime, newUsage] = cpuStat;
+    const auto& [readTime, newUsage, sampledPath] = cpuStat;
+    // Drop in-flight samples whose cgroup path changed (or whose target was
+    // deregistered) between sampling under the shared lock and processing here.
+    // Reseeding a baseline from a stale-path sample would make the next tick
+    // compute a delta across two different cgroups.
+    auto pathIt = targetCgroupPaths_.find(targetId);
+    if (pathIt == targetCgroupPaths_.end() || pathIt->second != sampledPath) {
+      continue;
+    }
     if (lastUsage.find(targetId) == lastUsage.end() ||
         lastTime.find(targetId) == lastTime.end()) {
       lastUsage[targetId] = newUsage;

--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -164,7 +164,7 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
 
   void processCgroupUsage(
       int level,
-      const std::map<std::string, std::tuple<TimePoint, uint64_t>>&
+      const std::map<std::string, std::tuple<TimePoint, uint64_t, std::string>>&
           cgroupCpuStats,
       TimePoint measure_time_lo,
       TMask mask);

--- a/dynolog/tests/CPUTimeMonitorTest.cpp
+++ b/dynolog/tests/CPUTimeMonitorTest.cpp
@@ -49,6 +49,14 @@ class CPUTimeMonitorTest : public ::testing::Test {
   auto readCgroupCpuStat(const std::string& cgroupPath) {
     return monitor->readCgroupCpuStat(cgroupPath);
   }
+  void processCgroupUsage(
+      int level,
+      const std::map<std::string, std::tuple<TimePoint, uint64_t, std::string>>&
+          cgroupCpuStats,
+      TimePoint tickTime,
+      CPUTimeMonitor::TMask mask) {
+    monitor->processCgroupUsage(level, cgroupCpuStats, tickTime, mask);
+  }
   auto& procCPUTimeLast_() const {
     return monitor->procCpuTimeLast_;
   }
@@ -63,6 +71,9 @@ class CPUTimeMonitorTest : public ::testing::Test {
   }
   auto& cgroupTimeLast_() const {
     return monitor->cgroupTimeLast_;
+  }
+  auto& targetCgroupPaths_() const {
+    return monitor->targetCgroupPaths_;
   }
   std::shared_ptr<CPUTimeMonitor> monitor = createTestMonitor();
 };
@@ -697,16 +708,18 @@ TEST_F(CPUTimeMonitorTest, testCgroupUsageProcessing) {
   EXPECT_GT(series1->size(), 0);
   EXPECT_GT(series2->size(), 0);
 
-  // Test deregistration cleans up cgroup data
+  // Test deregistration clears both cgroup baselines (usage and time)
   monitor->deRegisterTarget(target2);
-  EXPECT_FALSE(cgroupUsageLast_()[0].count(target2));
-  EXPECT_FALSE(cgroupUsageLast_()[1].count(target2));
-  EXPECT_FALSE(cgroupUsageLast_()[2].count(target2));
+  for (size_t i = 0; i < cgroupUsageLast_().size(); ++i) {
+    EXPECT_FALSE(cgroupUsageLast_()[i].count(target2));
+    EXPECT_FALSE(cgroupTimeLast_()[i].count(target2));
+  }
 
   // host target should still exist
-  EXPECT_TRUE(cgroupUsageLast_()[0].count(hostTarget));
-  EXPECT_TRUE(cgroupUsageLast_()[1].count(hostTarget));
-  EXPECT_TRUE(cgroupUsageLast_()[2].count(hostTarget));
+  for (size_t i = 0; i < cgroupUsageLast_().size(); ++i) {
+    EXPECT_TRUE(cgroupUsageLast_()[i].count(hostTarget));
+    EXPECT_TRUE(cgroupTimeLast_()[i].count(hostTarget));
+  }
 }
 
 // Test cgroup processing with mixed targets (some with cgroup paths, some
@@ -753,6 +766,109 @@ TEST_F(CPUTimeMonitorTest, testInvalidCgroupPath) {
   EXPECT_FALSE(cgroupUsageLast_()[0].count("invalid_path"));
 
   monitor->deRegisterTarget("invalid_path");
+}
+
+TEST_F(CPUTimeMonitorTest, testRegisterTargetUpdatesCgroupPath) {
+  const std::string target = "moving_cgroup";
+
+  monitor->registerTarget(target, {}, "/old/cgroup/path");
+  ASSERT_EQ(targetCgroupPaths_().at(target), "/old/cgroup/path");
+
+  const auto now = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < cgroupUsageLast_().size(); ++i) {
+    cgroupUsageLast_()[i][target] = 100;
+    cgroupTimeLast_()[i][target] = now;
+  }
+
+  monitor->registerTarget(target, {}, "/new/cgroup/path");
+
+  EXPECT_EQ(targetCgroupPaths_().at(target), "/new/cgroup/path");
+  for (size_t i = 0; i < cgroupUsageLast_().size(); ++i) {
+    EXPECT_FALSE(cgroupUsageLast_()[i].count(target));
+    EXPECT_FALSE(cgroupTimeLast_()[i].count(target));
+  }
+
+  monitor->deRegisterTarget(target);
+}
+
+TEST_F(CPUTimeMonitorTest, testRegisterTargetUpdatesCpuSet) {
+  const std::string target = "moving_cpuset";
+  const std::string path = "/sys/fs/cgroup";
+
+  monitor->registerTarget(target, {0, 1}, path);
+
+  // Seed stale baselines for both data sources.
+  const auto now = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < procCPUTimeLast_().size(); ++i) {
+    procCPUTimeLast_()[i][target] = ::dynolog::CpuTime{};
+    cgroupUsageLast_()[i][target] = 100;
+    cgroupTimeLast_()[i][target] = now;
+  }
+
+  // Re-register with a different cpuSet but the same cgroup path.
+  monitor->registerTarget(target, {2, 3}, path);
+
+  // proc baselines are reset because the cpuSet changed...
+  for (size_t i = 0; i < procCPUTimeLast_().size(); ++i) {
+    EXPECT_FALSE(procCPUTimeLast_()[i].count(target));
+  }
+  // ...but cgroup baselines are untouched because the path did not change.
+  for (size_t i = 0; i < cgroupUsageLast_().size(); ++i) {
+    EXPECT_TRUE(cgroupUsageLast_()[i].count(target));
+    EXPECT_TRUE(cgroupTimeLast_()[i].count(target));
+  }
+
+  monitor->deRegisterTarget(target);
+}
+
+// Re-registering with the same cores in a different order must be treated as
+// unchanged (cpuSet is compared as a set), so the proc baseline is preserved.
+TEST_F(CPUTimeMonitorTest, testRegisterTargetSameCpuSetReorderedKeepsBaseline) {
+  const std::string target = "reordered_cpuset";
+
+  monitor->registerTarget(target, {0, 1, 2, 3});
+  for (size_t i = 0; i < procCPUTimeLast_().size(); ++i) {
+    procCPUTimeLast_()[i][target] = ::dynolog::CpuTime{};
+  }
+
+  monitor->registerTarget(target, {3, 2, 1, 0});
+
+  for (size_t i = 0; i < procCPUTimeLast_().size(); ++i) {
+    EXPECT_TRUE(procCPUTimeLast_()[i].count(target));
+  }
+
+  monitor->deRegisterTarget(target);
+}
+
+// A cgroup sample read from a target's old path (under the shared lock) must be
+// dropped if registerTarget() changed the path before the sample is processed
+// (under the unique lock). Otherwise it would reseed a just-cleared baseline
+// and the next tick would compute a delta across two different cgroups.
+TEST_F(CPUTimeMonitorTest, testProcessCgroupUsageDropsStalePathSample) {
+  using CgroupSample = std::tuple<TimePoint, uint64_t, std::string>;
+  const std::string target = "racing_cgroup";
+  constexpr int kLevel = 2; // 100ms granularity
+
+  monitor->registerTarget(target, {}, "/new/cgroup/path");
+  ASSERT_EQ(targetCgroupPaths_().at(target), "/new/cgroup/path");
+
+  const auto now = std::chrono::steady_clock::now();
+
+  // In-flight sample from the old path must be ignored, not seed a baseline.
+  std::map<std::string, CgroupSample> staleSample;
+  staleSample[target] = CgroupSample{now, 12345u, "/old/cgroup/path"};
+  processCgroupUsage(kLevel, staleSample, now, subminor_tick_100ms);
+  EXPECT_FALSE(cgroupUsageLast_()[kLevel].count(target));
+  EXPECT_FALSE(cgroupTimeLast_()[kLevel].count(target));
+
+  // A sample on the current path seeds the baseline as usual.
+  std::map<std::string, CgroupSample> freshSample;
+  freshSample[target] = CgroupSample{now, 12345u, "/new/cgroup/path"};
+  processCgroupUsage(kLevel, freshSample, now, subminor_tick_100ms);
+  EXPECT_TRUE(cgroupUsageLast_()[kLevel].count(target));
+  EXPECT_TRUE(cgroupTimeLast_()[kLevel].count(target));
+
+  monitor->deRegisterTarget(target);
 }
 
 // Test data source selection functionality


### PR DESCRIPTION
Summary:

`CPUTimeMonitor::registerTarget()` runs on every allotment refresh, but it treated an already-registered target ID as a no-op. When an allotment's cpuSet or cgroup path changed under a reused UUID, that left two ways for the monitor to keep emitting stale CPU samples:

1. Stale registration: a changed cgroup path was never adopted, so the monitor kept reading the old `cpu.stat` path every 100ms, and a changed cpuSet was likewise ignored.

2. In-flight cross-cgroup delta (TOCTOU): `tick()` reads cgroup samples under a shared lock but processes them later under a separately-acquired unique lock. A path change in that window could reseed a just-cleared baseline from an old-path sample, so the next tick computed a delta across two different cgroups.

Changes:

- `registerTarget()` now updates the cpuSet and cgroup path of an existing target. A cpuSet change resets the proc-stat baselines; a cgroup-path change resets the cgroup-stat baselines, so the next sample reseeds from the new source instead of diffing across unrelated cgroups.
- Each cgroup sample now carries the path it was read from, and `processCgroupUsage()` drops any sample whose path no longer matches the target's currently registered path (this also covers deregistration), closing the TOCTOU race.
- `registerTarget()` is restructured so the create and update code paths share their bookkeeping instead of duplicating it.
- `deRegisterTarget()` now also clears `cgroupTimeLast_` (previously only `cgroupUsageLast_` was cleared), so the cgroup usage and time baselines are always torn down together.

Differential Revision: D106695775
