### PR TITLE
remove builtin metrics dependency

### DIFF
--- a/hbt/src/perf_event/BPerfEventsGroup.cpp
+++ b/hbt/src/perf_event/BPerfEventsGroup.cpp
@@ -276,20 +276,6 @@ void BPerfEventsGroup::close() {
   opened_ = false;
 }
 
-std::string BPerfEventsGroup::perThreadArrayMapFileName(const std::string& n) {
-  std::stringstream ss;
-
-  ss << "bperf_per_thread_array_" << n;
-  return ss.str();
-}
-
-std::string BPerfEventsGroup::perThreadIndexMapFileName(const std::string& n) {
-  std::stringstream ss;
-
-  ss << "bperf_per_thread_index_" << n;
-  return ss.str();
-}
-
 bool BPerfEventsGroup::isOpen() const {
   return opened_;
 }
@@ -403,8 +389,7 @@ void BPerfEventsGroup::syncGlobal_() const {
 
 int BPerfEventsGroup::pinThreadMaps_(bperf_leader_cgroup* skel) {
   int err, map_fd;
-  auto path = bpf_pinned_map_dir_ /
-      BPerfEventsGroup::perThreadIndexMapFileName(pin_name_);
+  auto path = bpf_pinned_map_dir_ / perThreadIndexMapFileName(pin_name_);
 
   map_fd = ::bpf_map__fd(skel->maps.per_thread_idx);
   ::unlink(path.c_str());
@@ -420,8 +405,7 @@ int BPerfEventsGroup::pinThreadMaps_(bperf_leader_cgroup* skel) {
     HBT_LOG_WARNING() << "Failed to chmod the map at " << path << ". ";
   }
 
-  path = bpf_pinned_map_dir_ /
-      BPerfEventsGroup::perThreadArrayMapFileName(pin_name_);
+  path = bpf_pinned_map_dir_ / perThreadArrayMapFileName(pin_name_);
   map_fd = ::bpf_map__fd(skel->maps.per_thread_data);
   ::unlink(path.c_str());
   if (err = ::bpf_obj_pin(map_fd, path.c_str()); err) {
@@ -849,8 +833,7 @@ void BPerfEventsGroup::cleanupLinks() {
 void BPerfEventsGroup::disablePerThreadMetadata(
     const std::string& pin_name,
     const std::filesystem::path& bpf_pinned_map_dir) {
-  auto path = bpf_pinned_map_dir /
-      BPerfEventsGroup::perThreadArrayMapFileName(pin_name);
+  auto path = bpf_pinned_map_dir / perThreadArrayMapFileName(pin_name);
   int map_fd = ::bpf_obj_get(path.c_str());
   if (map_fd < 0) {
     return;

--- a/hbt/src/perf_event/BPerfEventsGroup.h
+++ b/hbt/src/perf_event/BPerfEventsGroup.h
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include "hbt/src/perf_event/BPerfPinnedMapNames.h"
 #include "hbt/src/perf_event/Metrics.h"
 #include "hbt/src/perf_event/PerfEventsGroup.h"
 #include "hbt/src/perf_event/PmuDevices.h"
@@ -21,9 +22,6 @@ namespace facebook::hbt::perf_event {
 
 class BPerfEventsGroup {
  public:
-  static std::string perThreadArrayMapFileName(const std::string& n);
-  static std::string perThreadIndexMapFileName(const std::string& n);
-
   using ReadValues = GroupReadValues<mode::Counting>;
   ///
   ///  - confs: Event Confs for group.

--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -4,9 +4,18 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "hbt/src/perf_event/BPerfPerThreadReader.h"
+
 #include <bpf/bpf.h>
+#include <fcntl.h>
+#include <linux/perf_event.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
 #include <time.h>
-#include "hbt/src/perf_event/BPerfEventsGroup.h"
+#include <unistd.h>
+#include <cstddef>
+#include <cstring>
+
+#include "hbt/src/perf_event/BPerfPinnedMapNames.h"
 
 namespace facebook::hbt::perf_event {
 
@@ -54,14 +63,10 @@ int BPerfPerThreadReader::enable() {
 
   // use a list of directories to find if desired per-thread bpf map
   for (const auto& bpf_pinned_map_dir : bpf_pinned_map_dirs_) {
-    idx_fd =
-        ::bpf_obj_get((bpf_pinned_map_dir /
-                       BPerfEventsGroup::perThreadIndexMapFileName(pin_name_))
-                          .c_str());
-    data_fd_ =
-        ::bpf_obj_get((bpf_pinned_map_dir /
-                       BPerfEventsGroup::perThreadArrayMapFileName(pin_name_))
-                          .c_str());
+    idx_fd = ::bpf_obj_get(
+        (bpf_pinned_map_dir / perThreadIndexMapFileName(pin_name_)).c_str());
+    data_fd_ = ::bpf_obj_get(
+        (bpf_pinned_map_dir / perThreadArrayMapFileName(pin_name_)).c_str());
 
     if (idx_fd >= 0 && data_fd_ >= 0) {
       break;

--- a/hbt/src/perf_event/BPerfPinnedMapNames.h
+++ b/hbt/src/perf_event/BPerfPinnedMapNames.h
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <string>
+
+namespace facebook::hbt::perf_event {
+
+// Naming convention for the per-thread BPF maps pinned in bpffs. Shared by the
+// leader (BPerfEventsGroup) that pins the maps and the reader
+// (BPerfPerThreadReader) that opens them, so both agree on the same path.
+inline std::string perThreadArrayMapFileName(const std::string& n) {
+  return "bperf_per_thread_array_" + n;
+}
+
+inline std::string perThreadIndexMapFileName(const std::string& n) {
+  return "bperf_per_thread_index_" + n;
+}
+
+} // namespace facebook::hbt::perf_event


### PR DESCRIPTION
Summary:
`:BuiltinMetricsLight` depends on the generated perf events definition. these targets are quite slow, and we should avoid introduce it to a common library like BPerfPerThreadReader.

refactor the code so BPerfPerThreadReader will not rely on BuiltinMetrics directly or indirectly.

Reviewed By: yaoz08

Differential Revision: D107818763


