### PR TITLE
Venice HBT: collect CXL bandwidth via CCM Data Fabric counters (#582)

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -836,6 +836,122 @@ void addEvents(PmuDeviceManager& pmu_manager) {
       std::vector<EventId>({"zen4-l3-fill-rd-resp-smpl"}));
 }
 
+void addZen6CcmCxlEvents(PmuDeviceManager& pmu_manager) {
+  struct CcmCxlEvent {
+    const char* id;
+    const char* alias;
+    uint64_t code;
+  };
+  static const CcmCxlEvent kCcmCxlEvents[] = {
+      {"zen6::ccm_cxl_read_beats.ccm0",
+       "zen6-ccm-cxl-read-beats-ccm0",
+       amd_msr::kCcmZen6CxlReadBeatsCcm0.val},
+      {"zen6::ccm_cxl_read_beats.ccm1",
+       "zen6-ccm-cxl-read-beats-ccm1",
+       amd_msr::kCcmZen6CxlReadBeatsCcm1.val},
+      {"zen6::ccm_cxl_read_beats.ccm2",
+       "zen6-ccm-cxl-read-beats-ccm2",
+       amd_msr::kCcmZen6CxlReadBeatsCcm2.val},
+      {"zen6::ccm_cxl_read_beats.ccm3",
+       "zen6-ccm-cxl-read-beats-ccm3",
+       amd_msr::kCcmZen6CxlReadBeatsCcm3.val},
+      {"zen6::ccm_cxl_read_beats.ccm4",
+       "zen6-ccm-cxl-read-beats-ccm4",
+       amd_msr::kCcmZen6CxlReadBeatsCcm4.val},
+      {"zen6::ccm_cxl_read_beats.ccm5",
+       "zen6-ccm-cxl-read-beats-ccm5",
+       amd_msr::kCcmZen6CxlReadBeatsCcm5.val},
+      {"zen6::ccm_cxl_read_beats.ccm6",
+       "zen6-ccm-cxl-read-beats-ccm6",
+       amd_msr::kCcmZen6CxlReadBeatsCcm6.val},
+      {"zen6::ccm_cxl_read_beats.ccm7",
+       "zen6-ccm-cxl-read-beats-ccm7",
+       amd_msr::kCcmZen6CxlReadBeatsCcm7.val},
+      {"zen6::ccm_cxl_read_beats.ccm8",
+       "zen6-ccm-cxl-read-beats-ccm8",
+       amd_msr::kCcmZen6CxlReadBeatsCcm8.val},
+      {"zen6::ccm_cxl_read_beats.ccm9",
+       "zen6-ccm-cxl-read-beats-ccm9",
+       amd_msr::kCcmZen6CxlReadBeatsCcm9.val},
+      {"zen6::ccm_cxl_read_beats.ccm10",
+       "zen6-ccm-cxl-read-beats-ccm10",
+       amd_msr::kCcmZen6CxlReadBeatsCcm10.val},
+      {"zen6::ccm_cxl_read_beats.ccm11",
+       "zen6-ccm-cxl-read-beats-ccm11",
+       amd_msr::kCcmZen6CxlReadBeatsCcm11.val},
+      {"zen6::ccm_cxl_read_beats.ccm12",
+       "zen6-ccm-cxl-read-beats-ccm12",
+       amd_msr::kCcmZen6CxlReadBeatsCcm12.val},
+      {"zen6::ccm_cxl_read_beats.ccm13",
+       "zen6-ccm-cxl-read-beats-ccm13",
+       amd_msr::kCcmZen6CxlReadBeatsCcm13.val},
+      {"zen6::ccm_cxl_read_beats.ccm14",
+       "zen6-ccm-cxl-read-beats-ccm14",
+       amd_msr::kCcmZen6CxlReadBeatsCcm14.val},
+      {"zen6::ccm_cxl_read_beats.ccm15",
+       "zen6-ccm-cxl-read-beats-ccm15",
+       amd_msr::kCcmZen6CxlReadBeatsCcm15.val},
+      {"zen6::ccm_cxl_write_beats.ccm0",
+       "zen6-ccm-cxl-write-beats-ccm0",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm0.val},
+      {"zen6::ccm_cxl_write_beats.ccm1",
+       "zen6-ccm-cxl-write-beats-ccm1",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm1.val},
+      {"zen6::ccm_cxl_write_beats.ccm2",
+       "zen6-ccm-cxl-write-beats-ccm2",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm2.val},
+      {"zen6::ccm_cxl_write_beats.ccm3",
+       "zen6-ccm-cxl-write-beats-ccm3",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm3.val},
+      {"zen6::ccm_cxl_write_beats.ccm4",
+       "zen6-ccm-cxl-write-beats-ccm4",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm4.val},
+      {"zen6::ccm_cxl_write_beats.ccm5",
+       "zen6-ccm-cxl-write-beats-ccm5",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm5.val},
+      {"zen6::ccm_cxl_write_beats.ccm6",
+       "zen6-ccm-cxl-write-beats-ccm6",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm6.val},
+      {"zen6::ccm_cxl_write_beats.ccm7",
+       "zen6-ccm-cxl-write-beats-ccm7",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm7.val},
+      {"zen6::ccm_cxl_write_beats.ccm8",
+       "zen6-ccm-cxl-write-beats-ccm8",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm8.val},
+      {"zen6::ccm_cxl_write_beats.ccm9",
+       "zen6-ccm-cxl-write-beats-ccm9",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm9.val},
+      {"zen6::ccm_cxl_write_beats.ccm10",
+       "zen6-ccm-cxl-write-beats-ccm10",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm10.val},
+      {"zen6::ccm_cxl_write_beats.ccm11",
+       "zen6-ccm-cxl-write-beats-ccm11",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm11.val},
+      {"zen6::ccm_cxl_write_beats.ccm12",
+       "zen6-ccm-cxl-write-beats-ccm12",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm12.val},
+      {"zen6::ccm_cxl_write_beats.ccm13",
+       "zen6-ccm-cxl-write-beats-ccm13",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm13.val},
+      {"zen6::ccm_cxl_write_beats.ccm14",
+       "zen6-ccm-cxl-write-beats-ccm14",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm14.val},
+      {"zen6::ccm_cxl_write_beats.ccm15",
+       "zen6-ccm-cxl-write-beats-ccm15",
+       amd_msr::kCcmZen6CxlWriteBeatsCcm15.val},
+  };
+  for (const auto& e : kCcmCxlEvents) {
+    pmu_manager.addEvent(
+        std::make_shared<EventDef>(
+            PmuType::amd_df,
+            e.id,
+            EventDef::Encoding{.code = e.code},
+            "Venice CCM CXL beats (one CCM instance).",
+            "Venice CXL bandwidth beats measured on a single CCM (Coherent Master) instance of the Data Fabric."),
+        std::vector<EventId>({e.alias}));
+  }
+}
+
 } // namespace venice
 
 void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
