### PR TITLE
Default-initialize nicDevCount_ to fix uninitialized read in getNicDevCount()

### DIFF
--- a/dynolog/src/KernelCollectorBase.h
+++ b/dynolog/src/KernelCollectorBase.h
@@ -40,7 +40,7 @@ class KernelCollectorBase {
   // TODO discover sockets from /proc/cpuinfo
   size_t numCpuSockets_{1};
   const size_t cpuCoresTotal_;
-  size_t nicDevCount_;
+  size_t nicDevCount_{0};
   bool filterInteraces_;
   std::vector<std::string> nicInterfacePrefixes_;
 


### PR DESCRIPTION
Summary:
`KernelCollectorBase::nicDevCount_` had no initializer, while every sibling field in the struct does (`first_ = true`, `numCpuSockets_{1}`). It is only ever written inside `readNetworkStats()`, so any instance that reads it before a network refresh returns indeterminate memory from `getNicDevCount()`. The mock instance built by `KernelMonitor::makeTestInstance()` does not call `readNetworkStats()`, so it hit exactly this path.

This surfaced as `KernelMonitorTest.testSystemInfoAndNicDevCount` failing in the dynolog conveyor continuous signal: `getNicDevCount()` returned a garbage pointer-like value (e.g. 140537873736112) instead of the expected 0. The test had failed 13/13 runs and was auto-disabled.

Fix: give `nicDevCount_` a default member initializer of `{0}`, matching the struct's existing convention. The member is still overwritten unconditionally on every `readNetworkStats()` call, so production behavior is unchanged; only the pre-refresh read becomes deterministic.

Reviewed By: hmlee95070

Differential Revision: D109320276


