### PR TITLE
make RdcWrapperExample more consistent to rdc_singleton and add CMake target for it (#580)

### DIFF
--- a/dynolog/src/gpumon/amd/CMakeLists.txt
+++ b/dynolog/src/gpumon/amd/CMakeLists.txt
@@ -3,6 +3,50 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+cmake_minimum_required(VERSION 3.16)
+
+# When this directory is configured directly (standalone) rather than pulled in
+# via add_subdirectory() from the top-level dynolog build, set up a minimal
+# project that builds just the RDC wrapper library and the example:
+#
+#   cd dynolog/src/gpumon/amd
+#   cmake -B build -G Ninja -DROCM_VERSION=70000
+#   cmake --build build
+#
+# Prerequisites: RDC SDK + amd_smi (typically under /opt/rocm), glog, gflags.
+# Point CMake at non-standard locations with -DCMAKE_PREFIX_PATH=... if needed.
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project(RdcWrapperStandalone LANGUAGES CXX)
+
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+    # ROCm version code, e.g. 70000 == ROCm 7.0.x. Compiled in as
+    set(ROCM_VERSION 70000 CACHE STRING "ROCm version, e.g. 70000 for 7.0.x")
+
+    # Repo-rooted includes like "dynolog/src/gpumon/amd/RdcWrapper.h" resolve
+    # from the repository root, four levels up from this directory.
+    get_filename_component(DYNOLOG_REPO_ROOT
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+
+    find_package(rdc PATHS /opt/rocm REQUIRED)
+    find_package(amd_smi PATHS /opt/rocm REQUIRED)
+    # EPEL glog ships no cmake config, so locate the library directly.
+    find_library(GLOG_LIBRARY NAMES glog REQUIRED)
+
+    add_library(dynolog_rdc_lib STATIC RdcWrapper.cpp RdcWrapper.h)
+    target_include_directories(dynolog_rdc_lib PUBLIC "${DYNOLOG_REPO_ROOT}")
+    target_compile_definitions(
+        dynolog_rdc_lib PUBLIC DYNOLOG_ROCM_VERSION=${ROCM_VERSION})
+    target_link_libraries(dynolog_rdc_lib PUBLIC rdc ${GLOG_LIBRARY})
+
+    add_subdirectory(examples)
+    return()
+endif ()
+
+# --- Integrated build (add_subdirectory() from the top-level dynolog build) ---
+
 find_package(rdc PATHS /opt/rocm)
 find_package(amd_smi PATHS /opt/rocm)
 find_package(PkgConfig)
@@ -19,8 +63,7 @@ if (rdc_FOUND AND amd_smi_FOUND AND LIBCAP_FOUND)
     add_library(dynolog_amd_device_lib AmdDeviceTopology.cpp AmdDeviceTopology.h)
     target_link_libraries(dynolog_amd_device_lib glog::glog)
 
-    add_executable(RdcWrapperExample examples/RdcWrapperExample.cpp)
-    target_link_libraries(RdcWrapperExample dynolog_rdc_lib)
+    add_subdirectory(examples)
 else ()
     message(STATUS "RDC package not found. Ignore AMD GPU targets")
 endif ()

--- a/dynolog/src/gpumon/amd/RdcWrapper.cpp
+++ b/dynolog/src/gpumon/amd/RdcWrapper.cpp
@@ -32,10 +32,10 @@ const std::set<rdc_field_t> kPartitionSupportedMetrics = {
     RDC_FI_PROF_EVAL_FLOPS_16,
     RDC_FI_PROF_EVAL_FLOPS_32,
     RDC_FI_PROF_EVAL_FLOPS_64,
-#if FB_ROCM_VERSION >= 70000
+#if DYNOLOG_ROCM_VERSION >= 70000
     RDC_FI_KFD_ID,
     RDC_FI_PROF_SIMD_UTILIZATION,
-#elif FB_ROCM_VERSION >= 60402
+#elif DYNOLOG_ROCM_VERSION >= 60402
     RDC_FI_PROF_KFD_ID,
     RDC_FI_PROF_SIMD_UTILIZATION,
 #endif
@@ -135,7 +135,7 @@ RdcMetricsMap RdcWrapper::getRdcMetricsForDevice(uint32_t device) {
   }
   rdc_status_t result;
   for (auto metric : context.data.enabledMetrics_) {
-#if FB_ROCM_VERSION >= 60402
+#if DYNOLOG_ROCM_VERSION >= 60402
     rdc_entity_info_t deviceInfo = rdc_get_info_from_entity_index(device);
     // skip unsupported metrics for partitions
     if (deviceInfo.entity_role == RDC_DEVICE_ROLE_PARTITION_INSTANCE &&
@@ -221,7 +221,7 @@ std::vector<uint32_t> RdcWrapper::listDeviceIds_(RdcRuntimeContext& context) {
 std::vector<uint32_t> RdcWrapper::listPartitionIds_(
     RdcRuntimeContext& context) {
   std::vector<uint32_t> partitionIds;
-#if FB_ROCM_VERSION >= 60402
+#if DYNOLOG_ROCM_VERSION >= 60402
   auto devices = listDeviceIds_(context);
   for (auto dev : devices) {
     uint16_t numPartitions;
@@ -301,7 +301,7 @@ void RdcWrapper::initGpu_(RdcRuntimeContext& context) {
   }
 }
 void RdcWrapper::initPartition_(RdcRuntimeContext& context) {
-#if FB_ROCM_VERSION >= 60402
+#if DYNOLOG_ROCM_VERSION >= 60402
   auto partitionIds = listPartitionIds_(context);
   if (partitionIds.empty()) {
     return;

--- a/dynolog/src/gpumon/amd/RdcWrapper.h
+++ b/dynolog/src/gpumon/amd/RdcWrapper.h
@@ -17,6 +17,13 @@
 
 #pragma once
 
+// Normalize the ROCm version macro. The buck build defines FB_ROCM_VERSION; the
+// standalone CMake build defines DYNOLOG_ROCM_VERSION directly. Source guards
+// key off DYNOLOG_ROCM_VERSION only.
+#if defined(FB_ROCM_VERSION) && !defined(DYNOLOG_ROCM_VERSION)
+#define DYNOLOG_ROCM_VERSION FB_ROCM_VERSION
+#endif
+
 namespace dynolog {
 namespace gpumon {
 

--- a/dynolog/src/gpumon/amd/examples/CMakeLists.txt
+++ b/dynolog/src/gpumon/amd/examples/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Builds only the example program. The dynolog_rdc_lib library target (and the
+# FB_ROCM_VERSION define / include paths it propagates) is defined by the parent
+# directory's CMakeLists.txt (dynolog/src/gpumon/amd).
+
+add_executable(RdcWrapperExample RdcWrapperExample.cpp)
+
+if (TARGET gflags::gflags)
+    target_link_libraries(RdcWrapperExample PRIVATE dynolog_rdc_lib gflags::gflags)
+else ()
+    find_library(GFLAGS_LIBRARY NAMES gflags REQUIRED)
+    target_link_libraries(
+        RdcWrapperExample PRIVATE dynolog_rdc_lib ${GFLAGS_LIBRARY})
+endif ()

--- a/dynolog/src/gpumon/amd/examples/RdcWrapperExample.cpp
+++ b/dynolog/src/gpumon/amd/examples/RdcWrapperExample.cpp
@@ -9,8 +9,18 @@
 
 #include <gflags/gflags.h>
 #include <unistd.h>
+#include <chrono>
 #include <iostream>
 #include <thread>
+#include <variant>
+#include <vector>
+
+#ifdef DYNOLOG_ROCM_VERSION
+#include <dlfcn.h>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#endif
 
 DEFINE_int32(
     update_interval_ms,
@@ -22,12 +32,23 @@ DEFINE_int32(
     "Maximum age in seconds to keep RDC samples");
 DEFINE_int32(max_keep_samples, 100, "Maximum number of samples to keep");
 
-static std::vector<rdc_field_t> kRdcWatchedFields = {
+#ifdef DYNOLOG_ROCM_VERSION
+constexpr int kRocmVersion = DYNOLOG_ROCM_VERSION;
+#else
+constexpr int kRocmVersion = 0;
+#endif
+
+namespace {
+
+const std::vector<rdc_field_t> kEnabledMetrics = {
+#if DYNOLOG_ROCM_VERSION >= 60200
     RDC_FI_GPU_UTIL,
     RDC_FI_OAM_ID,
     RDC_FI_PCIE_BANDWIDTH,
     RDC_FI_POWER_USAGE,
     RDC_FI_PROF_OCCUPANCY_PERCENT,
+#endif
+#if DYNOLOG_ROCM_VERSION >= 60201
     RDC_FI_PROF_EVAL_MEM_R_BW,
     RDC_FI_PROF_EVAL_MEM_W_BW,
     RDC_FI_PROF_EVAL_FLOPS_16,
@@ -51,33 +72,93 @@ static std::vector<rdc_field_t> kRdcWatchedFields = {
     RDC_FI_XGMI_5_WRITE_KB,
     RDC_FI_XGMI_6_WRITE_KB,
     RDC_FI_XGMI_7_WRITE_KB,
-#if FB_ROCM_VERSION >= 70000
-    RDC_FI_KFD_ID,
-#else
-    RDC_FI_PROF_KFD_ID,
 #endif
-    RDC_FI_PROF_SIMD_UTILIZATION};
+#if DYNOLOG_ROCM_VERSION >= 70000
+    RDC_FI_KFD_ID,
+    RDC_FI_PROF_SIMD_UTILIZATION,
+#elif DYNOLOG_ROCM_VERSION >= 60402
+    RDC_FI_PROF_KFD_ID,
+    RDC_FI_PROF_SIMD_UTILIZATION,
+#endif
+};
+
+#ifdef DYNOLOG_ROCM_VERSION
+// Preload the ROCm RDC shared libraries from ROCM_PATH as a workaround for
+// dependency loading issues. Only compiled and run when DYNOLOG_ROCM_VERSION is
+// defined.
+void preloadRocmLibs() {
+  const char* rocmHome = getenv("ROCM_PATH");
+  if (rocmHome == nullptr) {
+    std::cerr << "ROCM_PATH is not set, skipping RDC preload\n";
+    return;
+  }
+  std::filesystem::path rocmPath(rocmHome);
+  const std::array<std::filesystem::path, 3> rdcLibs = {
+      rocmPath / "lib/rdc/librdc_rocp.so",
+      rocmPath / "lib/rdc/librdc_rvs.so",
+      rocmPath / "lib/rdc/librdc_rocr.so"};
+  for (const auto& lib : rdcLibs) {
+    void* rdc = dlopen(lib.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+    if (rdc == nullptr) {
+      std::cerr << "Failed to load " << lib << ": " << dlerror() << "\n";
+      continue;
+    }
+    std::cout << "Loaded " << lib << "\n";
+  }
+}
+#endif
+
+} // namespace
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
+#ifdef DYNOLOG_ROCM_VERSION
+  preloadRocmLibs();
+#endif
+
+  std::cout << "Initializing RDC example, ROCM version: " << kRocmVersion
+            << std::endl;
+  std::cout << "RDC watch config: update_interval=" << FLAGS_update_interval_ms
+            << "ms, max_keep_age=" << FLAGS_max_keep_age_seconds
+            << "s, max_keep_samples=" << FLAGS_max_keep_samples << std::endl;
+
+  std::cout << "Collecting " << kEnabledMetrics.size()
+            << " metrics:" << std::endl;
+  for (const auto field : kEnabledMetrics) {
+    std::cout << "  metric " << field_id_string(field) << " (id=" << field
+              << ")" << std::endl;
+  }
+
   dynolog::gpumon::RdcWrapper rdcWrapper(
-      kRdcWatchedFields,
+      kEnabledMetrics,
       std::chrono::milliseconds(FLAGS_update_interval_ms),
       std::chrono::seconds(FLAGS_max_keep_age_seconds),
       FLAGS_max_keep_samples);
-  auto entities = rdcWrapper.getMonitoredEntities();
 
+  const auto entities = rdcWrapper.getMonitoredEntities();
+  std::cout << "Monitoring " << entities.size()
+            << " entities (physical GPUs + partitions):" << std::endl;
+  for (const auto entity : entities) {
+    std::cout << "  entity index=" << entity << std::endl;
+  }
+
+  // This example runs until killed (Ctrl-C / SIGTERM): the worker loops
+  // forever polling metrics, so worker.join() below never returns and there is
+  // no clean shutdown path by design.
   auto worker = std::thread([&]() {
     while (true) {
       sleep(1);
-      for (auto entity : entities) {
-        auto metricMap = rdcWrapper.getRdcMetricsForDevice(entity);
-        std::cout << "entity: " << entity << std::endl;
+      for (const auto entity : entities) {
+        const auto metricMap = rdcWrapper.getRdcMetricsForDevice(entity);
+        std::cout << "entity " << entity << ": collected " << metricMap.size()
+                  << " metrics" << std::endl;
         for (const auto& [field, value] : metricMap) {
           std::visit(
-              [field](auto&& arg) {
-                std::cout << field << ": " << arg << std::endl;
+              [entity, field](auto&& arg) {
+                std::cout << "  entity " << entity << " "
+                          << field_id_string(field) << " (id=" << field
+                          << ")=" << arg << std::endl;
               },
               value);
         }


### PR DESCRIPTION
Summary:

use RdcWrapperExample as something we can share with AMD for debugging

refactor the code to remove the hard dependency of FB_ROCM_VERSION macro. also add some more loggings.

add cmakelist so it can build in oss environement

Reviewed By: DuoYi

Differential Revision: D110378974


