### PR TITLE
Add NVIDIA Vera-Rubin (VR200) uncore PMU support (#581)

### DIFF
--- a/hbt/src/perf_event/ArmEvents.cpp
+++ b/hbt/src/perf_event/ArmEvents.cpp
@@ -23,10 +23,22 @@ namespace {
 
 std::string getPmuName(const PmuType& pmu_type) {
   auto res = PmuTypeToStr(pmu_type);
-  if (pmu_type != PmuType::cs_etm) {
-    res += "_0";
+  if (pmu_type == PmuType::cs_etm) {
+    return res;
   }
-  return res;
+  // Vera-Rubin PCIe PMUs are enumerated per root complex as
+  // <pmu>_<socket>_rc_<rc> rather than <pmu>_<idx>. Scan socket 0 / root
+  // complex 0 for the (uniform) event set; fall back to <pmu>_0 for the
+  // Grace-Hopper naming.
+  if (pmu_type == PmuType::nvidia_pcie_pmu ||
+      pmu_type == PmuType::nvidia_pcie_tgt_pmu) {
+    const std::string rc0_events =
+        rootDir_ + "/sys/bus/event_source/devices/" + res + "_0_rc_0/events";
+    if (std::filesystem::is_directory(rc0_events)) {
+      return res + "_0_rc_0";
+    }
+  }
+  return res + "_0";
 }
 
 } // namespace
@@ -98,6 +110,15 @@ void addEvents(PmuDeviceManager& pmu_manager) {
   scanPmu(pmu_manager, PmuType::nvidia_nvlink_c2c0_pmu);
   scanPmu(pmu_manager, PmuType::nvidia_nvlink_c2c1_pmu);
   scanPmu(pmu_manager, PmuType::nvidia_pcie_pmu);
+
+  // Nvidia Vera-Rubin uncores. Absent on Grace-Hopper, where scanPmu
+  // simply logs "No events found" and returns.
+  scanPmu(pmu_manager, PmuType::nvidia_ucf_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_nvlink_c2c_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_cmem_latency_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_nvclink_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_nvdlink_pmu);
+  scanPmu(pmu_manager, PmuType::nvidia_pcie_tgt_pmu);
 
   // Add Neoverse v2 PMU events not found in sysfs
   pmu_manager.addEvent(

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -4008,6 +4008,156 @@ void addArmUncoreMetrics(
           System::Permissions{},
           std::vector<std::string>{}));
 
+  // Vera-Rubin uncore metrics. On Vera the uncore PMU sysfs names
+  // differ from Grace-Hopper (nvidia_ucf_pmu vs nvidia_scf_pmu, a single
+  // nvidia_nvlink_c2c_pmu vs c2c0/c2c1, per-root-complex pcie), so these are
+  // distinct metric ids. They bind on Vera (which maps to NEOVERSE_V2) and are
+  // gracefully skipped on Grace-Hopper where the PMU is absent (the uncore
+  // reader setup catches the missing-event-def and continues).
+  const auto addVeraUncore = [&metrics](
+                                 const MetricId& id,
+                                 const std::string& desc,
+                                 PmuType pmu,
+                                 const EventId& event) {
+    metrics->add(
+        std::make_shared<MetricDesc>(
+            id,
+            desc,
+            desc,
+            std::map<TOptCpuArch, EventRefs>{
+                {CpuArch::NEOVERSE_V2,
+                 EventRefs{EventRef{event, pmu, event, EventExtraAttr{}, {}}}}},
+            100'000'000,
+            System::Permissions{},
+            std::vector<std::string>{}));
+  };
+  // UCF (SCF + system-level-cache fabric) — memory bandwidth and SLC behavior.
+  addVeraUncore(
+      "HW_UCF_CYCLES",
+      "Cycles on UCF (SCF/SLC) uncore (Vera-Rubin)",
+      PmuType::nvidia_ucf_pmu,
+      "cycles");
+  addVeraUncore(
+      "HW_UCF_MEM_BYTES_RD",
+      "Bytes read from local CPU memory (LPDDR) via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "mem_bytes_rd");
+  addVeraUncore(
+      "HW_UCF_MEM_BYTES_WR",
+      "Bytes written to local CPU memory (LPDDR) via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "mem_bytes_wr");
+  addVeraUncore(
+      "HW_UCF_MEM_ACCESS_RD",
+      "Read accesses to local CPU memory via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "mem_access_rd");
+  addVeraUncore(
+      "HW_UCF_MEM_ACCESS_WR",
+      "Write accesses to local CPU memory via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "mem_access_wr");
+  addVeraUncore(
+      "HW_UCF_SLC_HIT_RD",
+      "System-level cache read hits",
+      PmuType::nvidia_ucf_pmu,
+      "slc_hit_rd");
+  addVeraUncore(
+      "HW_UCF_SLC_REFILL_RD",
+      "System-level cache read refills (misses)",
+      PmuType::nvidia_ucf_pmu,
+      "slc_refill_rd");
+  addVeraUncore(
+      "HW_UCF_LOCAL_SNOOP",
+      "Local snoop requests via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "local_snoop");
+  addVeraUncore(
+      "HW_UCF_EXT_SNP_ACCESS",
+      "External (cross-socket) snoop accesses via UCF",
+      PmuType::nvidia_ucf_pmu,
+      "ext_snp_access");
+  // NVLink-C2C (CPU<->GPU) — Vera-Rubin single PMU with per-socket instances.
+  addVeraUncore(
+      "HW_VC2C_CYCLES",
+      "Cycles on NVLink-C2C uncore (Vera-Rubin)",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "cycles");
+  addVeraUncore(
+      "HW_VC2C_IN_RD_REQ",
+      "NVLink-C2C inbound read requests",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "in_rd_req");
+  addVeraUncore(
+      "HW_VC2C_OUT_RD_REQ",
+      "NVLink-C2C outbound read requests",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "out_rd_req");
+  addVeraUncore(
+      "HW_VC2C_IN_WR_REQ",
+      "NVLink-C2C inbound write requests",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "in_wr_req");
+  addVeraUncore(
+      "HW_VC2C_OUT_WR_REQ",
+      "NVLink-C2C outbound write requests",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "out_wr_req");
+  addVeraUncore(
+      "HW_VC2C_IN_RD_CUM_OUTS",
+      "NVLink-C2C inbound read cumulative outstanding (latency numerator)",
+      PmuType::nvidia_nvlink_c2c_pmu,
+      "in_rd_cum_outs");
+  // CMEM latency — CPU memory (LPDDR) read latency (cum_outs / req / freq).
+  addVeraUncore(
+      "HW_CMEM_CYCLES",
+      "Cycles on CMEM latency PMU (Vera-Rubin)",
+      PmuType::nvidia_cmem_latency_pmu,
+      "cycles");
+  addVeraUncore(
+      "HW_CMEM_RD_REQ",
+      "CPU memory (LPDDR) read requests",
+      PmuType::nvidia_cmem_latency_pmu,
+      "rd_req");
+  addVeraUncore(
+      "HW_CMEM_RD_CUM_OUTS",
+      "CPU memory read cumulative outstanding (latency numerator)",
+      PmuType::nvidia_cmem_latency_pmu,
+      "rd_cum_outs");
+  // PCIe root-complex and target bandwidth (aggregated across all root
+  // complexes under the Host scope).
+  addVeraUncore(
+      "HW_PCIE_RD_BYTES",
+      "PCIe root-complex read bytes (all root complexes)",
+      PmuType::nvidia_pcie_pmu,
+      "rd_bytes");
+  addVeraUncore(
+      "HW_PCIE_WR_BYTES",
+      "PCIe root-complex write bytes (all root complexes)",
+      PmuType::nvidia_pcie_pmu,
+      "wr_bytes");
+  addVeraUncore(
+      "HW_PCIE_TGT_RD_BYTES",
+      "PCIe target read bytes (all root complexes)",
+      PmuType::nvidia_pcie_tgt_pmu,
+      "rd_bytes");
+  addVeraUncore(
+      "HW_PCIE_TGT_WR_BYTES",
+      "PCIe target write bytes (all root complexes)",
+      PmuType::nvidia_pcie_tgt_pmu,
+      "wr_bytes");
+  // NVLink C-link / D-link (NVSwitch-side) traffic.
+  addVeraUncore(
+      "HW_NVCLINK_IN_RD_REQ",
+      "NVLink C-link inbound read requests",
+      PmuType::nvidia_nvclink_pmu,
+      "in_rd_req");
+  addVeraUncore(
+      "HW_NVDLINK_IN_RD_REQ",
+      "NVLink D-link inbound read requests",
+      PmuType::nvidia_nvdlink_pmu,
+      "in_rd_req");
+
   metrics->add(
       std::make_shared<MetricDesc>(
           "HW_C2C0_CYCLES",

--- a/hbt/src/perf_event/CpuArch.h
+++ b/hbt/src/perf_event/CpuArch.h
@@ -126,6 +126,20 @@ inline CpuArch makeCpuArchArm(
         default:
           return CpuArch::UNKNOWN;
       }
+    case 0x4E: // NVIDIA Corporation
+      switch (cpu_model_num) {
+        // Vera (VR200 / Vera-Rubin) is an NVIDIA-designed Armv9 core that
+        // reports an NVIDIA MIDR (implementer 0x4E, part 0x010) rather than an
+        // Arm Neoverse part number. It is Neoverse-V2 class for perfmon
+        // purposes, so reuse the NEOVERSE_V2 core-event/metric definitions. Its
+        // uncore PMUs have different sysfs names (nvidia_ucf_pmu,
+        // nvidia_nvlink_c2c_pmu, ...) and are handled in
+        // ArmEvents/BuiltinMetrics.
+        case 0x010:
+          return CpuArch::NEOVERSE_V2;
+        default:
+          return CpuArch::UNKNOWN;
+      }
     case 0xC0: // Ampere Computing
       switch (cpu_model_num) {
         case 0xAC3:

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -94,6 +94,13 @@ std::string PmuTypeToStr(PmuType pmu_type) {
     CASE_PMU_TYPE(nvidia_nvlink_c2c1_pmu);
     CASE_PMU_TYPE(nvidia_pcie_pmu);
 
+    CASE_PMU_TYPE(nvidia_ucf_pmu);
+    CASE_PMU_TYPE(nvidia_nvlink_c2c_pmu);
+    CASE_PMU_TYPE(nvidia_cmem_latency_pmu);
+    CASE_PMU_TYPE(nvidia_nvclink_pmu);
+    CASE_PMU_TYPE(nvidia_nvdlink_pmu);
+    CASE_PMU_TYPE(nvidia_pcie_tgt_pmu);
+
     CASE_PMU_TYPE(amd_l3);
 
     CASE_PMU_TYPE(amd_umc);
@@ -155,6 +162,13 @@ PmuType PmuTypeFromStr(const std::string& str) {
   IF_PMU_TYPE(str, nvidia_nvlink_c2c0_pmu);
   IF_PMU_TYPE(str, nvidia_nvlink_c2c1_pmu);
   IF_PMU_TYPE(str, nvidia_pcie_pmu);
+
+  IF_PMU_TYPE(str, nvidia_ucf_pmu);
+  IF_PMU_TYPE(str, nvidia_nvlink_c2c_pmu);
+  IF_PMU_TYPE(str, nvidia_cmem_latency_pmu);
+  IF_PMU_TYPE(str, nvidia_nvclink_pmu);
+  IF_PMU_TYPE(str, nvidia_nvdlink_pmu);
+  IF_PMU_TYPE(str, nvidia_pcie_tgt_pmu);
 
   IF_PMU_TYPE(str, amd_l3);
 
@@ -319,6 +333,40 @@ std::optional<cpu_set_t> parseSysFsPmuCpuMask_(fs::directory_entry dentry) {
 /// PmuType and device id.
 std::pair<PmuType, std::optional<uint32_t>> parseDeviceTypeFromStr(
     const std::string& str) {
+  // NVIDIA per-root-complex PMUs (Vera-Rubin) are named
+  // <prefix>_<socket>_rc_<rc>, e.g. nvidia_pcie_pmu_0_rc_3 or
+  // nvidia_pcie_tgt_pmu_1_rc_5. The single-trailing-index parser below would
+  // mis-split these (leaving "..._rc" as the type), so handle them explicitly.
+  // The device enumeration is packed as socket * kMaxRootComplexesPerSocket +
+  // rc (unique per instance).
+  constexpr uint32_t kMaxRootComplexesPerSocket = 64;
+  if (const auto rc_pos = str.rfind("_rc_"); rc_pos != std::string::npos) {
+    const auto before_rc = str.substr(0, rc_pos); // "<prefix>_<socket>"
+    const auto sock_pos = before_rc.find_last_of('_');
+    if (sock_pos != std::string::npos) {
+      std::optional<uint32_t> enum_id;
+      try {
+        const uint32_t socket =
+            static_cast<uint32_t>(std::stoi(before_rc.substr(sock_pos + 1)));
+        const uint32_t rc =
+            static_cast<uint32_t>(std::stoi(str.substr(rc_pos + 4)));
+        // Guard the packing so a socket's root complexes never alias into the
+        // next socket's id range if a future part exposes more than
+        // kMaxRootComplexesPerSocket root complexes.
+        HBT_THROW_ASSERT_IF(rc >= kMaxRootComplexesPerSocket)
+            << "Root complex index " << rc << " in /sys/devices/" << str
+            << " exceeds the packing limit of " << kMaxRootComplexesPerSocket
+            << " root complexes per socket";
+        enum_id = socket * kMaxRootComplexesPerSocket + rc;
+      } catch (const std::invalid_argument&) {
+        // Not the <socket>_rc_<rc> shape; fall through to default handling.
+      }
+      if (enum_id.has_value()) {
+        return std::make_pair(
+            PmuTypeFromStr(before_rc.substr(0, sock_pos)), enum_id);
+      }
+    }
+  }
   const auto pos = str.find_last_of('_');
   if (pos != std::string::npos) {
     std::optional<uint32_t> num_device;

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -39,6 +39,14 @@ struct CpuSocket {
 using Scope = std::variant<Host, CpuSocket>;
 } // namespace uncore_scope
 
+/// Parse a /sys/devices PMU directory name into its PmuType and device
+/// enumeration. Handles both the <pmu>_<idx> form and the NVIDIA
+/// per-root-complex form <pmu>_<socket>_rc_<rc> (enumerated as socket * 64 +
+/// rc). Exposed for unit testing; throws std::invalid_argument if the type is
+/// unrecognized.
+std::pair<PmuType, std::optional<uint32_t>> parseDeviceTypeFromStr(
+    const std::string& str);
+
 inline std::string toCanonicalEventId(EventId ev_id) {
   transform(ev_id.begin(), ev_id.end(), ev_id.begin(), ::tolower);
   std::replace(ev_id.begin(), ev_id.end(), '-', '_');

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -82,11 +82,23 @@ enum class PmuType : uint16_t {
   // Arm
   armv8_pmuv3,
 
-  // Nvidia Uncores
+  // Nvidia Uncores (Grace-Hopper)
   nvidia_scf_pmu,
   nvidia_nvlink_c2c0_pmu,
   nvidia_nvlink_c2c1_pmu,
   nvidia_pcie_pmu,
+
+  // Nvidia Uncores (Vera-Rubin / Vera). The sysfs names differ from
+  // Grace-Hopper: nvidia_ucf_pmu replaces nvidia_scf_pmu, a single
+  // nvidia_nvlink_c2c_pmu (per-socket instances) replaces c2c0/c2c1, and
+  // nvidia_pcie{,_tgt}_pmu are enumerated per root complex
+  // (<pmu>_<sock>_rc_<n>).
+  nvidia_ucf_pmu,
+  nvidia_nvlink_c2c_pmu,
+  nvidia_cmem_latency_pmu,
+  nvidia_nvclink_pmu,
+  nvidia_nvdlink_pmu,
+  nvidia_pcie_tgt_pmu,
 
   // AMD L3
   amd_l3,

--- a/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
+++ b/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
@@ -55,6 +55,36 @@ TEST_F(BuiltinMetricsTest, ArmCpuIncludesArmCoreMetrics) {
   EXPECT_EQ(eventRefs->at(0).event_id, "ll_cache_miss_rd");
 }
 
+TEST_F(BuiltinMetricsTest, VeraUncoreMetricsRegistered) {
+  // addArmUncoreMetrics is arch-neutral C++ (only its call site in
+  // addUncoreMetrics is __aarch64__-gated), so it can be exercised directly on
+  // any host. Registers the Vera-Rubin uncore metrics for NEOVERSE_V2.
+  auto veraMetrics = std::make_shared<Metrics>();
+  addArmUncoreMetrics(veraMetrics, /*cpuSockets=*/2);
+
+  const auto& descs = veraMetrics->getMetricDescs();
+  // A representative metric per Vera uncore PMU family must be registered.
+  for (const auto* id :
+       {"HW_UCF_MEM_BYTES_RD",
+        "HW_UCF_CYCLES",
+        "HW_VC2C_CYCLES",
+        "HW_CMEM_RD_CUM_OUTS",
+        "HW_PCIE_RD_BYTES",
+        "HW_PCIE_TGT_WR_BYTES",
+        "HW_NVCLINK_IN_RD_REQ",
+        "HW_NVDLINK_IN_RD_REQ"}) {
+    EXPECT_EQ(descs.count(id), 1u) << "missing Vera uncore metric " << id;
+  }
+
+  // The event ref must bind the expected PMU + sysfs event for NEOVERSE_V2.
+  auto desc = veraMetrics->getMetricDesc("HW_UCF_MEM_BYTES_RD");
+  auto refs = desc->getEventRefs(CpuArch::NEOVERSE_V2);
+  ASSERT_TRUE(refs.has_value());
+  ASSERT_EQ(refs->size(), 1u);
+  EXPECT_EQ(refs->at(0).pmu_type, PmuType::nvidia_ucf_pmu);
+  EXPECT_EQ(refs->at(0).event_id, "mem_bytes_rd");
+}
+
 TEST_F(BuiltinMetricsTest, HwCacheEvents) {
   // -- test for hw cache events
   auto l1_dcache_load_hits = pmu_manager->findEventDef(

--- a/hbt/src/perf_event/tests/PmuDevicesTest.cpp
+++ b/hbt/src/perf_event/tests/PmuDevicesTest.cpp
@@ -363,3 +363,63 @@ TEST_F(PmuDevicesTest, LibPfm4Groups) {
   EXPECT_EQ(g1.getDescription(), "desc other group");
   EXPECT_EQ(g1.ev_defs.size(), 1);
 }
+
+// --- Vera-Rubin uncore PMU support ---
+
+TEST_F(PmuDevicesTest, VeraPmuTypeRoundTrip) {
+  const std::vector<std::pair<PmuType, std::string>> expected{
+      {PmuType::nvidia_ucf_pmu, "nvidia_ucf_pmu"},
+      {PmuType::nvidia_nvlink_c2c_pmu, "nvidia_nvlink_c2c_pmu"},
+      {PmuType::nvidia_cmem_latency_pmu, "nvidia_cmem_latency_pmu"},
+      {PmuType::nvidia_nvclink_pmu, "nvidia_nvclink_pmu"},
+      {PmuType::nvidia_nvdlink_pmu, "nvidia_nvdlink_pmu"},
+      {PmuType::nvidia_pcie_tgt_pmu, "nvidia_pcie_tgt_pmu"},
+  };
+  for (const auto& [type, name] : expected) {
+    EXPECT_EQ(PmuTypeToStr(type), name);
+    EXPECT_EQ(PmuTypeFromStr(name), type);
+  }
+}
+
+TEST_F(PmuDevicesTest, ParseVeraDeviceNames) {
+  // Regular single-index devices (per-socket suffix).
+  {
+    auto [type, id] = parseDeviceTypeFromStr("nvidia_ucf_pmu_0");
+    EXPECT_EQ(type, PmuType::nvidia_ucf_pmu);
+    EXPECT_EQ(id, std::optional<uint32_t>(0));
+  }
+  {
+    auto [type, id] = parseDeviceTypeFromStr("nvidia_nvlink_c2c_pmu_1");
+    EXPECT_EQ(type, PmuType::nvidia_nvlink_c2c_pmu);
+    EXPECT_EQ(id, std::optional<uint32_t>(1));
+  }
+  // Per-root-complex devices: <pmu>_<socket>_rc_<rc> -> enum = socket * 64 +
+  // rc.
+  {
+    auto [type, id] = parseDeviceTypeFromStr("nvidia_pcie_pmu_0_rc_0");
+    EXPECT_EQ(type, PmuType::nvidia_pcie_pmu);
+    EXPECT_EQ(id, std::optional<uint32_t>(0));
+  }
+  {
+    auto [type, id] = parseDeviceTypeFromStr("nvidia_pcie_pmu_0_rc_3");
+    EXPECT_EQ(type, PmuType::nvidia_pcie_pmu);
+    EXPECT_EQ(id, std::optional<uint32_t>(3));
+  }
+  {
+    auto [type, id] = parseDeviceTypeFromStr("nvidia_pcie_tgt_pmu_1_rc_5");
+    EXPECT_EQ(type, PmuType::nvidia_pcie_tgt_pmu);
+    EXPECT_EQ(id, std::optional<uint32_t>(1u * 64 + 5));
+  }
+  // Unrecognized PMU type still throws (unchanged behavior).
+  EXPECT_THROW(
+      parseDeviceTypeFromStr("not_a_real_pmu_0_rc_0"), std::invalid_argument);
+}
+
+TEST_F(PmuDevicesTest, VeraCpuArchMapping) {
+  // Vera (VR200 / Vera-Rubin): NVIDIA implementer 0x4E, part 0x010.
+  EXPECT_EQ(makeCpuArchArm(0x4E, 0, 0x010, 0), CpuArch::NEOVERSE_V2);
+  // Unknown NVIDIA part number -> UNKNOWN.
+  EXPECT_EQ(makeCpuArchArm(0x4E, 0, 0x999, 0), CpuArch::UNKNOWN);
+  // Regression: Arm-implemented Neoverse V2 (Grace-Hopper) still maps.
+  EXPECT_EQ(makeCpuArchArm(0x41, 0, 0xD4F, 0), CpuArch::NEOVERSE_V2);
+}


### PR DESCRIPTION
Summary:

Vera CPUs report an NVIDIA MIDR (implementer 0x4E, part 0x010) rather than an
Arm Neoverse part number, so hbt resolved CpuArch::UNKNOWN and collected none
of the Vera-Rubin uncore PMUs. The uncore PMU sysfs names also changed from
Grace-Hopper: nvidia_ucf_pmu (was nvidia_scf_pmu), a single
nvidia_nvlink_c2c_pmu with per-socket instances (was c2c0/c2c1), and
per-root-complex nvidia_pcie{,_tgt}_pmu_<sock>_rc_<n>. So even recognized
PMUs were silently dropped.

Changes:
- hbt/CpuArch.h: map NVIDIA implementer 0x4E / part 0x010 (Vera) -> NEOVERSE_V2.
- hbt PmuEvent/PmuDevices/ArmEvents: add PmuTypes nvidia_ucf_pmu,
  nvidia_nvlink_c2c_pmu, nvidia_cmem_latency_pmu, nvidia_nvclink_pmu,
  nvidia_nvdlink_pmu, nvidia_pcie_tgt_pmu; parse <prefix>_<sock>_rc_<n>
  device names; scan the per-root-complex pcie event set.
- hbt/BuiltinMetrics.cpp: 24 Vera uncore MetricDescs (memory BW, SLC, C2C,
  PCIe, CMEM latency, NVLink C/D), keyed to NEOVERSE_V2.
- dyno/PerfCounterManagerHbtArm: 24 uncore ElemIds + 13 calc accessors.
- dyno/Updater.cpp: export 13 ODS keys (dyno.ucf_mem_bw_read_MBps,
  dyno.pcie_bw_read_MBps, dyno.cmem_read_latency_ns, ...).

Grace-Hopper metrics skip on Vera and vice-versa via the existing graceful
per-metric setup, so existing Grace-Hopper behavior is unchanged.

Reviewed By: bigzachattack, yaoz08

Differential Revision: D110434831