@@ -875,6 +991,8 @@ void addAmdEvents(const CpuInfo& cpu_info, PmuDeviceManager& pmu_manager) {
       venice::addEvents(pmu_manager);
       // UMC bandwidth events (same encodings as Zen5).
       turin::addZen5UmcEvents(pmu_manager);
+      // CCM-based CXL bandwidth events (Zen6-only, Data Fabric PMU).
+      venice::addZen6CcmCxlEvents(pmu_manager);
       break;
     default:
       HBT_LOG_ERROR()

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -597,6 +597,199 @@ constexpr PmuMsr kVeniceIcMabRequest{
     .amdCore = {.event = 0x9c, .unitMask = 0xdf, .event_11_8 = 0x2}};
 constexpr PmuMsr kVeniceBadSpeculation{
     .amdCore = {.event = 0xaa, .unitMask = 0x03}}; // bits[1:0] only on Venice
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm0{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm1{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm2{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm3{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm4{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm5{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm6{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm7{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm8{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm9{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm10{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm11{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm12{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm13{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm14{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlReadBeatsCcm15{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe0,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm0{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm1{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm2{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm3{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x4}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm4{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm5{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm6{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm7{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x5}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm8{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm9{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm10{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm11{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x6}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm12{
+    .amdDfZen4 = {
+        .event = 0x1e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm13{
+    .amdDfZen4 = {
+        .event = 0x5e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm14{
+    .amdDfZen4 = {
+        .event = 0x9e,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
+constexpr PmuMsr kCcmZen6CxlWriteBeatsCcm15{
+    .amdDfZen4 = {
+        .event = 0xde,
+        .unitMask = 0xe1,
+        .unitMask_11_8 = 0xf,
+        .event_13_8 = 0x7}};
 
 } // namespace amd_msr
 

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -3850,6 +3850,36 @@ void addAmdUncoreMetrics(std::shared_ptr<Metrics>& metrics) {
       "UMC bus cycles read_write_cyc(0)/write_cyc(1)/cyc(2)",
       PmuType::amd_umc,
       {"zen5::umc_read_write_cyc", "zen5::umc_write_cyc", "zen5::umc_cyc"});
+
+  // CXL bandwidth via the 16 CCM instances (Venice/Zen6-only, Data Fabric PMU).
+  // Each CCM instance is registered as its own single-event metric so the
+  // kernel can time-multiplex them across the limited number of DF hardware
+  // counters
+  auto addVeniceCcmCxlGroup = [&](const std::string& id,
+                                  const std::string& event_id) {
+    EventRefs refs;
+    refs.push_back(
+        EventRef{event_id, PmuType::amd_df, event_id, EventExtraAttr{}, {}});
+    std::map<TOptCpuArch, EventRefs> event_refs_by_arch;
+    event_refs_by_arch[CpuArch::VENICE] = refs;
+    metrics->add(
+        std::make_shared<MetricDesc>(
+            id,
+            id,
+            id,
+            std::move(event_refs_by_arch),
+            100'000'000,
+            System::Permissions{},
+            std::vector<std::string>{}));
+  };
+  for (int i = 0; i < 16; ++i) {
+    addVeniceCcmCxlGroup(
+        "CxlReadBw" + std::to_string(i),
+        "zen6::ccm_cxl_read_beats.ccm" + std::to_string(i));
+    addVeniceCcmCxlGroup(
+        "CxlWriteBw" + std::to_string(i),
+        "zen6::ccm_cxl_write_beats.ccm" + std::to_string(i));
+  }
 }
 
 void addArmUncoreMetrics(

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -105,6 +105,8 @@ std::string PmuTypeToStr(PmuType pmu_type) {
 
     CASE_PMU_TYPE(amd_umc);
 
+    CASE_PMU_TYPE(amd_df);
+
     CASE_PMU_TYPE(cs_etm);
   }
   return "";
@@ -173,6 +175,8 @@ PmuType PmuTypeFromStr(const std::string& str) {
   IF_PMU_TYPE(str, amd_l3);
 
   IF_PMU_TYPE(str, amd_umc);
+
+  IF_PMU_TYPE(str, amd_df);
 
   IF_PMU_TYPE(str, cs_etm);
 

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -106,6 +106,9 @@ enum class PmuType : uint16_t {
   // AMD Zen5 UMC
   amd_umc,
 
+  // AMD Data Fabric (used for Zen6/Venice CCM CXL bandwidth counters)
+  amd_df,
+
   // Arm
   cs_etm,
 };


### PR DESCRIPTION
Summary:

Adds collection of CXL memory bandwidth on AMD Venice (Zen6) to the HBT perf-counter path (`PerfCounterManagerHbtAmd`). Venice measures CXL traffic on the 16 CCM (Coherent Master) instances of the Data Fabric, distinct from the Turin/Zen5 CS-based comparators. This mirrors the legacy `CorePcmAmd` CCM support from D106044184 but plumbs it through HBT's `MetricDesc`/`EventDef` system instead of the raw-MSR `programCounter` path.

hbt library:
- New `PmuType::amd_df` (Data Fabric PMU), wired into `PmuTypeToStr`/`PmuTypeFromStr` so `/sys/bus/event_source/devices/amd_df*` devices are discovered by `loadSysFsPmus`.
- 32 `kCcmZen6Cxl{Read,Write}BeatsCcm0..15` MSR constants in `AmdEvents.h` (read beat = 32B, write beat = 64B).
- `venice::addZen6CcmCxlEvents` registers the 32 CCM `EventDef`s under `amd_df`, called from the `CpuArch::VENICE` dispatch in `addAmdEvents`.
- `addAmdUncoreMetrics` registers 32 Venice-only single-event metric groups `CxlReadBw{0..15}` / `CxlWriteBw{0..15}`. They are single-event (not one bundled 16-event group) because the DF PMU has far fewer hardware counters than 32, so a bundled group would exceed the counters and fail to schedule; single-event groups let the kernel time-multiplex them.

dyno consumer (`PerfCounterManagerHbtAmd`):
- `getUncoreMetricIds` returns the 32 CXL groups on Venice only, so `configureUncoreMetrics` opens them in the shared uncore mux group.
- `calcCxlBandwidth{Read,Write,Total}MBps` sum the per-instance per-second beat rates and apply the per-direction bytes-per-beat weighting to produce MB/s.
- `recordUncoreSnapshot` stores the read/write MB/s into new `KernelInfo::cxlBW{Read,Write}MBps` fields (copied through in `KernelMonitor::sumOverHistory`), mirroring how the HBT memory-bandwidth metrics reach `KernelInfo`. A follow-up commit exports these to ODS from the shared AMD `Updater` path.

Note: like D106044184, functional validation of the raw counts must be done post-land on a Venice host; Venice A0 silicon measures only CPU-to-CXL traffic and write BW is known-inaccurate (both expected fixed on B0).

Differential Revision: D111741347


