### PR TITLE
Route T2_VNC (AMD Venice) to the HBT perf-counter manager (#579)

### DIFF
--- a/hbt/src/perf_event/json_events/generated/CpuArch.h
+++ b/hbt/src/perf_event/json_events/generated/CpuArch.h
@@ -133,11 +133,10 @@ inline CpuArch makeCpuArchX86(
     }
   } else if (cpu_family == CpuFamily::AMDZEN6) {
     switch (cpu_model_num) {
-      // Venice A0 silicon: Family 1Ah Model 50h (0x50 == 80), per
-      // the AMD PPR (PPR Vol 1 for AMD Family 1Ah Model 50h A0).
-      // TODO(venice): update to B0 Model 51h (0x51 == 81) once we
-      // move to B0 hardware.
+      // Venice silicon, per the AMD PPR (Family 1Ah):
+      //   A0 = Model 50h (0x50 == 80), B0 = Model 51h (0x51 == 81).
       case 80:
+      case 81:
         return CpuArch::VENICE;
     }
   } else if (cpu_family == CpuFamily::INTEL) {


### PR DESCRIPTION
Summary:

Route `T2_VNC` (AMD Venice / Zen6) hosts to `PerfCounterManagerHbtAmd` instead of the legacy `PerfCounterManagerAmd`, which lacks Venice support. Selection happens in `createPerfCounterManager_`, gated by the `dyno/dynolog_feature_gate:use_hbt_amd_for_t2_vnc` feature gate (default off) for a controlled ramp; non-`T2_VNC` AMD hosts fall through to the legacy manager. This is v1: memBW and the working core-metric set flow via HBT, with a v2 follow-up to close the remaining Venice core-metric slots.

Reviewed By: Alston-Tang

Differential Revision: D109969503


