### PR TITLE
AMD Venice (Zen 6) builtin core metric descriptors

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -664,6 +664,22 @@ void addEvents(PmuDeviceManager& pmu_manager) {
           "L2 cache fill from all DRAM or MMIO responses.",
           "L2 cache fill requests that target the same or another NUMA node and return from either DRAM or MMIO from the same or different NUMA node."),
       std::vector<EventId>({"l2-fill-dram-resp"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "l3_cache_access",
+          EventDef::Encoding{.code = amd_msr::kL3CacheAccess.val},
+          "L3 cache accesses.",
+          "All coherent accesses (hit + miss) to L3."),
+      std::vector<EventId>({"amd-l3-cache-access"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "l3_cache_misses",
+          EventDef::Encoding{.code = amd_msr::kL3CacheMisses.val},
+          "L3 cache misses.",
+          "Coherent accesses that miss in L3."),
+      std::vector<EventId>({"amd-l3-cache-misses"}));
 }
 
 void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
@@ -690,10 +706,137 @@ void addZen5UmcEvents(PmuDeviceManager& pmu_manager) {
           EventDef::Encoding{.code = amd_msr::kUmcZen5Cyc.val},
           "Zen5 UMC cycles",
           "Total number of DRAM bus channel cycles."),
-      std::vector<EventId>({"zen5-umc-write-cycles"}));
+      std::vector<EventId>({"zen5-umc-cycles"}));
 }
 
 } // namespace turin
