### PR TITLE
AMD Venice (Zen 6) CPU family + arch detection

### DIFF
--- a/hbt/src/common/System.h
+++ b/hbt/src/common/System.h
@@ -312,7 +312,7 @@ struct CpuInfo {
       uint32_t cpu_model_num,
       uint32_t cpu_step_num,
       uint32_t vendor_id_int = 0)
-      : cpu_family(perf_event::makeCpuFamily(cpu_family_num)),
+      : cpu_family(perf_event::makeCpuFamily(cpu_family_num, cpu_model_num)),
         cpu_arch(
             perf_event::makeCpuArch(
                 vendor_id_int,

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -12,7 +12,7 @@
 
 namespace facebook::hbt::perf_event {
 
-enum class CpuFamily { AMDZEN3, AMDZEN5, INTEL, ARM, UNKNOWN };
+enum class CpuFamily { AMDZEN3, AMDZEN5, AMDZEN6, INTEL, ARM, UNKNOWN };
 
 inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
   switch (f) {
@@ -20,6 +20,8 @@ inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
       return os << "AMD Zen 3 / Zen 3+ / Zen 4";
     case CpuFamily::AMDZEN5:
       return os << "AMD Zen 5";
+    case CpuFamily::AMDZEN6:
+      return os << "AMD Zen 6";
     case CpuFamily::INTEL:
       return os << "INTEL";
     case CpuFamily::ARM:
@@ -32,9 +34,11 @@ inline std::ostream& operator<<(std::ostream& os, CpuFamily f) {
 // Create CpuFamily enumeration from integer.
 inline CpuFamily makeCpuFamily(
 #if defined(__x86_64__)
-    uint32_t cpu_family
+    uint32_t cpu_family,
+    uint32_t cpu_model_num
 #else
-    uint32_t /* cpu_family */
+    uint32_t /* cpu_family */,
+    uint32_t /* cpu_model_num */
 #endif
 ) {
 #if defined(__x86_64__)
@@ -44,6 +48,12 @@ inline CpuFamily makeCpuFamily(
     case 25:
       return CpuFamily::AMDZEN3;
     case 26:
+      // AMD Family 1Ah (0x1A == 26) covers BOTH Zen 5 (Turin) and Zen 6
+      // (Venice); they are distinguished only by model number, per the AMD
+      // PPR. Venice: Models 50h-57h (A0 = 50h, B0 = 51h). Turin: 00h-1Fh.
+      if (cpu_model_num >= 0x50 && cpu_model_num <= 0x57) {
+        return CpuFamily::AMDZEN6;
+      }
       return CpuFamily::AMDZEN5;
     // Not recognized CPU model.
     default:

--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -22,6 +22,7 @@ enum class CpuArch {
   GENOA,
   BERGAMO,
   TURIN,
+  VENICE,
   // Intel Architectures Sorted by model id.
   BDW,
   BDW_DE,
@@ -65,6 +66,8 @@ inline std::ostream& operator<<(std::ostream& os, CpuArch ev) {
       return os << "BERGAMO";
     case CpuArch::TURIN:
       return os << "TURIN";
+    case CpuArch::VENICE:
+      return os << "VENICE";
     case CpuArch::BDW:
       return os << "BDW";
     case CpuArch::BDW_DE:
@@ -112,7 +115,7 @@ inline CpuArch makeCpuArchX86(
     uint32_t cpu_family_num,
     uint32_t cpu_model_num,
     uint32_t cpu_step_num) {
-  auto cpu_family = makeCpuFamily(cpu_family_num);
+  auto cpu_family = makeCpuFamily(cpu_family_num, cpu_model_num);
   if (cpu_family == CpuFamily::AMDZEN3) {
     switch (cpu_model_num) {
       case 1:
@@ -127,6 +130,15 @@ inline CpuArch makeCpuArchX86(
       case 2:
       case 17:
         return CpuArch::TURIN;
+    }
+  } else if (cpu_family == CpuFamily::AMDZEN6) {
+    switch (cpu_model_num) {
+      // Venice A0 silicon: Family 1Ah Model 50h (0x50 == 80), per
+      // the AMD PPR (PPR Vol 1 for AMD Family 1Ah Model 50h A0).
+      // TODO(venice): update to B0 Model 51h (0x51 == 81) once we
+      // move to B0 hardware.
+      case 80:
+        return CpuArch::VENICE;
     }
   } else if (cpu_family == CpuFamily::INTEL) {
     switch (cpu_model_num) {


### PR DESCRIPTION
Summary:
Why: the hbt perf_event CPU-identification layer must recognize Zen 6 / Venice
before any Venice events or metrics can be registered; AMD family 1Ah is shared by
Zen 5 (Turin) and Zen 6 (Venice), so detection must disambiguate by model.
What: add CpuFamily::AMDZEN6 and CpuArch::VENICE (+ ostream cases); makeCpuFamily()
now takes cpu_model_num and maps model 50h-57h to Venice, threaded through System.h
CpuInfo and the generated makeCpuArchX86(); mirror the change in the json_events
generator (generate.py) so the generated CpuArch.h stays in sync. No behavior
change for existing architectures.

Differential Revision: D108026391


