### PR TITLE
Add ARM L1 i/d cache miss-ratio metrics to ODS

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -2379,6 +2379,54 @@ void addArmCoreMetrics(std::shared_ptr<Metrics>& metrics) {
 
   metrics->add(
       std::make_shared<MetricDesc>(
+          "HW_CORE_L1I_CACHE",
+          "L1 instruction cache access",
+          "Counts instruction fetches that access the L1 instruction cache. Denominator for the L1 instruction-cache miss ratio.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "l1i_cache",
+                   PmuType::armv8_pmuv3,
+                   "l1i_cache",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "l1i_cache",
+                   PmuType::armv8_pmuv3,
+                   "l1i_cache",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "HW_CORE_L1D_CACHE",
+          "L1 data cache access",
+          "Counts level 1 data cache accesses from any load or store operation. Denominator for the L1 data-cache miss ratio.",
+          std::map<TOptCpuArch, EventRefs>{
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "l1d_cache",
+                   PmuType::armv8_pmuv3,
+                   "l1d_cache",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "l1d_cache",
+                   PmuType::armv8_pmuv3,
+                   "l1d_cache",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
           "HW_CORE_L2_CACHE_REFILL",
           "L2 cache refill",
           "Counts any cacheable transaction from L1 which causes data to be read from outside the core. L2 refills caused by stashes into L2 should not be counted.",


### PR DESCRIPTION
Summary:
Adds two ARM core PMU metrics for S661471, bringing Grace/Neoverse to parity with the AMD `l1_icache_miss_ratio_permilli` / `l1_dcache_miss_ratio_permilli` ODS keys:

- `l1_icache_miss_ratio_permilli` = `l1i_cache_refill / l1i_cache * 1000`
- `l1_dcache_miss_ratio_permilli` = `l1d_cache_refill / l1d_cache * 1000`

Values are per-mille (misses/accesses * 1000), matching AMD's `(int64_t)(1000.*ratio)` convention. To supply the access-count denominators, this registers two architectural PMUv3 events for Neoverse V2 and V3 in HBT: `HW_CORE_L1I_CACHE` (`l1i_cache`, 0x14) and `HW_CORE_L1D_CACHE` (`l1d_cache`, 0x04). The metrics are published from `exportPerfCountersArmCore` in `Updater.cpp` next to the existing per-kinst cache keys.

The remaining AMD cache-ratio keys are intentionally left x86-only: Neoverse L2 is unified (no instruction/data split) and there is no L2 prefetch-hit PMUv3 event, so `l2_data_miss_ratio_permilli`, `l2_code_miss_ratio_permilli`, and `l2_prefetch_hit_percent` are not implementable on ARM. The unified ARM L2 signal already ships as `l2cache_misses_per_kinst`.

Differential Revision: D108204535


