### PR TITLE
Relocate pod-resources gflags to k8s/Flags.{h,cpp} (#586)

### DIFF
--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -23,6 +23,7 @@
 #include "dynolog/src/gpumon/dcgm_fields.h"
 
 #ifdef USE_K8S_PODRESOURCES
+#include "dynolog/src/k8s/Flags.h"
 #include "dynolog/src/k8s/K8sPodCache.h"
 #include "dynolog/src/k8s/PodResourcesClient.h"
 #endif
@@ -100,23 +101,6 @@ DEFINE_bool(
     "Currently this support SLURM job scheduler environment variables.");
 
 #ifdef USE_K8S_PODRESOURCES
-DEFINE_bool(
-    enable_pod_resources_attribution,
-    false,
-    "Enable kubelet pod-resources attribution: query the local kubelet's "
-    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
-    "pod_name, container_name) onto each GPU record by GPU UUID. "
-    "Requires DCGM_FI_DEV_UUID (54) in --dcgm_fields.");
-
-DEFINE_string(
-    pod_resources_socket,
-    "/var/lib/kubelet/pod-resources/kubelet.sock",
-    "Path to kubelet pod-resources gRPC unix socket.");
-
-DEFINE_string(
-    pod_resources_gpu_resource,
-    "nvidia.com/gpu",
-    "K8s extended resource name to filter for GPU device assignments.");
 
 namespace {
 ::dynolog::k8s::PodResourcesClient* getPodResourcesClient() {

--- a/dynolog/src/k8s/CMakeLists.txt
+++ b/dynolog/src/k8s/CMakeLists.txt
@@ -63,11 +63,13 @@ target_link_libraries(dynolog_kubelet_podresources_lib PUBLIC
 # K8s integration library: PodResourcesClient (gRPC over kubelet socket)
 # and K8sPodCache (HTTP+JSON to the K8s API).
 add_library(dynolog_k8s_lib
+    Flags.cpp              Flags.h
     PodResourcesClient.cpp PodResourcesClient.h
     K8sPodCache.cpp        K8sPodCache.h
 )
 target_include_directories(dynolog_k8s_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(dynolog_k8s_lib PUBLIC USE_K8S_PODRESOURCES)
 target_link_libraries(dynolog_k8s_lib PUBLIC
     glog::glog
     gflags::gflags

--- a/dynolog/src/k8s/Flags.cpp
+++ b/dynolog/src/k8s/Flags.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/k8s/Flags.h"
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+DEFINE_bool(
+    enable_pod_resources_attribution,
+    false,
+    "Enable kubelet pod-resources attribution: query the local kubelet's "
+    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
+    "pod_name, container_name) onto each accelerator record by device id. "
+    "Used by both GPU (DcgmGroupInfo) and TPU (TpuGroupInfo) modules; "
+    "filtered to a specific accelerator resource via "
+    "--pod_resources_gpu_resource / --pod_resources_tpu_resource.");
+
+DEFINE_string(
+    pod_resources_socket,
+    "/var/lib/kubelet/pod-resources/kubelet.sock",
+    "Path to kubelet pod-resources gRPC unix socket.");
+
+DEFINE_string(
+    pod_resources_gpu_resource,
+    "nvidia.com/gpu",
+    "K8s extended resource name to filter for GPU device assignments. "
+    "DCGM_FI_DEV_UUID values join against this resource's device_ids.");
+
+DEFINE_string(
+    pod_resources_tpu_resource,
+    "google.com/tpu",
+    "K8s extended resource name to filter for TPU device assignments. "
+    "tpu-device-plugin accelerator_id values join against this "
+    "resource's device_ids.");
+
+#endif // USE_K8S_PODRESOURCES

--- a/dynolog/src/k8s/Flags.h
+++ b/dynolog/src/k8s/Flags.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+// Shared kubelet pod-resources attribution flags. Defined once in Flags.cpp
+// so both gpumon (DcgmGroupInfo) and tpumon (TpuGroupInfo) can reference
+// the same FLAGS_* symbols without producing duplicate-symbol link errors.
+DECLARE_bool(enable_pod_resources_attribution);
+DECLARE_string(pod_resources_socket);
+DECLARE_string(pod_resources_gpu_resource);
+DECLARE_string(pod_resources_tpu_resource);
+
+#endif // USE_K8S_PODRESOURCES


### PR DESCRIPTION
Summary:

Preparation for the upcoming dynolog TPU module (tpumon/), which will share
the same kubelet pod-resources attribution machinery as the GPU module
(gpumon/DcgmGroupInfo).

The three pod-resources gflags are currently defined inside
DcgmGroupInfo.cpp under a USE_K8S_PODRESOURCES guard:

  DEFINE_bool(enable_pod_resources_attribution, ...)
  DEFINE_string(pod_resources_socket, ...)
  DEFINE_string(pod_resources_gpu_resource, ...)

If a future TpuGroupInfo.cpp redefines any of these via DEFINE_*, gflags
fails at link time with duplicate-symbol errors when both gpumon and tpumon
are linked into the dynolog binary. If TPU instead skips the flags, it
can't share the socket-path knob with the GPU module.

This diff:

  - Adds fbcode/dynolog/src/k8s/Flags.{h,cpp} as a new shared compilation
    unit containing DECLARE_* (h) and DEFINE_* (cpp) for the three existing
    flags. The header is the single source of truth that any module needing
    pod-resources attribution can include.

  - Adds a fourth flag --pod_resources_tpu_resource (default 'google.com/tpu')
    in the same file. The TPU module will use this; the GPU module continues
    to use --pod_resources_gpu_resource. Both share --pod_resources_socket.

  - Replaces the three DEFINE_* blocks in gpumon/DcgmGroupInfo.cpp with an
    #include of the new Flags.h. The cpp still references FLAGS_* symbols
    the same way; DECLARE_* makes them visible.

  - Registers Flags.{cpp,h}:
    - Buck: new cpp_library //dynolog/src/k8s:libk8sflags with
      propagated_pp_flags=['-DUSE_K8S_PODRESOURCES'] so the flag body
      actually compiles (the existing DcgmGroupInfo pattern propagates the
      same define). libdcgm now declares libk8sflags as an exported_dep so
      downstream binaries see the flags.
    - CMake: appends Flags.cpp/Flags.h to the existing dynolog_k8s_lib
      (already linked with gflags, glog).

No behavior change. The three existing flags keep the same names, defaults,
and semantics; descriptions were lightly revised to clarify both GPU and
TPU modules now consume them.

Reviewed By: hmlee95070

Differential Revision: D112923245


