### PR TITLE
AMD Venice (Zen 6) raw perf-event encodings (#567)

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -664,6 +664,22 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "L2 cache fill from all DRAM or MMIO responses.",
           "L2 cache fill requests that target the same or another NUMA node and return from either DRAM or MMIO from the same or different NUMA node."),
       std::vector<EventId>({"l2-fill-dram-resp"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "l3_cache_access",
+          EventDef::Encoding{.code = amd_msr::kL3CacheAccess.val},
+          "L3 cache accesses.",
+          "All coherent accesses (hit + miss) to L3."),
+      std::vector<EventId>({"amd-l3-cache-access"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "l3_cache_misses",
+          EventDef::Encoding{.code = amd_msr::kL3CacheMisses.val},
+          "L3 cache misses.",
+          "Coherent accesses that miss in L3."),
+      std::vector<EventId>({"amd-l3-cache-misses"}));
 }
 
 void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
@@ -690,10 +706,137 @@ void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
           EventDef::Encoding{.code = amd_msr::kUmcZen5Cyc.val},
           "Zen5 UMC cycles",
           "Total number of DRAM bus channel cycles."),
-      std::vector<EventId>({"zen5-umc-write-cycles"}));
+      std::vector<EventId>({"zen5-umc-cycles"}));
 }
 
 } // namespace turin