+
+namespace venice {
+
+// Venice unchanged core events come from addCoreEvents()
+void addEvents(PmuDeviceManager& pmu_manager) {
+  // ---- Core events with Venice specific encodings (changed vs Turin) ----
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l1_dcache_misses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL1DCacheMisses.val},
+          "L1 data cache misses (Venice).",
+          "L1 data cache misses (all allocations)."),
+      std::vector<EventId>({"zen6-l1-dcache-misses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l2_dcache_accesses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL2DCacheAccesses.val},
+          "L2 data cache accesses (Venice).",
+          "L2 data cache accesses."),
+      std::vector<EventId>({"zen6-l2-dcache-accesses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::l2_accesses",
+          EventDef::Encoding{.code = amd_msr::kVeniceL2Accesses.val},
+          "L2 cache accesses (Venice).",
+          "L2 cache accesses including L2 prefetcher."),
+      std::vector<EventId>({"zen6-l2-accesses"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::ls_mab_alloc_pipes",
+          EventDef::Encoding{.code = amd_msr::kVeniceLsMabAllocPipes.val},
+          "Load-store MAB allocated to pipes (Venice).",
+          "Load-store MAB allocated to pipes."),
+      std::vector<EventId>({"zen6-ls-mab-alloc-pipes"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_back_pressure",
+          EventDef::Encoding{
+              .code = amd_msr::kVeniceStalledCyclesBackPressure.val},
+          "Stalled cycles due to back pressure (Venice).",
+          "Dynamic tokens dispatch stall cycles due to back pressure."),
+      std::vector<EventId>({"zen6-stalled-cycles-back-pressure"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_idq_empty",
+          EventDef::Encoding{.code = amd_msr::kVeniceStalledCyclesIdqEmpty.val},
+          "Stalled cycles due to op queue empty (Venice).",
+          "Op queue (IDQ) empty cycles."),
+      std::vector<EventId>({"zen6-stalled-cycles-idq-empty"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::stalled_cycles_any",
+          EventDef::Encoding{.code = amd_msr::kVeniceStalledCyclesAny.val},
+          "Stalled cycles due to any reason (Venice).",
+          "Cycles with no retire."),
+      std::vector<EventId>({"zen6-stalled-cycles-any"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::ic_mab_request",
+          EventDef::Encoding{.code = amd_msr::kVeniceIcMabRequest.val},
+          "Instruction cache MAB requests (Venice).",
+          "Instruction cache fills from any data source."),
+      std::vector<EventId>({"zen6-ic-mab-request"}));
+
+  // ---- New Venice core metrics ----
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::retired_sse_avx_flops",
+          // Venice (Zen6) uses the Zen4+ SSE/AVX FLOPS unitMask (0x1f),
+          // matching Genoa/Bergamo/Turin
+          EventDef::Encoding{.code = amd_msr::kZen4RetiredSseAvxFlops.val},
+          "Retired SSE/AVX floating-point ops (Venice).",
+          "Retired SSE/AVX floating-point ops."),
+      std::vector<EventId>({"zen6-retired-sse-avx-flops"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::bad_speculation",
+          EventDef::Encoding{.code = amd_msr::kVeniceBadSpeculation.val},
+          "Bad speculation (Venice).",
+          "Ops dispatched that did not retire."),
+      std::vector<EventId>({"zen6-bad-speculation"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::sw_prefetch_total",
+          EventDef::Encoding{.code = amd_msr::kLsSwPfDcFillsAll.val},
+          "Software prefetch total (Venice).",
+          "All software prefetch data cache fills."),
+      std::vector<EventId>({"zen6-sw-prefetch-total"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "zen6::inefficient_sw_prefetch",
+          EventDef::Encoding{.code = amd_msr::kLsInefSwPref.val},
+          "Inefficient software prefetches (Venice).",
+          "Inefficient software prefetches."),
+      std::vector<EventId>({"zen6-inefficient-sw-prefetch"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_fill_rd_resp_cnt",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4FillRdRespCnt.val},
+          "L3 sampled fill read-response latency (aggregate).",
+          "Aggregate sampled latency of L3 fill read responses across all sources."),
+      std::vector<EventId>({"zen4-l3-fill-rd-resp-cnt"}));
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::amd_l3,
+          "zen4::l3_fill_rd_resp_smpl",
+          EventDef::Encoding{.code = amd_msr::kL3Zen4FillRdRespSmpl.val},
+          "L3 sampled fill read-response requests (aggregate).",
+          "Aggregate count of sampled L3 fill read-response requests across all sources."),
+      std::vector<EventId>({"zen4-l3-fill-rd-resp-smpl"}));
+}
+
+} // namespace venice
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
   // Add AMD core L1 - common across all architectures
@@ -721,6 +864,17 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
       milan::addEventsFb(pmu_manager);
 #endif
       turin::addEvents(pmu_manager);
+      turin::addZen5UmcEvents(pmu_manager);
+      break;
+    case CpuArch::VENICE:
+      // Reuse Milan & Turin unchanged events
+      milan::addEvents(pmu_manager);
+      turin::addEvents(pmu_manager);
+      // Venice-specific core encoding overrides + new core metrics + L3
+      // access/aggregate-latency events.
+      venice::addEvents(pmu_manager);
+      // UMC bandwidth events (same encodings as Zen5).
+      turin::addZen5UmcEvents(pmu_manager);
       break;
     default:
       HBT_LOG_ERROR()

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -572,6 +572,32 @@ constexpr PmuMsr kDfZen4CxlWriteBeatsCmp3{
         .event_13_8 = 0x3,
     }};
 
+// Venice (Zen 6) core counters.
+// These event encodings changed vs Turin/Zen5; see the AMD Venice PPR. Events
+// that are unchanged (NC) continue to use the common constants above.
+constexpr PmuMsr kVeniceL1DCacheMisses{
+    .amdCore = {.event = 0x41, .unitMask = 0x0f}}; // 0x1f reserved on Venice
+constexpr PmuMsr kVeniceL2DCacheAccesses{
+    .amdCore = {.event = 0x64, .unitMask = 0xf8}}; // adds bit7 LsRdBlkCS
+constexpr PmuMsr kVeniceL2Accesses{
+    .amdCore = {.event = 0x64, .unitMask = 0xff}};
+constexpr PmuMsr kVeniceLsMabAllocPipes{
+    .amdCore = {
+        .event = 0x41,
+        .unitMask = 0x0f}}; // same fix as L1 dcache misses
+constexpr PmuMsr kVeniceStalledCyclesBackPressure{
+    .amdCore = {.event = 0xae, .unitMask = 0x5f}}; // PMCx087 removed on Venice
+constexpr PmuMsr kVeniceStalledCyclesIdqEmpty{
+    .amdCore = {.event = 0xa9}}; // Op Queue Empty; PMCx087 removed
+constexpr PmuMsr kVeniceStalledCyclesAny{
+    .amdCore = {.event = 0xd6, .unitMask = 0x1b}}; // cycles with no retire
+constexpr PmuMsr kVeniceIcMabRequest{
+    // PMCx29C unitmask 0xDF (Any IC Fills by Data Source), per the AMD PPR.
+    // The 12-bit event-select 0x29C, (0x2 << 8) | 0x9C == 0x29C
+    .amdCore = {.event = 0x9c, .unitMask = 0xdf, .event_11_8 = 0x2}};
+constexpr PmuMsr kVeniceBadSpeculation{
+    .amdCore = {.event = 0xaa, .unitMask = 0x03}}; // bits[1:0] only on Venice
+
 } // namespace amd_msr
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager);

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -499,7 +499,8 @@ void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager) {
   }
 
   if (cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
-      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
+      cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN6) {
     addAmdEvents(cpu_info, *pmu_manager);
   } else if (cpu_info.cpu_family == CpuFamily::INTEL) {
     //
@@ -538,7 +539,8 @@ void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager) {
       "dtlb_load_misses", std::vector<EventId>({"dTLB-load-misses"}));
 
   if (cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
-      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
+      cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN6) {
     if (cpu_info.cpu_arch != CpuArch::MILAN) {
       pmu_manager->addAliases(
           "l2_fill_l3_resp", std::vector<EventId>({"llc-cache-misses-oncore"}));
@@ -562,7 +564,8 @@ void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager) {
 
   // Alias for AMD
   if (cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
-      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
+      cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN6) {
     pmu_manager->addAliases(
         "ex_ret_brn_tkn",
         std::vector<EventId>({"branch-instructions-ret-tkn"}));
@@ -686,7 +689,8 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
             std::vector<std::string>{}));
   } else if (
       cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
-      cpu_info.cpu_family == CpuFamily::AMDZEN5) {
+      cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN6) {
     metrics->add(
         std::make_shared<MetricDesc>(
             "l2_cache_misses",
@@ -1717,6 +1721,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    PmuType::cpu,
                    "l1_dcache_misses",
                    EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::l1_dcache_misses",
+                   PmuType::cpu,
+                   "zen6::l1_dcache_misses",
+                   EventExtraAttr{},
                    {}}}}},
           100'000'000,
           System::Permissions{},
