### PR TITLE
Add AVG aggregation for ALLOTMENT CPU utilization and saturation thrift API

### DIFF
--- a/dynolog/src/CPUTimeMonitor.h
+++ b/dynolog/src/CPUTimeMonitor.h
@@ -78,7 +78,7 @@ class CPUTimeMonitor : MonitorBase<Ticker<60000, 1000, 10, 3>> {
 
   void deRegisterTarget(const std::string& targetId);
 
-  std::optional<double> getAvgCPUCoresUsage(
+  virtual std::optional<double> getAvgCPUCoresUsage(
       Granularity gran,
       uint64_t seconds_ago,
       const std::optional<std::string>& targetId = std::nullopt,


### PR DESCRIPTION
Summary:
Adds Aggregation::AVG support for MetricName::CPU_UTIL and MetricName::CPU_SATURATION at ALLOTMENT scope in DynoLogSchematizedService, bringing the CPU specs to parity with memory bandwidth.

The MetricSpec entry allows AVG through validation; AllotmentMetricsReader routes AVG to getAvgCPUCoresUsage instead of getQuantileCPUCoresUsage. Default aggregation stays P99.

Reviewed By: yaoz08

Differential Revision: D106575692