+
+namespace venice {
+
+// Venice unchanged core events come from addCoreEvents()
+void addEvents(PmuDeviceManager& pmu_manager) {
+  // ---- Core events with Venice specific encodings (changed vs Turin) ----
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l1_dcache_misses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL1DCacheMisses.val},
+          "L1 data cache misses (Venice).",
+          "L1 data cache misses (all allocations)."),
+      std::vector<EventId>({"zen6-l1-dcache-misses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l2_dcache_accesses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL2DCacheAccesses.val},
+          "L2 data cache accesses (Venice).",
+          "L2 data cache accesses."),
+      std::vector<EventId>({"zen6-l2-dcache-accesses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l2_accesses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL2Accesses.val},
+          "L2 cache accesses (Venice).",
+          "L2 cache accesses including L2 prefetcher."),
+      std::vector<EventId>({"zen6-l2-accesses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::ls_mab_alloc_pipes",
+          EventDef::Encoding{.code = amd_msr::kVeniceLsMabAllocPipes.val},
+          "Load-store MAB allocated to pipes (Venice).",
+          "Load-store MAB allocated to pipes."),
+      std::vector<EventId>({"zen6-ls-mab-alloc-pipes"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_back_pressure",
+          EventDef::Encoding{
+              .code = amd_msr::kVeniceStalledCyclesBackPressure.val},
+          "Stalled cycles due to back pressure (Venice).",
+          "Dynamic tokens dispatch stall cycles due to back pressure."),
+      std::vector<EventId>({"zen6-stalled-cycles-back-pressure"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_idq_empty",
+          EventDef::Encoding{.code = amd_msr::kVeniceStalledCyclesIdqEmpty.val},
+          "Stalled cycles due to op queue empty (Venice).",
+          "Op queue (IDQ) empty cycles."),
+      std::vector<EventId>({"zen6-stalled-cycles-idq-empty"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_any",
+          EventDef::Encoding{.code = amd_msr::kVeniceStalledCyclesAny.val},
+          "Stalled cycles due to any reason (Venice).",
+          "Cycles with no retire."),
+      std::vector<EventId>({"zen6-stalled-cycles-any"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::ic_mab_request",
+          EventDef::Encoding{.code = amd_msr::kVeniceIcMabRequest.val},
+          "Instruction cache MAB requests (Venice).",
+          "Instruction cache fills from any data source."),
+      std::vector<EventId>({"zen6-ic-mab-request"}));
+
+  // ---- New Venice core metrics ----
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::retired_sse_avx_flops",
+          // Venice (Zen6) uses the Zen4+ SSE/AVX FLOPS unitMask (0x1f),
+          // matching Genoa/Bergamo/Turin
+          EventDef::Encoding{.code = amd_msr::kZen4RetiredSseAvxFlops.val},
+          "Retired SSE/AVX floating-point ops (Venice).",
+          "Retired SSE/AVX floating-point ops."),
+      std::vector<EventId>({"zen6-retired-sse-avx-flops"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::bad_speculation",
+          EventDef::Encoding{.code = amd_msr::kVeniceBadSpeculation.val},
+          "Bad speculation (Venice).",
+          "Ops dispatched that did not retire."),
+      std::vector<EventId>({"zen6-bad-speculation"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::sw_prefetch_total",
+          EventDef::Encoding{.code = amd_msr::kLsSwPfDcFillsAll.val},
+          "Software prefetch total (Venice).",
+          "All software prefetch data cache fills."),
+      std::vector<EventId>({"zen6-sw-prefetch-total"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::inefficient_sw_prefetch",
+          EventDef::Encoding{.code = amd_msr::kLsInefSwPref.val},
+          "Inefficient software prefetches (Venice).",
+          "Inefficient software prefetches."),
+      std::vector<EventId>({"zen6-inefficient-sw-prefetch"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_fill_rd_resp_cnt",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4FillRdRespCnt.val},
+          "L3 sampled fill read-response latency (aggregate).",
+          "Aggregate sampled latency of L3 fill read responses across all sources."),
+      std::vector<EventId>({"zen4-l3-fill-rd-resp-cnt"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_fill_rd_resp_smpl",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4FillRdRespSmpl.val},
+          "L3 sampled fill read-response requests (aggregate).",
+          "Aggregate count of sampled L3 fill read-response requests across all sources."),
+      std::vector<EventId>({"zen4-l3-fill-rd-resp-smpl"}));
+}
+
+} // namespace venice
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
   // Add AMD core L1 - common across all architectures
@@ -721,6 +864,17 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
       milan::addEventsFb(pmu_manager);
 #endif
       turin::addEvents(pmu_manager);
+      turin::addZen5UmcEvents(pmu_manager);
+      break;
+    case CpuArch::VENICE:
+      // Reuse Milan & Turin unchanged events
+      milan::addEvents(pmu_manager);
+      turin::addEvents(pmu_manager);
+      // Venice-specific core encoding overrides + new core metrics + L3
+      // access/aggregate-latency events.
+      venice::addEvents(pmu_manager);
+      // UMC bandwidth events (same encodings as Zen5).
+      turin::addZen5UmcEvents(pmu_manager);
       break;
     default:
       HBT_LOG_ERROR()

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -572,6 +572,32 @@ constexpr PmuMsr kDfZen4CxlWriteBeatsCmp3{
         .event_13_8 = 0x3,
     }};
 
+// Venice (Zen 6) core counters.
+// These event encodings changed vs Turin/Zen5; see the AMD Venice PPR. Events
+// that are unchanged (NC) continue to use the common constants above.
+constexpr PmuMsr kVeniceL1DCacheMisses{
+    .amdCore = {.event = 0x41, .unitMask = 0x0f}}; // 0x1f reserved on Venice
+constexpr PmuMsr kVeniceL2DCacheAccesses{
+    .amdCore = {.event = 0x64, .unitMask = 0xf8}}; // adds bit7 LsRdBlkCS
+constexpr PmuMsr kVeniceL2Accesses{
+    .amdCore = {.event = 0x64, .unitMask = 0xff}};
+constexpr PmuMsr kVeniceLsMabAllocPipes{
+    .amdCore = {
+        .event = 0x41,
+        .unitMask = 0x0f}}; // same fix as L1 dcache misses
+constexpr PmuMsr kVeniceStalledCyclesBackPressure{
+    .amdCore = {.event = 0xae, .unitMask = 0x5f}}; // PMCx087 removed on Venice
+constexpr PmuMsr kVeniceStalledCyclesIdqEmpty{
+    .amdCore = {.event = 0xa9}}; // Op Queue Empty; PMCx087 removed
+constexpr PmuMsr kVeniceStalledCyclesAny{
+    .amdCore = {.event = 0xd6, .unitMask = 0x1b}}; // cycles with no retire
+constexpr PmuMsr kVeniceIcMabRequest{
+    // PMCx29C unitmask 0xDF (Any IC Fills by Data Source), per the AMD PPR.
+    // The 12-bit event-select 0x29C, (0x2 << 8) | 0x9C == 0x29C
+    .amdCore = {.event = 0x9c, .unitMask = 0xdf, .event_11_8 = 0x2}};
+constexpr PmuMsr kVeniceBadSpeculation{
+    .amdCore = {.event = 0xaa, .unitMask = 0x03}}; // bits[1:0] only on Venice
+
 } // namespace amd_msr
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager);


### PR DESCRIPTION
Summary:

Why: Venice changes several core event/unit-mask encodings vs Zen5 and adds new
core and L3 events; the raw encodings must be registered with the PmuDeviceManager
before any metric descriptor can reference them.
What: amd_msr gains the kVenice* MSR encodings that differ from Turin/Zen5;
venice::addEvents() adds the core encoding overrides and new core events (retired
SSE/AVX FLOPs, bad speculation, sw-prefetch totals) plus the amd_l3 aggregate
sampled-latency events; register l3_cache_access/l3_cache_misses under amd_l3 and
fix the zen5 UMC cycles alias; addAmdEvents() wires the CpuArch::VENICE dispatch
(reuse Milan+Turin events, then Venice overrides + Zen5 UMC).

Differential Revision: D108026157


