### PR TITLE
TpuScraper: HTTP scrape + Prometheus text parser (#587)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(USE_OTLP "Enable OTLP metrics export" OFF)
 option(USE_OTEL "Enable OTLP export via OpenTelemetry, requires
 libprotobuf-dev and libcurl4-openssl-dev on the system"
 OFF)
+option(USE_TPU "Enable TPU metrics scraping, requires libcurl" OFF)
 
 if(USE_PROMETHEUS)
   find_package(prometheus-cpp CONFIG REQUIRED)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -10,6 +10,7 @@ message("Use Prometheus = ${USE_PROMETHEUS}")
 message("Use OTLP = ${USE_OTLP}")
 message("Use ODS Graph API = ${USE_ODS_GRAPH_API}")
 message("Use K8s pod-resources = ${USE_K8S_PODRESOURCES}")
+message("Use TPU = ${USE_TPU}")
 
 # our build script will first create a src/ dir where all source code will exist
 file(GLOB dynolog_src "*.h" "*.cpp")
@@ -64,6 +65,11 @@ add_subdirectory(k8s)
 
 add_subdirectory(gpumon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_dcgm_lib "-ldl")
+
+if(USE_TPU)
+  add_subdirectory(tpumon)
+  target_link_libraries(dynolog_lib PRIVATE dynolog_tpu_lib)
+endif()
 
 add_subdirectory(rdmamon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_rdmamon_lib)

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -23,6 +23,7 @@
 #include "dynolog/src/gpumon/dcgm_fields.h"
 
 #ifdef USE_K8S_PODRESOURCES
+#include "dynolog/src/k8s/Flags.h"
 #include "dynolog/src/k8s/K8sPodCache.h"
 #include "dynolog/src/k8s/PodResourcesClient.h"
 #endif
@@ -100,23 +101,6 @@ DEFINE_bool(
     "Currently this support SLURM job scheduler environment variables.");
 
 #ifdef USE_K8S_PODRESOURCES
-DEFINE_bool(
-    enable_pod_resources_attribution,
-    false,
-    "Enable kubelet pod-resources attribution: query the local kubelet's "
-    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
-    "pod_name, container_name) onto each GPU record by GPU UUID. "
-    "Requires DCGM_FI_DEV_UUID (54) in --dcgm_fields.");
-
-DEFINE_string(
-    pod_resources_socket,
-    "/var/lib/kubelet/pod-resources/kubelet.sock",
-    "Path to kubelet pod-resources gRPC unix socket.");
-
-DEFINE_string(
-    pod_resources_gpu_resource,
-    "nvidia.com/gpu",
-    "K8s extended resource name to filter for GPU device assignments.");
 
 namespace {
 ::dynolog::k8s::PodResourcesClient* getPodResourcesClient() {

--- a/dynolog/src/k8s/CMakeLists.txt
+++ b/dynolog/src/k8s/CMakeLists.txt
@@ -63,11 +63,13 @@ target_link_libraries(dynolog_kubelet_podresources_lib PUBLIC
 # K8s integration library: PodResourcesClient (gRPC over kubelet socket)
 # and K8sPodCache (HTTP+JSON to the K8s API).
 add_library(dynolog_k8s_lib
+    Flags.cpp              Flags.h
     PodResourcesClient.cpp PodResourcesClient.h
     K8sPodCache.cpp        K8sPodCache.h
 )
 target_include_directories(dynolog_k8s_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(dynolog_k8s_lib PUBLIC USE_K8S_PODRESOURCES)
 target_link_libraries(dynolog_k8s_lib PUBLIC
     glog::glog
     gflags::gflags

--- a/dynolog/src/k8s/Flags.cpp
+++ b/dynolog/src/k8s/Flags.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/k8s/Flags.h"
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+DEFINE_bool(
+    enable_pod_resources_attribution,
+    false,
+    "Enable kubelet pod-resources attribution: query the local kubelet's "
+    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
+    "pod_name, container_name) onto each accelerator record by device id. "
+    "Used by both GPU (DcgmGroupInfo) and TPU (TpuGroupInfo) modules; "
+    "filtered to a specific accelerator resource via "
+    "--pod_resources_gpu_resource / --pod_resources_tpu_resource.");
+
+DEFINE_string(
+    pod_resources_socket,
+    "/var/lib/kubelet/pod-resources/kubelet.sock",
+    "Path to kubelet pod-resources gRPC unix socket.");
+
+DEFINE_string(
+    pod_resources_gpu_resource,
+    "nvidia.com/gpu",
+    "K8s extended resource name to filter for GPU device assignments. "
+    "DCGM_FI_DEV_UUID values join against this resource's device_ids.");
+
+DEFINE_string(
+    pod_resources_tpu_resource,
+    "google.com/tpu",
+    "K8s extended resource name to filter for TPU device assignments. "
+    "tpu-device-plugin accelerator_id values join against this "
+    "resource's device_ids.");
+
+#endif // USE_K8S_PODRESOURCES

--- a/dynolog/src/k8s/Flags.h
+++ b/dynolog/src/k8s/Flags.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+// Shared kubelet pod-resources attribution flags. Defined once in Flags.cpp
+// so both gpumon (DcgmGroupInfo) and tpumon (TpuGroupInfo) can reference
+// the same FLAGS_* symbols without producing duplicate-symbol link errors.
+DECLARE_bool(enable_pod_resources_attribution);
+DECLARE_string(pod_resources_socket);
+DECLARE_string(pod_resources_gpu_resource);
+DECLARE_string(pod_resources_tpu_resource);
+
+#endif // USE_K8S_PODRESOURCES

--- a/dynolog/src/tpumon/CMakeLists.txt
+++ b/dynolog/src/tpumon/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TPU scraper needs libcurl for HTTP scrape of tpu-device-plugin /metrics.
+# Keep discovery local so builds without USE_TPU do not require libcurl.
+if(NOT TARGET CURL::libcurl)
+  find_package(CURL REQUIRED)
+endif()
+
+add_library(dynolog_tpu_lib
+    TpuScraper.cpp TpuScraper.h
+)
+target_include_directories(dynolog_tpu_lib
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(dynolog_tpu_lib PUBLIC glog::glog)
+target_link_libraries(dynolog_tpu_lib PUBLIC fmt::fmt)
+target_link_libraries(dynolog_tpu_lib PRIVATE CURL::libcurl)

--- a/dynolog/src/tpumon/TpuScraper.cpp
+++ b/dynolog/src/tpumon/TpuScraper.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+#include <curl/curl.h>
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <mutex>
+#include <string_view>
+#include <utility>
+
+namespace dynolog::tpumon {
+
+namespace {
+
+// libcurl requires a one-time global init before any other curl call.
+// OtlpMetricsLogger already calls this in some builds, but TpuScraper
+// may be constructed on TPU pods that don't use the OTLP metrics path
+// (they use the OTLP logs path via OtlpLogger). Use a mutex-guarded
+// boolean rather than std::once_flag / std::call_once to keep dynolog
+// OSS-compatible without folly and to avoid the once_flag lint.
+void ensureCurlGlobalInit() {
+  static std::mutex init_mu;
+  static bool initialized = false;
+  std::lock_guard<std::mutex> lock(init_mu);
+  if (initialized) {
+    return;
+  }
+  const CURLcode rc = curl_global_init(CURL_GLOBAL_DEFAULT);
+  if (rc != CURLE_OK) {
+    LOG(ERROR) << "TpuScraper: curl_global_init() failed: "
+               << curl_easy_strerror(rc);
+  }
+  initialized = true;
+}
+
+size_t curlWriteToString(char* ptr, size_t size, size_t nmemb, void* userdata) {
+  const size_t total = size * nmemb;
+  auto* out = static_cast<std::string*>(userdata);
+  try {
+    out->append(ptr, total);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "TpuScraper: exception in curlWriteToString: " << ex.what();
+    return 0;
+  }
+  return total;
+}
+
+bool nameMatchesAllowlist(
+    std::string_view name,
+    const std::vector<std::string>& allowlist) {
+  if (allowlist.empty()) {
+    return true;
+  }
+  for (const auto& prefix : allowlist) {
+    if (name.rfind(prefix, 0) == 0) { // starts_with (C++17)
+      return true;
+    }
+  }
+  return false;
+}
+
+// Skip leading whitespace in `s`.
+void skipWhitespace(std::string_view& s) {
+  size_t i = 0;
+  while (i < s.size() && (s[i] == ' ' || s[i] == '\t')) {
+    ++i;
+  }
+  s.remove_prefix(i);
+}
+
+// Parse a single Prometheus label-value string starting at the opening quote.
+// Advances `s` past the closing quote. Returns false on malformed input.
+// Handles \\, \", \n escapes per the spec.
+bool parseLabelValue(std::string_view& s, std::string& out) {
+  if (s.empty() || s.front() != '"') {
+    return false;
+  }
+  s.remove_prefix(1);
+  out.clear();
+  while (!s.empty()) {
+    const char c = s.front();
+    if (c == '"') {
+      s.remove_prefix(1);
+      return true;
+    }
+    if (c == '\\') {
+      if (s.size() < 2) {
+        return false;
+      }
+      const char esc = s[1];
+      if (esc == 'n') {
+        out.push_back('\n');
+      } else {
+        // Covers \\ and \", and any other char passes through literally.
+        out.push_back(esc);
+      }
+      s.remove_prefix(2);
+      continue;
+    }
+    out.push_back(c);
+    s.remove_prefix(1);
+  }
+  return false; // unterminated string
+}
+
+// Parse a `key="value",key2="value2"` label block starting AFTER the opening
+// '{' and ending AT the matching '}'. Advances `s` past the '}'.
+bool parseLabels(
+    std::string_view& s,
+    std::unordered_map<std::string, std::string>& labels) {
+  while (!s.empty()) {
+    skipWhitespace(s);
+    if (s.empty()) {
+      return false;
+    }
+    if (s.front() == '}') {
+      s.remove_prefix(1);
+      return true;
+    }
+    // Read label name up to '='.
+    size_t eq = s.find('=');
+    if (eq == std::string_view::npos) {
+      return false;
+    }
+    std::string key(s.substr(0, eq));
+    s.remove_prefix(eq + 1);
+    std::string value;
+    if (!parseLabelValue(s, value)) {
+      return false;
+    }
+    labels.emplace(std::move(key), std::move(value));
+    skipWhitespace(s);
+    if (!s.empty() && s.front() == ',') {
+      s.remove_prefix(1);
+    }
+  }
+  return false;
+}
+
+// Parse a numeric value token. Returns false if the value is a
+// non-finite Prometheus special (+Inf, -Inf, NaN) — those samples are
+// dropped rather than propagated as sentinel doubles.
+bool parseValue(std::string_view s, double& out) {
+  skipWhitespace(s);
+  if (s.empty()) {
+    return false;
+  }
+  // Take up to next whitespace / end of line as the numeric token.
+  size_t end = 0;
+  while (end < s.size() && s[end] != ' ' && s[end] != '\t') {
+    ++end;
+  }
+  const std::string token(s.substr(0, end));
+  if (token == "+Inf" || token == "-Inf" || token == "Inf" || token == "NaN") {
+    return false;
+  }
+  char* endp = nullptr;
+  const double v = std::strtod(token.c_str(), &endp);
+  if (endp == token.c_str()) {
+    return false;
+  }
+  if (!std::isfinite(v)) {
+    return false;
+  }
+  out = v;
+  return true;
+}
+
+} // namespace
+
+std::vector<TpuSample> parsePrometheusText(const std::string& body) {
+  std::vector<TpuSample> out;
+  out.reserve(64);
+  size_t pos = 0;
+  while (pos < body.size()) {
+    const size_t nl = body.find('\n', pos);
+    const size_t end = (nl == std::string::npos) ? body.size() : nl;
+    std::string_view line(body.data() + pos, end - pos);
+    pos = end + 1;
+
+    // Trim trailing \r for CRLF endpoints.
+    if (!line.empty() && line.back() == '\r') {
+      line.remove_suffix(1);
+    }
+    if (line.empty()) {
+      continue;
+    }
+    if (line.front() == '#') {
+      continue; // HELP / TYPE / free-form comments
+    }
+
+    // Extract metric name (up to '{' or whitespace).
+    size_t name_end = 0;
+    while (name_end < line.size() && line[name_end] != '{' &&
+           line[name_end] != ' ' && line[name_end] != '\t') {
+      ++name_end;
+    }
+    if (name_end == 0) {
+      VLOG(2) << "TpuScraper: skipping malformed line (no name): " << line;
+      continue;
+    }
+    TpuSample sample;
+    sample.name.assign(line.data(), name_end);
+    std::string_view rest = line.substr(name_end);
+
+    if (!rest.empty() && rest.front() == '{') {
+      rest.remove_prefix(1);
+      if (!parseLabels(rest, sample.labels)) {
+        VLOG(2) << "TpuScraper: skipping malformed labels: " << line;
+        continue;
+      }
+    }
+    double value = 0.0;
+    if (!parseValue(rest, value)) {
+      VLOG(2) << "TpuScraper: skipping unparseable value: " << line;
+      continue;
+    }
+    sample.value = value;
+    out.push_back(std::move(sample));
+  }
+  return out;
+}
+
+TpuScraper::TpuScraper(
+    std::string url,
+    int timeout_ms,
+    std::vector<std::string> allowlist)
+    : url_{std::move(url)},
+      timeout_ms_{timeout_ms},
+      allowlist_{
+          allowlist.empty()
+              ? std::vector<
+                    std::
+                        string>{std::begin(kDefaultTpuMetricAllowlist), std::end(kDefaultTpuMetricAllowlist)}
+              : std::move(allowlist)} {
+  ensureCurlGlobalInit();
+}
+
+std::vector<TpuSample> TpuScraper::scrape() {
+  failing_ = false;
+  last_error_.clear();
+
+  CURL* curl = curl_easy_init();
+  if (curl == nullptr) {
+    failing_ = true;
+    last_error_ = "curl_easy_init() returned nullptr";
+    LOG(ERROR) << "TpuScraper: " << last_error_;
+    return {};
+  }
+
+  std::string body;
+  body.reserve(64 * 1024);
+
+  curl_easy_setopt(curl, CURLOPT_URL, url_.c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms_));
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(1000));
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWriteToString);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+
+  const CURLcode rc = curl_easy_perform(curl);
+  long http_code = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_easy_cleanup(curl);
+
+  if (rc != CURLE_OK) {
+    failing_ = true;
+    last_error_ = fmt::format("curl_easy_perform: {}", curl_easy_strerror(rc));
+    LOG_EVERY_N(ERROR, 60) << "TpuScraper: " << last_error_ << " (url=" << url_
+                           << ")";
+    return {};
+  }
+  if (http_code < 200 || http_code >= 300) {
+    failing_ = true;
+    last_error_ = fmt::format("HTTP {}", http_code);
+    LOG_EVERY_N(ERROR, 60) << "TpuScraper: " << last_error_ << " (url=" << url_
+                           << ")";
+    return {};
+  }
+
+  auto samples = parsePrometheusText(body);
+  if (!allowlist_.empty()) {
+    samples.erase(
+        std::remove_if(
+            samples.begin(),
+            samples.end(),
+            [this](const TpuSample& s) {
+              return !nameMatchesAllowlist(s.name, allowlist_);
+            }),
+        samples.end());
+  }
+  return samples;
+}
+
+} // namespace dynolog::tpumon

--- a/dynolog/src/tpumon/TpuScraper.h
+++ b/dynolog/src/tpumon/TpuScraper.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dynolog::tpumon {
+
+// One parsed Prometheus sample from tpu-device-plugin's /metrics endpoint.
+// Example raw line:
+//   duty_cycle{accelerator_id="1234567890123456789-4",make="cloud-tpu",
+//              model="tpu7x",namespace="test-namespace",pod="...",
+//              container="vllm-worker",tpu_topology="2x2x2"} 42.5
+struct TpuSample {
+  std::string name; // e.g. "duty_cycle" or "duty_cycle_node"
+  double value = 0.0;
+  std::unordered_map<std::string, std::string> labels;
+};
+
+// Default metric-name prefixes we care about from tpu-device-plugin.
+// Everything else (Go runtime, promhttp self-metrics) is dropped.
+// Kept in sync with the collector-side keep-regex in
+// conf/node-collector/pipelines/tpu.yml.
+constexpr const char* kDefaultTpuMetricAllowlist[] = {
+    "duty_cycle",
+    "tensorcore_utilization",
+    "memory_total",
+    "memory_used",
+    "memory_bandwidth_utilization",
+};
+
+// HTTP-fetch + parse of the tpu-device-plugin Prometheus endpoint.
+//
+// Thread-safety: not intended for concurrent scrape() calls on the same
+// instance. TpuGroupInfo owns exactly one TpuScraper and calls scrape()
+// from the single tpu_monitor_loop thread.
+class TpuScraper {
+ public:
+  explicit TpuScraper(
+      std::string url,
+      int timeout_ms = 2000,
+      std::vector<std::string> allowlist = {});
+  ~TpuScraper() = default;
+
+  TpuScraper(const TpuScraper&) = delete;
+  TpuScraper& operator=(const TpuScraper&) = delete;
+  TpuScraper(TpuScraper&&) = delete;
+  TpuScraper& operator=(TpuScraper&&) = delete;
+
+  // Performs one HTTP GET against url_ and returns the parsed, filtered
+  // samples. On HTTP failure returns an empty vector and sets isFailing()
+  // = true; lastError() carries the curl error string. Callers are
+  // expected to synthesize a tpu_error record when this returns empty.
+  std::vector<TpuSample> scrape();
+
+  bool isFailing() const {
+    return failing_;
+  }
+  const std::string& lastError() const {
+    return last_error_;
+  }
+  const std::string& url() const {
+    return url_;
+  }
+
+ private:
+  const std::string url_;
+  const int timeout_ms_;
+  const std::vector<std::string> allowlist_;
+  bool failing_ = false;
+  std::string last_error_;
+};
+
+// Prometheus text-format parser exposed for direct unit-testing.
+// Returns every sample line; the caller applies any name allowlist.
+//
+// Handles:
+//   - `# HELP` and `# TYPE` comment lines (skipped)
+//   - `name{k1="v1",k2="v2"} 123.45`
+//   - `name 123`
+//   - Escape sequences \\, \", \n inside label values
+//   - `+Inf`, `-Inf`, `NaN` values (dropped, not returned)
+//   - Blank lines and unrecognized garbage (skipped, logged at V(2))
+std::vector<TpuSample> parsePrometheusText(const std::string& body);
+
+} // namespace dynolog::tpumon

--- a/dynolog/tests/tpumon/TpuScraperTest.cpp
+++ b/dynolog/tests/tpumon/TpuScraperTest.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dynolog::tpumon {
+namespace {
+
+// Real exposition captured from tpu-device-plugin v1.35.7-gke.0 on a
+// tpu7x-standard-4t node (test-tpu-cluster). Trimmed for the test:
+// * 4 bound chips (indices 4-7) carry namespace/pod/container labels
+// * memory_bandwidth_utilization is node-only (see plan Appendix A)
+// * Go runtime lines are included to exercise the allowlist filter
+constexpr const char* kProbeOutputTpu7x =
+    R"PROM(# HELP duty_cycle Percent of time when the TPU was actively processing
+# TYPE duty_cycle gauge
+duty_cycle{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 0
+# HELP duty_cycle_node Percent of time when the TPU was actively processing
+# TYPE duty_cycle_node gauge
+duty_cycle_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+duty_cycle_node{accelerator_id="1234567890123456789-4",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+# HELP memory_total Total memory available on the TPU in bytes
+# TYPE memory_total gauge
+memory_total{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 2.03465670656e+11
+# HELP memory_used Allocated TPU memory in bytes
+# TYPE memory_used gauge
+memory_used{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 1.76938736128e+11
+# HELP memory_bandwidth_utilization_node Memory bandwidth utilization of the TPU device per node
+# TYPE memory_bandwidth_utilization_node gauge
+memory_bandwidth_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 42.5
+# HELP tensorcore_utilization_node Tensorcore percent utilization of the TPU device per node
+# TYPE tensorcore_utilization_node gauge
+tensorcore_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 34
+process_cpu_seconds_total 5699.87
+promhttp_metric_handler_requests_total{code="200"} 37730
+)PROM";
+
+// Returns a reference to the matching sample, or aborts the test via
+// GTEST fatal ADD_FAILURE + a throw. Return-by-reference avoids the
+// nullable-pointer deref pattern that NULLSAFECLANG flags after
+// ASSERT_NE (which the static analyzer cannot see through).
+const TpuSample& sampleByNameAndAccel(
+    const std::vector<TpuSample>& samples,
+    const std::string& name,
+    const std::string& accel_id) {
+  for (const auto& s : samples) {
+    if (s.name != name) {
+      continue;
+    }
+    auto it = s.labels.find("accelerator_id");
+    if (it != s.labels.end() && it->second == accel_id) {
+      return s;
+    }
+  }
+  ADD_FAILURE() << "sample not found: name=" << name
+                << " accelerator_id=" << accel_id;
+  throw std::runtime_error("sample not found");
+}
+
+bool hasSample(
+    const std::vector<TpuSample>& samples,
+    const std::string& name,
+    const std::string& accel_id) {
+  for (const auto& s : samples) {
+    if (s.name != name) {
+      continue;
+    }
+    auto it = s.labels.find("accelerator_id");
+    if (it != s.labels.end() && it->second == accel_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(ParsePrometheusTextTest, ParsesRealTpuDevicePluginExposition) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+
+  // Bound chip -4 should have BOTH the container-labelled duty_cycle and
+  // the node-labelled duty_cycle_node.
+  const auto& container_dc =
+      sampleByNameAndAccel(samples, "duty_cycle", "1234567890123456789-4");
+  EXPECT_EQ(container_dc.labels.at("container"), "vllm-worker");
+  EXPECT_EQ(container_dc.labels.at("namespace"), "test-namespace");
+  EXPECT_EQ(container_dc.labels.at("model"), "tpu7x");
+  EXPECT_EQ(container_dc.labels.at("make"), "cloud-tpu");
+  EXPECT_EQ(container_dc.value, 0.0);
+
+  const auto& node_dc =
+      sampleByNameAndAccel(samples, "duty_cycle_node", "1234567890123456789-4");
+  EXPECT_EQ(node_dc.labels.count("container"), 0u);
+  EXPECT_EQ(node_dc.labels.count("pod"), 0u);
+
+  // Unbound chip -0 should only have the node-labelled series.
+  EXPECT_FALSE(hasSample(samples, "duty_cycle", "1234567890123456789-0"));
+  EXPECT_TRUE(hasSample(samples, "duty_cycle_node", "1234567890123456789-0"));
+}
+
+TEST(ParsePrometheusTextTest, ScientificAndPlainNumericValues) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+
+  const auto& mem_total =
+      sampleByNameAndAccel(samples, "memory_total", "1234567890123456789-4");
+  EXPECT_DOUBLE_EQ(mem_total.value, 2.03465670656e+11);
+
+  const auto& mem_bw = sampleByNameAndAccel(
+      samples, "memory_bandwidth_utilization_node", "1234567890123456789-0");
+  EXPECT_DOUBLE_EQ(mem_bw.value, 42.5);
+}
+
+TEST(ParsePrometheusTextTest, SkipsCommentsAndBlankLines) {
+  const std::string body =
+      "# HELP foo bar\n"
+      "\n"
+      "# TYPE foo gauge\n"
+      "foo 1.5\n"
+      "\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 1u);
+  EXPECT_EQ(samples[0].name, "foo");
+  EXPECT_DOUBLE_EQ(samples[0].value, 1.5);
+}
+
+TEST(ParsePrometheusTextTest, DropsNonFiniteValues) {
+  const std::string body =
+      "good 1.0\n"
+      "posinf +Inf\n"
+      "neginf -Inf\n"
+      "notanumber NaN\n"
+      "good2 2.0\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 2u);
+  EXPECT_EQ(samples[0].name, "good");
+  EXPECT_EQ(samples[1].name, "good2");
+}
+
+TEST(ParsePrometheusTextTest, HandlesEscapedLabelValues) {
+  const std::string body =
+      "foo{key=\"line1\\nline2\",path=\"a\\\\b\",quote=\"say \\\"hi\\\"\"} 42\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 1u);
+  EXPECT_EQ(samples[0].labels.at("key"), "line1\nline2");
+  EXPECT_EQ(samples[0].labels.at("path"), "a\\b");
+  EXPECT_EQ(samples[0].labels.at("quote"), "say \"hi\"");
+}
+
+TEST(ParsePrometheusTextTest, HandlesCrlfLineEndings) {
+  const std::string body = "foo 1\r\nbar 2\r\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 2u);
+  EXPECT_EQ(samples[0].name, "foo");
+  EXPECT_EQ(samples[1].name, "bar");
+}
+
+TEST(TpuScraperAllowlistTest, DefaultAllowlistDropsGoRuntimeAndPromhttp) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+  // Sanity: parser preserves Go runtime and promhttp metrics.
+  bool found_go = false;
+  bool found_promhttp = false;
+  for (const auto& s : samples) {
+    if (s.name == "go_goroutines") {
+      found_go = true;
+    }
+    if (s.name == "promhttp_metric_handler_requests_total") {
+      found_promhttp = true;
+    }
+  }
+  EXPECT_TRUE(found_go);
+  EXPECT_TRUE(found_promhttp);
+
+  // Apply the same allowlist filtering logic as TpuScraper::scrape():
+  // keep a sample if its name starts with any prefix in
+  // kDefaultTpuMetricAllowlist.
+  const std::vector<std::string> allowlist(
+      std::begin(kDefaultTpuMetricAllowlist),
+      std::end(kDefaultTpuMetricAllowlist));
+  auto isAllowed = [&allowlist](const TpuSample& s) {
+    for (const auto& prefix : allowlist) {
+      if (s.name.rfind(prefix, 0) == 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  std::vector<TpuSample> filtered;
+  for (const auto& s : samples) {
+    if (isAllowed(s)) {
+      filtered.push_back(s);
+    }
+  }
+
+  // Go runtime and promhttp metrics must be dropped by the allowlist.
+  for (const auto& s : filtered) {
+    EXPECT_NE(s.name, "go_goroutines");
+    EXPECT_NE(s.name, "promhttp_metric_handler_requests_total");
+    EXPECT_NE(s.name, "process_cpu_seconds_total");
+  }
+
+  // At least one sample from each allowed family should survive.
+  bool has_duty = false;
+  bool has_tensorcore = false;
+  bool has_mem_total = false;
+  bool has_mem_used = false;
+  bool has_mem_bw = false;
+  for (const auto& s : filtered) {
+    if (s.name.rfind("duty_cycle", 0) == 0) {
+      has_duty = true;
+    } else if (s.name.rfind("tensorcore_utilization", 0) == 0) {
+      has_tensorcore = true;
+    } else if (s.name.rfind("memory_total", 0) == 0) {
+      has_mem_total = true;
+    } else if (s.name.rfind("memory_used", 0) == 0) {
+      has_mem_used = true;
+    } else if (s.name.rfind("memory_bandwidth_utilization", 0) == 0) {
+      has_mem_bw = true;
+    }
+  }
+  EXPECT_TRUE(has_duty);
+  EXPECT_TRUE(has_tensorcore);
+  EXPECT_TRUE(has_mem_total);
+  EXPECT_TRUE(has_mem_used);
+  EXPECT_TRUE(has_mem_bw);
+}
+
+} // namespace
+} // namespace dynolog::tpumon

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,10 @@
 set -eux -o pipefail
 BUILD_PROMETHEUS="${BUILD_PROMETHEUS:-0}"
 BUILD_OTLP="${BUILD_OTLP:-0}"
+BUILD_TPU="${BUILD_TPU:-0}"
 USE_PROMETHEUS="OFF"
 USE_OTLP="OFF"
+USE_TPU="OFF"
 
 # Check dependencies
 cmake --version || echo "Please install cmake for your platform using dnf/apt-get etc."
@@ -92,6 +94,18 @@ if [ "${BUILD_K8S_PODRESOURCES}" -eq 1 ]; then
   USE_K8S_PODRESOURCES="ON"
 fi
 
+## Build the TPU scraper if enabled.
+## Requires libcurl for scraping tpu-device-plugin's metrics endpoint.
+if [ "${BUILD_TPU}" -eq 1 ]; then
+  if ! pkg-config --exists libcurl 2>/dev/null; then
+    echo "Error: libcurl not found. Install with:"
+    echo "  apt-get install libcurl4-openssl-dev               # Debian/Ubuntu"
+    echo "  dnf install libcurl-devel                          # Fedora/RHEL"
+    exit 1
+  fi
+  USE_TPU="ON"
+fi
+
 ## Initialize opentelemetry-proto submodule if OTLP is enabled
 if [ "${BUILD_OTLP}" -eq 1 ]
 then
@@ -107,7 +121,7 @@ mkdir -p build; cd build;
 # note we can build without ninja if not available on this system
 cmake "-DUSE_PROMETHEUS=${USE_PROMETHEUS}" "-DUSE_OTEL=${USE_OTEL}" \
   "-DUSE_K8S_PODRESOURCES=${USE_K8S_PODRESOURCES}" \
-  "-DUSE_OTLP=${USE_OTLP}" \
+  "-DUSE_OTLP=${USE_OTLP}" "-DUSE_TPU=${USE_TPU}" \
   -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 


### PR DESCRIPTION
Summary:

Adds HTTP scraping and Prometheus text-format parsing for TPU device metrics in dynolog — the first layer of TPU integration for the accelerator stats path. Follow-up diffs pivot parsed samples into per-chip records and add the Helm chart.

TpuScraper fetches tpu-device-plugin's Prometheus /metrics endpoint
(default http://\$(NODE_IP):2112/metrics) via libcurl and parses the
exposition into typed TpuSample records ({name, value, labels}). The
default allowlist filters to the five families exposed by
tpu-device-plugin v1.35.7-gke.0 on tpu7x nodes:

  duty_cycle, tensorcore_utilization, memory_total, memory_used,
  memory_bandwidth_utilization

Kept in sync with the collector-side keep-regex in
conf/node-collector/pipelines/tpu.yml. Go runtime / promhttp
self-metrics are dropped.

The Prometheus parser handles:
- HELP/TYPE comments and blank lines
- name{k=\"v\",k2=\"v2\"} value and label-less name value
- Escape sequences (\, \", \n) inside label values per the spec
- CRLF line endings
- Non-finite values (+Inf/-Inf/NaN) — dropped rather than propagated

Tests use real exposition captured from a tpu7x-standard-4t node in
test-tpu-cluster. Verify: (a) bound chips carry namespace/pod/container
labels; (b) unbound chips only have _node series; (c) mixed
plain-int/scientific-notation values parse; (d) escapes / CRLF /
non-finite handled; (e) default allowlist covers the 5
tpu-device-plugin families and drops Go runtime + promhttp
self-metrics.

Reviewed By: hmlee95070

Differential Revision: D112923243
