### PR TITLE
Bypass forward proxy for K8s API calls (#566)

### DIFF
--- a/dynolog/src/k8s/K8sPodCache.cpp
+++ b/dynolog/src/k8s/K8sPodCache.cpp
@@ -153,6 +153,10 @@ struct K8sPodCache::Impl {
     }
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    // Bypass forward proxy for in-cluster K8s API calls (T272296869).
+    // The K8s API server is always cluster-internal; routing through
+    // fwdproxy causes false-positive crawler detection.
+    curl_easy_setopt(curl, CURLOPT_NOPROXY, "*");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWrite);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);


### PR DESCRIPTION
Summary:

K8sPodCache makes curl calls to the in-cluster Kubernetes API server
HTTP_PROXY/HTTPS_PROXY environment variables, causing these internal calls to be
detection pipeline (T272296869) since the calls appeared as accessing 41 distinct
"domains" (different K8s API server IPv6 addresses).

Fix: Set CURLOPT_NOPROXY to "*" to ensure K8s API calls are made directly
without going through the forward proxy.

Differential Revision: D106845050