@@ -1769,6 +1780,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    PmuType::cpu,
                    "l2_dcache_accesses",
                    EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::l2_dcache_accesses",
+                   PmuType::cpu,
+                   "zen6::l2_dcache_accesses",
+                   EventExtraAttr{},
                    {}}}}},
           100'000'000,
           System::Permissions{},
@@ -1803,6 +1821,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    "l2_accesses",
                    PmuType::cpu,
                    "l2_accesses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::l2_accesses",
+                   PmuType::cpu,
+                   "zen6::l2_accesses",
                    EventExtraAttr{},
                    {}}}}},
           100'000'000,
@@ -2046,6 +2071,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    PmuType::cpu,
                    "stalled_cycles_back_pressure",
                    EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::stalled_cycles_back_pressure",
+                   PmuType::cpu,
+                   "zen6::stalled_cycles_back_pressure",
+                   EventExtraAttr{},
                    {}}}}},
           100'000'000,
           System::Permissions{},
@@ -2063,6 +2095,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    PmuType::cpu,
                    "stalled_cycles_idq_empty",
                    EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::stalled_cycles_idq_empty",
+                   PmuType::cpu,
+                   "zen6::stalled_cycles_idq_empty",
+                   EventExtraAttr{},
                    {}}}}},
           100'000'000,
           System::Permissions{},
@@ -2079,6 +2118,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    "stalled_cycles_any",
                    PmuType::cpu,
                    "stalled_cycles_any",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::stalled_cycles_any",
+                   PmuType::cpu,
+                   "zen6::stalled_cycles_any",
                    EventExtraAttr{},
                    {}}}}},
           100'000'000,
@@ -2150,6 +2196,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    PmuType::cpu,
                    "ls_mab_alloc_pipes",
                    EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::ls_mab_alloc_pipes",
+                   PmuType::cpu,
+                   "zen6::ls_mab_alloc_pipes",
+                   EventExtraAttr{},
                    {}}}}},
           100'000'000,
           System::Permissions{},
@@ -2166,6 +2219,13 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    "ic_mab_request",
                    PmuType::cpu,
                    "ic_mab_request",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::ic_mab_request",
+                   PmuType::cpu,
+                   "zen6::ic_mab_request",
                    EventExtraAttr{},
                    {}}}}},
           100'000'000,
@@ -2321,6 +2381,75 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
                    "smt_contention_stalls",
                    PmuType::cpu,
                    "smt_contention_stalls",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  // Venice-only core metrics.
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_RETIRED_SSE_AVX_FLOPS",
+          "Retired SSE/AVX floating-point operations",
+          "Retired SSE/AVX floating-point operations.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::retired_sse_avx_flops",
+                   PmuType::cpu,
+                   "zen6::retired_sse_avx_flops",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_BAD_SPECULATION",
+          "Bad speculation",
+          "Ops dispatched that did not retire.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::bad_speculation",
+                   PmuType::cpu,
+                   "zen6::bad_speculation",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_SW_PREFETCH_TOTAL",
+          "Software prefetch total",
+          "All software prefetch data cache fills.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::sw_prefetch_total",
+                   PmuType::cpu,
+                   "zen6::sw_prefetch_total",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_INEFFICIENT_SW_PREFETCH",
+          "Inefficient software prefetches",
+          "Inefficient software prefetches.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "zen6::inefficient_sw_prefetch",
+                   PmuType::cpu,
+                   "zen6::inefficient_sw_prefetch",
                    EventExtraAttr{},
                    {}}}}},
           100'000'000,


### PR DESCRIPTION
Summary:
Why: the builtin metric catalog must expose Venice core metrics (resolving to the
Zen6 event encodings) so the PerfCounterManager can request them by metric id.
What: gate the AMD event/alias registration on CpuFamily::AMDZEN6 (alongside
AMDZEN3/AMDZEN5); add CpuArch::VENICE EventRefs to the existing AMD core
MetricDescs whose encodings changed on Venice (l1_dcache_misses, l2 accesses,
stalled-cycle variants, ls_mab_alloc_pipes, ic_mab_request); and add the 4
Venice-only core MetricDescs (CORE_RETIRED_SSE_AVX_FLOPS, CORE_BAD_SPECULATION,
CORE_SW_PREFETCH_TOTAL, CORE_INEFFICIENT_SW_PREFETCH). All EventRefs reference
events registered in the preceding encodings commit.

Differential Revision: D108026251


