### PR TITLE
TpuGroupInfo + Main.cpp wiring + metric-mappings CSV (#589)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(USE_OTLP "Enable OTLP metrics export" OFF)
 option(USE_OTEL "Enable OTLP export via OpenTelemetry, requires
 libprotobuf-dev and libcurl4-openssl-dev on the system"
 OFF)
+option(USE_TPU "Enable TPU metrics scraping, requires libcurl" OFF)
 
 if(USE_PROMETHEUS)
   find_package(prometheus-cpp CONFIG REQUIRED)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -10,6 +10,7 @@ message("Use Prometheus = ${USE_PROMETHEUS}")
 message("Use OTLP = ${USE_OTLP}")
 message("Use ODS Graph API = ${USE_ODS_GRAPH_API}")
 message("Use K8s pod-resources = ${USE_K8S_PODRESOURCES}")
+message("Use TPU = ${USE_TPU}")
 
 # our build script will first create a src/ dir where all source code will exist
 file(GLOB dynolog_src "*.h" "*.cpp")
@@ -64,6 +65,11 @@ add_subdirectory(k8s)
 
 add_subdirectory(gpumon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_dcgm_lib "-ldl")
+
+if(USE_TPU)
+  add_subdirectory(tpumon)
+  target_link_libraries(dynolog_lib PRIVATE dynolog_tpu_lib)
+endif()
 
 add_subdirectory(rdmamon)
 target_link_libraries(dynolog_lib PUBLIC dynolog_rdmamon_lib)

--- a/dynolog/src/CMakeLists.txt
+++ b/dynolog/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(dynolog_lib PUBLIC dynolog_dcgm_lib "-ldl")
 
 if(USE_TPU)
   add_subdirectory(tpumon)
+  target_compile_definitions(dynolog_lib PUBLIC USE_TPU)
   target_link_libraries(dynolog_lib PRIVATE dynolog_tpu_lib)
 endif()
 

--- a/dynolog/src/Main.cpp
+++ b/dynolog/src/Main.cpp
@@ -25,6 +25,10 @@
 #include "dynolog/src/rpc/SimpleJsonServerInl.h"
 #include "dynolog/src/tracing/IPCMonitor.h"
 
+#ifdef USE_TPU
+#include "dynolog/src/tpumon/TpuGroupInfo.h"
+#endif
+
 #ifdef USE_PROMETHEUS
 #include "dynolog/src/PrometheusLogger.h"
 #endif
@@ -75,6 +79,22 @@ DEFINE_int32(
     dcgm_reporting_interval_s,
     10,
     "Duration in seconds to read and report metrics for DCGM");
+#ifdef USE_TPU
+DEFINE_bool(
+    enable_tpu_monitor,
+    false,
+    "Enable TPU monitor. Scrapes tpu-device-plugin's Prometheus /metrics "
+    "endpoint on the local node (see --tpu_device_plugin_url) and emits "
+    "one metric record per chip per cycle.");
+DEFINE_int32(
+    tpu_reporting_interval_s,
+    10,
+    "Duration in seconds between TPU scrapes.");
+DEFINE_int32(
+    tpu_scrape_timeout_ms,
+    2000,
+    "Per-scrape HTTP timeout in ms for --tpu_device_plugin_url.");
+#endif
 DEFINE_bool(
     enable_ipc_monitor,
     false,
@@ -204,6 +224,48 @@ auto setup_server(const std::shared_ptr<ServiceHandler>& handler) {
   }
 }
 
+#ifdef USE_TPU
+[[noreturn]] void tpu_monitor_loop(
+    const std::shared_ptr<tpumon::TpuGroupInfo>& tpu) {
+  auto logger = getLogger(FLAGS_scribe_category, /*include_otel=*/true);
+
+  LOG(INFO) << "Running TPU loop : interval = "
+            << FLAGS_tpu_reporting_interval_s
+            << " s, url = " << tpumon::FLAGS_tpu_device_plugin_url;
+
+  while (true) {
+    auto wakeup_timepoint = next_wakeup(FLAGS_tpu_reporting_interval_s);
+
+    tpu->update();
+    tpu->log(*logger);
+
+    /* sleep override */
+    std::this_thread::sleep_until(wakeup_timepoint);
+  }
+}
+
+bool start_tpu_monitor(std::unique_ptr<std::thread>& thread) {
+  if (!FLAGS_enable_tpu_monitor) {
+    return true;
+  }
+
+  auto tpu = tpumon::TpuGroupInfo::factory(
+      tpumon::FLAGS_tpu_device_plugin_url,
+      FLAGS_tpu_scrape_timeout_ms,
+      FLAGS_tpu_reporting_interval_s * 1000);
+  if (!tpu) {
+    LOG(ERROR) << "Failed to initialize TpuGroupInfo";
+    return false;
+  }
+  thread = std::make_unique<std::thread>(tpu_monitor_loop, std::move(tpu));
+  return true;
+}
+#else
+bool start_tpu_monitor(std::unique_ptr<std::thread>&) {
+  return true;
+}
+#endif
+
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   FLAGS_logtostderr = true;
@@ -215,7 +277,8 @@ int main(int argc, char** argv) {
   std::shared_ptr<gpumon::DcgmGroupInfo> dcgm;
 
   std::unique_ptr<tracing::IPCMonitor> ipcmon;
-  std::unique_ptr<std::thread> ipcmon_thread, gpumon_thread, pm_thread;
+  std::unique_ptr<std::thread> ipcmon_thread, gpumon_thread, tpumon_thread,
+      pm_thread;
 
   if (FLAGS_enable_ipc_monitor) {
     LOG(INFO) << "Starting IPC Monitor";
@@ -234,6 +297,10 @@ int main(int argc, char** argv) {
       gpumon_thread = std::make_unique<std::thread>(gpu_monitor_loop, dcgm);
     }
   }
+  if (!start_tpu_monitor(tpumon_thread)) {
+    return 1;
+  }
+
   std::thread km_thread{kernel_monitor_loop};
   if (FLAGS_enable_perf_monitor) {
     pm_thread = std::make_unique<std::thread>(perf_monitor_loop);

--- a/dynolog/src/gpumon/DcgmGroupInfo.cpp
+++ b/dynolog/src/gpumon/DcgmGroupInfo.cpp
@@ -23,6 +23,7 @@
 #include "dynolog/src/gpumon/dcgm_fields.h"
 
 #ifdef USE_K8S_PODRESOURCES
+#include "dynolog/src/k8s/Flags.h"
 #include "dynolog/src/k8s/K8sPodCache.h"
 #include "dynolog/src/k8s/PodResourcesClient.h"
 #endif
@@ -100,23 +101,6 @@ DEFINE_bool(
     "Currently this support SLURM job scheduler environment variables.");
 
 #ifdef USE_K8S_PODRESOURCES
-DEFINE_bool(
-    enable_pod_resources_attribution,
-    false,
-    "Enable kubelet pod-resources attribution: query the local kubelet's "
-    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
-    "pod_name, container_name) onto each GPU record by GPU UUID. "
-    "Requires DCGM_FI_DEV_UUID (54) in --dcgm_fields.");
-
-DEFINE_string(
-    pod_resources_socket,
-    "/var/lib/kubelet/pod-resources/kubelet.sock",
-    "Path to kubelet pod-resources gRPC unix socket.");
-
-DEFINE_string(
-    pod_resources_gpu_resource,
-    "nvidia.com/gpu",
-    "K8s extended resource name to filter for GPU device assignments.");
 
 namespace {
 ::dynolog::k8s::PodResourcesClient* getPodResourcesClient() {

--- a/dynolog/src/k8s/CMakeLists.txt
+++ b/dynolog/src/k8s/CMakeLists.txt
@@ -63,11 +63,13 @@ target_link_libraries(dynolog_kubelet_podresources_lib PUBLIC
 # K8s integration library: PodResourcesClient (gRPC over kubelet socket)
 # and K8sPodCache (HTTP+JSON to the K8s API).
 add_library(dynolog_k8s_lib
+    Flags.cpp              Flags.h
     PodResourcesClient.cpp PodResourcesClient.h
     K8sPodCache.cpp        K8sPodCache.h
 )
 target_include_directories(dynolog_k8s_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(dynolog_k8s_lib PUBLIC USE_K8S_PODRESOURCES)
 target_link_libraries(dynolog_k8s_lib PUBLIC
     glog::glog
     gflags::gflags

--- a/dynolog/src/k8s/Flags.cpp
+++ b/dynolog/src/k8s/Flags.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/k8s/Flags.h"
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+DEFINE_bool(
+    enable_pod_resources_attribution,
+    false,
+    "Enable kubelet pod-resources attribution: query the local kubelet's "
+    "pod-resources gRPC socket each cycle and join the (pod_namespace, "
+    "pod_name, container_name) onto each accelerator record by device id. "
+    "Used by both GPU (DcgmGroupInfo) and TPU (TpuGroupInfo) modules; "
+    "filtered to a specific accelerator resource via "
+    "--pod_resources_gpu_resource / --pod_resources_tpu_resource.");
+
+DEFINE_string(
+    pod_resources_socket,
+    "/var/lib/kubelet/pod-resources/kubelet.sock",
+    "Path to kubelet pod-resources gRPC unix socket.");
+
+DEFINE_string(
+    pod_resources_gpu_resource,
+    "nvidia.com/gpu",
+    "K8s extended resource name to filter for GPU device assignments. "
+    "DCGM_FI_DEV_UUID values join against this resource's device_ids.");
+
+DEFINE_string(
+    pod_resources_tpu_resource,
+    "google.com/tpu",
+    "K8s extended resource name to filter for TPU device assignments. "
+    "tpu-device-plugin accelerator_id values join against this "
+    "resource's device_ids.");
+
+#endif // USE_K8S_PODRESOURCES

--- a/dynolog/src/k8s/Flags.h
+++ b/dynolog/src/k8s/Flags.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_K8S_PODRESOURCES
+
+#include <gflags/gflags.h>
+
+// Shared kubelet pod-resources attribution flags. Defined once in Flags.cpp
+// so both gpumon (DcgmGroupInfo) and tpumon (TpuGroupInfo) can reference
+// the same FLAGS_* symbols without producing duplicate-symbol link errors.
+DECLARE_bool(enable_pod_resources_attribution);
+DECLARE_string(pod_resources_socket);
+DECLARE_string(pod_resources_gpu_resource);
+DECLARE_string(pod_resources_tpu_resource);
+
+#endif // USE_K8S_PODRESOURCES

--- a/dynolog/src/tpumon/CMakeLists.txt
+++ b/dynolog/src/tpumon/CMakeLists.txt
@@ -11,10 +11,13 @@ endif()
 
 add_library(dynolog_tpu_lib
     TpuScraper.cpp TpuScraper.h
+    TpuGroupInfo.cpp TpuGroupInfo.h
 )
 target_include_directories(dynolog_tpu_lib
     INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(dynolog_tpu_lib PUBLIC glog::glog)
 target_link_libraries(dynolog_tpu_lib PUBLIC fmt::fmt)
+target_link_libraries(dynolog_tpu_lib PUBLIC gflags::gflags)
+target_link_libraries(dynolog_tpu_lib PUBLIC nlohmann_json::nlohmann_json)
 target_link_libraries(dynolog_tpu_lib PRIVATE CURL::libcurl)

--- a/dynolog/src/tpumon/CMakeLists.txt
+++ b/dynolog/src/tpumon/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TPU scraper needs libcurl for HTTP scrape of tpu-device-plugin /metrics.
+# Keep discovery local so builds without USE_TPU do not require libcurl.
+if(NOT TARGET CURL::libcurl)
+  find_package(CURL REQUIRED)
+endif()
+
+add_library(dynolog_tpu_lib
+    TpuScraper.cpp TpuScraper.h
+)
+target_include_directories(dynolog_tpu_lib
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(dynolog_tpu_lib PUBLIC glog::glog)
+target_link_libraries(dynolog_tpu_lib PUBLIC fmt::fmt)
+target_link_libraries(dynolog_tpu_lib PRIVATE CURL::libcurl)

--- a/dynolog/src/tpumon/TpuGroupInfo.cpp
+++ b/dynolog/src/tpumon/TpuGroupInfo.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuGroupInfo.h"
+
+#include <fmt/format.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string_view>
+#include <utility>
+
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+namespace dynolog::tpumon {
+
+DEFINE_string(
+    tpu_device_plugin_url,
+    "http://localhost:2112/metrics",
+    "Prometheus /metrics URL exposed by tpu-device-plugin on the local "
+    "node. On GKE with hostNetwork:true device-plugin, the canonical form "
+    "is http://$(NODE_IP):2112/metrics where NODE_IP is injected via the "
+    "K8s downward API (fieldRef: status.hostIP).");
+
+namespace {
+
+// Metric-name allowlist for the record-shape logic below. Kept in sync
+// with kDefaultTpuMetricAllowlist in TpuScraper.h; the scraper filters
+// on prefixes so both _node and _container variants get through.
+constexpr std::string_view kDutyCycle = "duty_cycle";
+constexpr std::string_view kDutyCycleNode = "duty_cycle_node";
+constexpr std::string_view kMemoryTotal = "memory_total";
+constexpr std::string_view kMemoryTotalNode = "memory_total_node";
+constexpr std::string_view kMemoryUsed = "memory_used";
+constexpr std::string_view kMemoryUsedNode = "memory_used_node";
+
+struct ChipId {
+  std::string serial; // uuid prefix, shared across all chips on this node
+  int index = -1; // 0..N-1 per host
+};
+
+// tpu-device-plugin's accelerator_id label is `<uuid>-<idx>`. We split
+// the two so the uuid populates accelerator_serial_number and the
+// per-host int populates the Hive-bucket-shaped `device_id`. See plan
+// §2 "Hive bucket compatibility".
+bool parseAcceleratorId(const std::string& accel_id, ChipId& out) {
+  const size_t dash = accel_id.rfind('-');
+  if (dash == std::string::npos || dash == 0 || dash + 1 >= accel_id.size()) {
+    return false;
+  }
+  const std::string idx_str = accel_id.substr(dash + 1);
+  char* endp = nullptr;
+  const long idx = std::strtol(idx_str.c_str(), &endp, 10);
+  // strtol's contract guarantees endp is non-null after the call (it
+  // writes the first non-consumed character position), but static
+  // analysis can't prove that; the explicit `endp == nullptr` check
+  // silences NULLSAFECLANG / CLANGTIDY facebook-hte-NullableDereference.
+  if (endp == nullptr || endp == idx_str.c_str() || *endp != '\0' || idx < 0) {
+    return false;
+  }
+  out.serial = accel_id.substr(0, dash);
+  out.index = static_cast<int>(idx);
+  return true;
+}
+
+// True if the sample carries pod attribution labels (namespace/pod);
+// used to pick container variant over node fallback when both are
+// present for the same chip.
+bool sampleHasPodLabels(const TpuSample& s) {
+  return s.labels.find("namespace") != s.labels.end() &&
+      s.labels.find("pod") != s.labels.end();
+}
+
+} // namespace
+
+std::shared_ptr<TpuGroupInfo> TpuGroupInfo::factory(
+    std::string device_plugin_url,
+    int scrape_timeout_ms,
+    int updateIntervalMs) {
+  LOG(INFO) << "Creating TpuGroupInfo scraping " << device_plugin_url
+            << " every " << updateIntervalMs << " ms";
+  return std::shared_ptr<TpuGroupInfo>(new TpuGroupInfo(
+      std::move(device_plugin_url), scrape_timeout_ms, updateIntervalMs));
+}
+
+TpuGroupInfo::TpuGroupInfo(
+    std::string device_plugin_url,
+    int scrape_timeout_ms,
+    int updateIntervalMs)
+    : scraper_{std::make_unique<TpuScraper>(
+          std::move(device_plugin_url),
+          scrape_timeout_ms)},
+      updateIntervalMs_{updateIntervalMs} {}
+
+TpuGroupInfo::~TpuGroupInfo() = default;
+
+void TpuGroupInfo::update() {
+  const auto samples = scraper_->scrape();
+  updateFromSamples(samples, scraper_->isFailing());
+}
+
+void TpuGroupInfo::updateFromSamples(
+    const std::vector<TpuSample>& samples,
+    bool scrape_failed) {
+  metricsMapDouble_.clear();
+  metricsMapInt_.clear();
+  metricsMapString_.clear();
+  envMetadataMapString_.clear();
+
+  if (scrape_failed) {
+    failing_ = true;
+    // We can't attribute an error to a specific chip when the scrape
+    // itself failed (we don't know how many chips are on the node), so
+    // set a single sentinel row at index 0 with tpu_error=1.
+    metricsMapInt_[0]["tpu_error"] = 1;
+    metricsMapString_[0]["accelerator_vendor"] = "cloud-tpu";
+    return;
+  }
+  failing_ = false;
+
+  // First pass: discover chips by their (uuid, index) and stash string
+  // metadata from any sample we see (labels are identical across
+  // samples for the same chip).
+  //
+  // Two-pass structure keeps the container-vs-node fallback simple:
+  // container samples "win" for duty_cycle / memory_*, node samples are
+  // fallbacks. tensorcore_utilization_node and
+  // memory_bandwidth_utilization_node are intentionally NOT emitted at
+  // per-chip granularity (host-aggregate only — see plan §5a).
+  for (const auto& s : samples) {
+    const auto id_it = s.labels.find("accelerator_id");
+    if (id_it == s.labels.end()) {
+      continue;
+    }
+    ChipId chip;
+    if (!parseAcceleratorId(id_it->second, chip)) {
+      LOG_EVERY_N(WARNING, 60)
+          << "TpuGroupInfo: unparseable accelerator_id: " << id_it->second;
+      continue;
+    }
+    auto& str_map = metricsMapString_[chip.index];
+    if (str_map.count("accelerator_serial_number") == 0) {
+      str_map["accelerator_serial_number"] = chip.serial;
+    }
+    const auto model_it = s.labels.find("model");
+    if (model_it != s.labels.end() && str_map.count("accelerator_model") == 0) {
+      str_map["accelerator_model"] = model_it->second;
+    }
+    const auto make_it = s.labels.find("make");
+    if (make_it != s.labels.end() && str_map.count("accelerator_vendor") == 0) {
+      str_map["accelerator_vendor"] = make_it->second;
+    }
+    // Ensure error column is populated (0 = healthy scrape).
+    if (metricsMapInt_[chip.index].count("tpu_error") == 0) {
+      metricsMapInt_[chip.index]["tpu_error"] = 0;
+    }
+  }
+
+  // Second pass: pull numeric values with the container>node fallback.
+  // Track (chip_index, metric_family) tuples; once we've stored a
+  // container-scoped value for a chip, subsequent node-scoped samples
+  // for the same chip are ignored.
+  std::unordered_map<int, bool> has_container_dc;
+  std::unordered_map<int, bool> has_container_mem_total;
+  std::unordered_map<int, bool> has_container_mem_used;
+  std::unordered_map<int, double> mem_total;
+  std::unordered_map<int, double> mem_used;
+
+  for (const auto& s : samples) {
+    const auto id_it = s.labels.find("accelerator_id");
+    if (id_it == s.labels.end()) {
+      continue;
+    }
+    ChipId chip;
+    if (!parseAcceleratorId(id_it->second, chip)) {
+      continue;
+    }
+    const bool has_pod = sampleHasPodLabels(s);
+    auto& dbl = metricsMapDouble_[chip.index];
+
+    if (s.name == kDutyCycle && has_pod) {
+      dbl["accelerator_utilization"] = s.value;
+      has_container_dc[chip.index] = true;
+    } else if (s.name == kDutyCycleNode) {
+      if (!has_container_dc[chip.index]) {
+        dbl["accelerator_utilization"] = s.value;
+      }
+    } else if (s.name == kMemoryTotal && has_pod) {
+      mem_total[chip.index] = s.value;
+      has_container_mem_total[chip.index] = true;
+    } else if (s.name == kMemoryTotalNode) {
+      if (!has_container_mem_total[chip.index]) {
+        mem_total[chip.index] = s.value;
+      }
+    } else if (s.name == kMemoryUsed && has_pod) {
+      mem_used[chip.index] = s.value;
+      has_container_mem_used[chip.index] = true;
+    } else if (s.name == kMemoryUsedNode) {
+      if (!has_container_mem_used[chip.index]) {
+        mem_used[chip.index] = s.value;
+      }
+    }
+    // tensorcore_utilization_node and memory_bandwidth_utilization_node
+    // are intentionally dropped for per-chip rows (see plan §5a).
+  }
+
+  // Compose memory_utilization from the two capacity gauges.
+  for (const auto& [idx, total] : mem_total) {
+    const auto used_it = mem_used.find(idx);
+    if (used_it == mem_used.end() || total <= 0.0) {
+      continue;
+    }
+    metricsMapDouble_[idx]["memory_utilization"] =
+        (used_it->second / total) * 100.0;
+  }
+}
+
+void TpuGroupInfo::log(Logger& logger) {
+  const auto t = std::chrono::system_clock::now();
+  logger.setTimestamp(t);
+  for (const auto& [index, dbl_map] : metricsMapDouble_) {
+    for (const auto& [k, v] : dbl_map) {
+      logger.logFloat(k, v);
+    }
+    const auto int_it = metricsMapInt_.find(index);
+    if (int_it != metricsMapInt_.end()) {
+      for (const auto& [k, v] : int_it->second) {
+        logger.logInt(k, v);
+      }
+    }
+    const auto str_it = metricsMapString_.find(index);
+    if (str_it != metricsMapString_.end()) {
+      for (const auto& [k, v] : str_it->second) {
+        logger.logStr(k, v);
+      }
+    }
+    const auto env_it = envMetadataMapString_.find(index);
+    if (env_it != envMetadataMapString_.end()) {
+      for (const auto& [k, v] : env_it->second) {
+        logger.logStr(k, v);
+      }
+    }
+    logger.logInt("device", index);
+    logger.finalize();
+  }
+  // Emit the sentinel error row when no chips were discovered.
+  if (metricsMapDouble_.empty()) {
+    const auto int_it = metricsMapInt_.find(0);
+    if (int_it != metricsMapInt_.end()) {
+      for (const auto& [k, v] : int_it->second) {
+        logger.logInt(k, v);
+      }
+      const auto str_it = metricsMapString_.find(0);
+      if (str_it != metricsMapString_.end()) {
+        for (const auto& [k, v] : str_it->second) {
+          logger.logStr(k, v);
+        }
+      }
+      logger.logInt("device", 0);
+      logger.finalize();
+    }
+  }
+}
+
+} // namespace dynolog::tpumon

--- a/dynolog/src/tpumon/TpuGroupInfo.h
+++ b/dynolog/src/tpumon/TpuGroupInfo.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "dynolog/src/Logger.h"
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+namespace dynolog::tpumon {
+
+DECLARE_string(tpu_device_plugin_url);
+
+class TpuScraper;
+
+// TPU counterpart to gpumon::DcgmGroupInfo. Owns the periodic
+// scrape-and-emit for TPU chips on the local node:
+//
+//   1. update()   — HTTP-scrape tpu-device-plugin, pivot samples per chip
+//                   into metricsMap{Double,Int,String}_. If pod-resources
+//                   attribution is enabled, also populates
+//                   envMetadataMapString_ per chip from the K8s API.
+//   2. log(Logger&) — emit one record per chip (float/int/string kv +
+//                   `device` id) followed by finalize().
+//
+// Mirrors DcgmGroupInfo's public contract so Main.cpp wiring is
+// symmetric (factory -> shared_ptr -> loop thread).
+class TpuGroupInfo {
+ public:
+  ~TpuGroupInfo();
+  TpuGroupInfo(const TpuGroupInfo&) = delete;
+  TpuGroupInfo& operator=(const TpuGroupInfo&) = delete;
+  TpuGroupInfo(TpuGroupInfo&&) = delete;
+  TpuGroupInfo& operator=(TpuGroupInfo&&) = delete;
+
+  // Constructs a TpuGroupInfo. `device_plugin_url` is the HTTP endpoint
+  // exposing tpu-device-plugin's Prometheus /metrics; typically
+  // "http://<NODE_IP>:2112/metrics". `scrape_timeout_ms` bounds each
+  // per-cycle scrape. Returns nullptr on unrecoverable init failure
+  // (currently: never — the scraper is lazy and tolerates absent
+  // endpoints). `updateIntervalMs` is informational only (the caller's
+  // loop drives the actual cadence).
+  static std::shared_ptr<TpuGroupInfo> factory(
+      std::string device_plugin_url,
+      int scrape_timeout_ms,
+      int updateIntervalMs);
+
+  // Scrape once and pivot into per-chip metric maps.
+  void update();
+
+  // Test seam: skip HTTP and inject scrape results directly. Never
+  // called from production code — invoked only by TpuGroupInfoTest,
+  // which cannot bind loopback under buck2's default network sandbox.
+  void updateFromSamples(
+      const std::vector<TpuSample>& samples,
+      bool scrape_failed);
+
+  // Emit one OTLP record per chip. See class doc for shape.
+  void log(Logger& logger);
+
+  bool isFailing() const {
+    return failing_;
+  }
+  int getChipCount() const {
+    return static_cast<int>(metricsMapDouble_.size());
+  }
+
+ private:
+  TpuGroupInfo(
+      std::string device_plugin_url,
+      int scrape_timeout_ms,
+      int updateIntervalMs);
+
+  std::unique_ptr<TpuScraper> scraper_;
+  [[maybe_unused]] const int updateIntervalMs_;
+  bool failing_ = false;
+
+  // Keyed by per-host chip index (0..N-1). N is not known ahead of
+  // time; it's the count of unique accelerator_id suffixes observed on
+  // the last successful scrape.
+  std::unordered_map<int, std::unordered_map<std::string, double>>
+      metricsMapDouble_;
+  std::unordered_map<int, std::unordered_map<std::string, int64_t>>
+      metricsMapInt_;
+  std::unordered_map<int, std::unordered_map<std::string, std::string>>
+      metricsMapString_;
+  // Pod attribution: MAST_* env vars via K8sPodCache, plus namespace/pod/
+  // container from pod-resources. Populated only when the shared
+  // --enable_pod_resources_attribution flag is on (Phase 0). Left empty
+  // in Phase 2/3; the pod-resources integration lands in a follow-up
+  // diff to keep this change reviewable.
+  std::unordered_map<int, std::unordered_map<std::string, std::string>>
+      envMetadataMapString_;
+};
+
+} // namespace dynolog::tpumon

--- a/dynolog/src/tpumon/TpuScraper.cpp
+++ b/dynolog/src/tpumon/TpuScraper.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+#include <curl/curl.h>
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <mutex>
+#include <string_view>
+#include <utility>
+
+namespace dynolog::tpumon {
+
+namespace {
+
+// libcurl requires a one-time global init before any other curl call.
+// OtlpMetricsLogger already calls this in some builds, but TpuScraper
+// may be constructed on TPU pods that don't use the OTLP metrics path
+// (they use the OTLP logs path via OtlpLogger). Use a mutex-guarded
+// boolean rather than std::once_flag / std::call_once to keep dynolog
+// OSS-compatible without folly and to avoid the once_flag lint.
+void ensureCurlGlobalInit() {
+  static std::mutex init_mu;
+  static bool initialized = false;
+  std::lock_guard<std::mutex> lock(init_mu);
+  if (initialized) {
+    return;
+  }
+  const CURLcode rc = curl_global_init(CURL_GLOBAL_DEFAULT);
+  if (rc != CURLE_OK) {
+    LOG(ERROR) << "TpuScraper: curl_global_init() failed: "
+               << curl_easy_strerror(rc);
+  }
+  initialized = true;
+}
+
+size_t curlWriteToString(char* ptr, size_t size, size_t nmemb, void* userdata) {
+  const size_t total = size * nmemb;
+  auto* out = static_cast<std::string*>(userdata);
+  try {
+    out->append(ptr, total);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "TpuScraper: exception in curlWriteToString: " << ex.what();
+    return 0;
+  }
+  return total;
+}
+
+bool nameMatchesAllowlist(
+    std::string_view name,
+    const std::vector<std::string>& allowlist) {
+  if (allowlist.empty()) {
+    return true;
+  }
+  for (const auto& prefix : allowlist) {
+    if (name.rfind(prefix, 0) == 0) { // starts_with (C++17)
+      return true;
+    }
+  }
+  return false;
+}
+
+// Skip leading whitespace in `s`.
+void skipWhitespace(std::string_view& s) {
+  size_t i = 0;
+  while (i < s.size() && (s[i] == ' ' || s[i] == '\t')) {
+    ++i;
+  }
+  s.remove_prefix(i);
+}
+
+// Parse a single Prometheus label-value string starting at the opening quote.
+// Advances `s` past the closing quote. Returns false on malformed input.
+// Handles \\, \", \n escapes per the spec.
+bool parseLabelValue(std::string_view& s, std::string& out) {
+  if (s.empty() || s.front() != '"') {
+    return false;
+  }
+  s.remove_prefix(1);
+  out.clear();
+  while (!s.empty()) {
+    const char c = s.front();
+    if (c == '"') {
+      s.remove_prefix(1);
+      return true;
+    }
+    if (c == '\\') {
+      if (s.size() < 2) {
+        return false;
+      }
+      const char esc = s[1];
+      if (esc == 'n') {
+        out.push_back('\n');
+      } else {
+        // Covers \\ and \", and any other char passes through literally.
+        out.push_back(esc);
+      }
+      s.remove_prefix(2);
+      continue;
+    }
+    out.push_back(c);
+    s.remove_prefix(1);
+  }
+  return false; // unterminated string
+}
+
+// Parse a `key="value",key2="value2"` label block starting AFTER the opening
+// '{' and ending AT the matching '}'. Advances `s` past the '}'.
+bool parseLabels(
+    std::string_view& s,
+    std::unordered_map<std::string, std::string>& labels) {
+  while (!s.empty()) {
+    skipWhitespace(s);
+    if (s.empty()) {
+      return false;
+    }
+    if (s.front() == '}') {
+      s.remove_prefix(1);
+      return true;
+    }
+    // Read label name up to '='.
+    size_t eq = s.find('=');
+    if (eq == std::string_view::npos) {
+      return false;
+    }
+    std::string key(s.substr(0, eq));
+    s.remove_prefix(eq + 1);
+    std::string value;
+    if (!parseLabelValue(s, value)) {
+      return false;
+    }
+    labels.emplace(std::move(key), std::move(value));
+    skipWhitespace(s);
+    if (!s.empty() && s.front() == ',') {
+      s.remove_prefix(1);
+    }
+  }
+  return false;
+}
+
+// Parse a numeric value token. Returns false if the value is a
+// non-finite Prometheus special (+Inf, -Inf, NaN) — those samples are
+// dropped rather than propagated as sentinel doubles.
+bool parseValue(std::string_view s, double& out) {
+  skipWhitespace(s);
+  if (s.empty()) {
+    return false;
+  }
+  // Take up to next whitespace / end of line as the numeric token.
+  size_t end = 0;
+  while (end < s.size() && s[end] != ' ' && s[end] != '\t') {
+    ++end;
+  }
+  const std::string token(s.substr(0, end));
+  if (token == "+Inf" || token == "-Inf" || token == "Inf" || token == "NaN") {
+    return false;
+  }
+  char* endp = nullptr;
+  const double v = std::strtod(token.c_str(), &endp);
+  if (endp == token.c_str()) {
+    return false;
+  }
+  if (!std::isfinite(v)) {
+    return false;
+  }
+  out = v;
+  return true;
+}
+
+} // namespace
+
+std::vector<TpuSample> parsePrometheusText(const std::string& body) {
+  std::vector<TpuSample> out;
+  out.reserve(64);
+  size_t pos = 0;
+  while (pos < body.size()) {
+    const size_t nl = body.find('\n', pos);
+    const size_t end = (nl == std::string::npos) ? body.size() : nl;
+    std::string_view line(body.data() + pos, end - pos);
+    pos = end + 1;
+
+    // Trim trailing \r for CRLF endpoints.
+    if (!line.empty() && line.back() == '\r') {
+      line.remove_suffix(1);
+    }
+    if (line.empty()) {
+      continue;
+    }
+    if (line.front() == '#') {
+      continue; // HELP / TYPE / free-form comments
+    }
+
+    // Extract metric name (up to '{' or whitespace).
+    size_t name_end = 0;
+    while (name_end < line.size() && line[name_end] != '{' &&
+           line[name_end] != ' ' && line[name_end] != '\t') {
+      ++name_end;
+    }
+    if (name_end == 0) {
+      VLOG(2) << "TpuScraper: skipping malformed line (no name): " << line;
+      continue;
+    }
+    TpuSample sample;
+    sample.name.assign(line.data(), name_end);
+    std::string_view rest = line.substr(name_end);
+
+    if (!rest.empty() && rest.front() == '{') {
+      rest.remove_prefix(1);
+      if (!parseLabels(rest, sample.labels)) {
+        VLOG(2) << "TpuScraper: skipping malformed labels: " << line;
+        continue;
+      }
+    }
+    double value = 0.0;
+    if (!parseValue(rest, value)) {
+      VLOG(2) << "TpuScraper: skipping unparseable value: " << line;
+      continue;
+    }
+    sample.value = value;
+    out.push_back(std::move(sample));
+  }
+  return out;
+}
+
+TpuScraper::TpuScraper(
+    std::string url,
+    int timeout_ms,
+    std::vector<std::string> allowlist)
+    : url_{std::move(url)},
+      timeout_ms_{timeout_ms},
+      allowlist_{
+          allowlist.empty()
+              ? std::vector<
+                    std::
+                        string>{std::begin(kDefaultTpuMetricAllowlist), std::end(kDefaultTpuMetricAllowlist)}
+              : std::move(allowlist)} {
+  ensureCurlGlobalInit();
+}
+
+std::vector<TpuSample> TpuScraper::scrape() {
+  failing_ = false;
+  last_error_.clear();
+
+  CURL* curl = curl_easy_init();
+  if (curl == nullptr) {
+    failing_ = true;
+    last_error_ = "curl_easy_init() returned nullptr";
+    LOG(ERROR) << "TpuScraper: " << last_error_;
+    return {};
+  }
+
+  std::string body;
+  body.reserve(64 * 1024);
+
+  curl_easy_setopt(curl, CURLOPT_URL, url_.c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms_));
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(1000));
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWriteToString);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+
+  const CURLcode rc = curl_easy_perform(curl);
+  long http_code = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_easy_cleanup(curl);
+
+  if (rc != CURLE_OK) {
+    failing_ = true;
+    last_error_ = fmt::format("curl_easy_perform: {}", curl_easy_strerror(rc));
+    LOG_EVERY_N(ERROR, 60) << "TpuScraper: " << last_error_ << " (url=" << url_
+                           << ")";
+    return {};
+  }
+  if (http_code < 200 || http_code >= 300) {
+    failing_ = true;
+    last_error_ = fmt::format("HTTP {}", http_code);
+    LOG_EVERY_N(ERROR, 60) << "TpuScraper: " << last_error_ << " (url=" << url_
+                           << ")";
+    return {};
+  }
+
+  auto samples = parsePrometheusText(body);
+  if (!allowlist_.empty()) {
+    samples.erase(
+        std::remove_if(
+            samples.begin(),
+            samples.end(),
+            [this](const TpuSample& s) {
+              return !nameMatchesAllowlist(s.name, allowlist_);
+            }),
+        samples.end());
+  }
+  return samples;
+}
+
+} // namespace dynolog::tpumon

--- a/dynolog/src/tpumon/TpuScraper.h
+++ b/dynolog/src/tpumon/TpuScraper.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dynolog::tpumon {
+
+// One parsed Prometheus sample from tpu-device-plugin's /metrics endpoint.
+// Example raw line:
+//   duty_cycle{accelerator_id="1234567890123456789-4",make="cloud-tpu",
+//              model="tpu7x",namespace="test-namespace",pod="...",
+//              container="vllm-worker",tpu_topology="2x2x2"} 42.5
+struct TpuSample {
+  std::string name; // e.g. "duty_cycle" or "duty_cycle_node"
+  double value = 0.0;
+  std::unordered_map<std::string, std::string> labels;
+};
+
+// Default metric-name prefixes we care about from tpu-device-plugin.
+// Everything else (Go runtime, promhttp self-metrics) is dropped.
+// Kept in sync with the collector-side keep-regex in
+// conf/node-collector/pipelines/tpu.yml.
+constexpr const char* kDefaultTpuMetricAllowlist[] = {
+    "duty_cycle",
+    "tensorcore_utilization",
+    "memory_total",
+    "memory_used",
+    "memory_bandwidth_utilization",
+};
+
+// HTTP-fetch + parse of the tpu-device-plugin Prometheus endpoint.
+//
+// Thread-safety: not intended for concurrent scrape() calls on the same
+// instance. TpuGroupInfo owns exactly one TpuScraper and calls scrape()
+// from the single tpu_monitor_loop thread.
+class TpuScraper {
+ public:
+  explicit TpuScraper(
+      std::string url,
+      int timeout_ms = 2000,
+      std::vector<std::string> allowlist = {});
+  ~TpuScraper() = default;
+
+  TpuScraper(const TpuScraper&) = delete;
+  TpuScraper& operator=(const TpuScraper&) = delete;
+  TpuScraper(TpuScraper&&) = delete;
+  TpuScraper& operator=(TpuScraper&&) = delete;
+
+  // Performs one HTTP GET against url_ and returns the parsed, filtered
+  // samples. On HTTP failure returns an empty vector and sets isFailing()
+  // = true; lastError() carries the curl error string. Callers are
+  // expected to synthesize a tpu_error record when this returns empty.
+  std::vector<TpuSample> scrape();
+
+  bool isFailing() const {
+    return failing_;
+  }
+  const std::string& lastError() const {
+    return last_error_;
+  }
+  const std::string& url() const {
+    return url_;
+  }
+
+ private:
+  const std::string url_;
+  const int timeout_ms_;
+  const std::vector<std::string> allowlist_;
+  bool failing_ = false;
+  std::string last_error_;
+};
+
+// Prometheus text-format parser exposed for direct unit-testing.
+// Returns every sample line; the caller applies any name allowlist.
+//
+// Handles:
+//   - `# HELP` and `# TYPE` comment lines (skipped)
+//   - `name{k1="v1",k2="v2"} 123.45`
+//   - `name 123`
+//   - Escape sequences \\, \", \n inside label values
+//   - `+Inf`, `-Inf`, `NaN` values (dropped, not returned)
+//   - Blank lines and unrecognized garbage (skipped, logged at V(2))
+std::vector<TpuSample> parsePrometheusText(const std::string& body);
+
+} // namespace dynolog::tpumon

--- a/dynolog/tests/tpumon/TpuGroupInfoTest.cpp
+++ b/dynolog/tests/tpumon/TpuGroupInfoTest.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuGroupInfo.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "dynolog/src/Logger.h"
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+namespace dynolog::tpumon {
+namespace {
+
+struct CapturedRecord {
+  std::unordered_map<std::string, double> floats;
+  std::unordered_map<std::string, int64_t> ints;
+  std::unordered_map<std::string, std::string> strings;
+};
+
+class RecordingLogger : public Logger {
+ public:
+  void logFloat(const std::string& key, float value) override {
+    current_.floats[key] = value;
+  }
+  void logInt(const std::string& key, int64_t value) override {
+    current_.ints[key] = value;
+  }
+  void logUint(const std::string& key, uint64_t value) override {
+    current_.ints[key] = static_cast<int64_t>(value);
+  }
+  void logStr(const std::string& key, const std::string& value) override {
+    current_.strings[key] = value;
+  }
+  void setTimestamp(Logger::Timestamp) override {}
+  void finalize() override {
+    records_.push_back(std::move(current_));
+    current_ = {};
+  }
+  const std::vector<CapturedRecord>& records() const {
+    return records_;
+  }
+
+ private:
+  CapturedRecord current_;
+  std::vector<CapturedRecord> records_;
+};
+
+// Real exposition captured from tpu-device-plugin v1.35.7-gke.0 on a
+// tpu7x-standard-4t node in test-tpu-cluster. Chip -4/-5 bound to a
+// vllm-worker pod; chip -0 unbound.
+constexpr const char* kProbeOutputTpu7x =
+    R"PROM(duty_cycle{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 42
+duty_cycle{accelerator_id="1234567890123456789-5",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 43
+duty_cycle_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+duty_cycle_node{accelerator_id="1234567890123456789-4",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 99
+memory_total{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 2.03465670656e+11
+memory_used{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 1.017328353e+11
+memory_total_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 2.03465670656e+11
+memory_used_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+tensorcore_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 88
+memory_bandwidth_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 77
+)PROM";
+
+// Returns a reference to the matching record, or aborts the test via
+// GTEST fatal ADD_FAILURE + a throw. Return-by-reference avoids the
+// nullable-pointer deref pattern that NULLSAFECLANG flags after
+// ASSERT_NE (which the static analyzer cannot see through).
+const CapturedRecord& recordByDevice(
+    const std::vector<CapturedRecord>& records,
+    int64_t device) {
+  for (const auto& r : records) {
+    const auto it = r.ints.find("device");
+    if (it != r.ints.end() && it->second == device) {
+      return r;
+    }
+  }
+  ADD_FAILURE() << "no record found for device=" << device;
+  throw std::runtime_error("record not found");
+}
+
+// Fixture: parse the real exposition once, then drive TpuGroupInfo via
+// the testing seam (skips HTTP because buck2's sandbox blocks loopback).
+class TpuGroupInfoTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // URL not used — the seam bypasses TpuScraper::scrape().
+    info_ = TpuGroupInfo::factory("http://unused", 100, 10000);
+    ASSERT_NE(info_, nullptr);
+  }
+
+  void updateFromExposition(const std::string& body) {
+    const auto samples = parsePrometheusText(body);
+    info_->updateFromSamples(samples, /*scrape_failed=*/false);
+    info_->log(logger_);
+  }
+
+  std::shared_ptr<TpuGroupInfo> info_;
+  RecordingLogger logger_;
+};
+
+TEST_F(TpuGroupInfoTest, PopulatesPerChipRowsFromRealExposition) {
+  updateFromExposition(kProbeOutputTpu7x);
+
+  // Bound chip -4: container variant wins over node fallback (42 not 99).
+  const auto& r4 = recordByDevice(logger_.records(), 4);
+  EXPECT_DOUBLE_EQ(r4.floats.at("accelerator_utilization"), 42.0);
+  // memory_utilization = 1.017328353e+11 / 2.03465670656e+11 * 100 = 50%.
+  EXPECT_NEAR(r4.floats.at("memory_utilization"), 50.0, 0.01);
+  EXPECT_EQ(r4.strings.at("accelerator_model"), "tpu7x");
+  EXPECT_EQ(r4.strings.at("accelerator_vendor"), "cloud-tpu");
+  EXPECT_EQ(r4.strings.at("accelerator_serial_number"), "1234567890123456789");
+  EXPECT_EQ(r4.ints.at("tpu_error"), 0);
+
+  // Unbound chip -0: only node variants — accelerator_utilization=0.
+  const auto& r0 = recordByDevice(logger_.records(), 0);
+  EXPECT_DOUBLE_EQ(r0.floats.at("accelerator_utilization"), 0.0);
+  EXPECT_DOUBLE_EQ(r0.floats.at("memory_utilization"), 0.0);
+}
+
+TEST_F(TpuGroupInfoTest, DeviceIdBucketKeyMatchesGpuShape) {
+  updateFromExposition(kProbeOutputTpu7x);
+
+  // Every record must carry an integer `device` in [0, N) and share the
+  // same accelerator_serial_number so the Hive bucket
+  // (timestamp_10s, host_name, device_id, device_instance_id) stays
+  // consistent with GPU rows.
+  std::set<int64_t> device_ids;
+  for (const auto& r : logger_.records()) {
+    ASSERT_EQ(r.ints.count("device"), 1u);
+    device_ids.insert(r.ints.at("device"));
+    ASSERT_EQ(r.strings.at("accelerator_serial_number"), "1234567890123456789");
+  }
+  const std::set<int64_t> expected = {0, 4, 5};
+  EXPECT_EQ(device_ids, expected);
+}
+
+TEST_F(TpuGroupInfoTest, ScrapeFailureEmitsErrorRow) {
+  info_->updateFromSamples(/*samples=*/{}, /*scrape_failed=*/true);
+  info_->log(logger_);
+
+  ASSERT_EQ(logger_.records().size(), 1u);
+  const auto& r = logger_.records()[0];
+  EXPECT_EQ(r.ints.at("tpu_error"), 1);
+  EXPECT_EQ(r.strings.at("accelerator_vendor"), "cloud-tpu");
+  EXPECT_EQ(r.ints.at("device"), 0);
+}
+
+TEST_F(TpuGroupInfoTest, HostAggregateOnlyMetricsNotEmitted) {
+  updateFromExposition(kProbeOutputTpu7x);
+
+  // tensorcore_utilization_node and memory_bandwidth_utilization_node
+  // are host-aggregate only — per plan §5a they MUST NOT be stuffed
+  // into per-chip rows.
+  for (const auto& r : logger_.records()) {
+    EXPECT_EQ(r.floats.count("tensorcore_active"), 0u)
+        << "tensorcore_active must not appear on TPU rows (plan §5a)";
+    EXPECT_EQ(r.floats.count("mem_bw_util"), 0u)
+        << "mem_bw_util must not appear on TPU rows (plan §5a)";
+  }
+}
+
+} // namespace
+} // namespace dynolog::tpumon

--- a/dynolog/tests/tpumon/TpuScraperTest.cpp
+++ b/dynolog/tests/tpumon/TpuScraperTest.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "dynolog/src/tpumon/TpuScraper.h"
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dynolog::tpumon {
+namespace {
+
+// Real exposition captured from tpu-device-plugin v1.35.7-gke.0 on a
+// tpu7x-standard-4t node (test-tpu-cluster). Trimmed for the test:
+// * 4 bound chips (indices 4-7) carry namespace/pod/container labels
+// * memory_bandwidth_utilization is node-only (see plan Appendix A)
+// * Go runtime lines are included to exercise the allowlist filter
+constexpr const char* kProbeOutputTpu7x =
+    R"PROM(# HELP duty_cycle Percent of time when the TPU was actively processing
+# TYPE duty_cycle gauge
+duty_cycle{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 0
+# HELP duty_cycle_node Percent of time when the TPU was actively processing
+# TYPE duty_cycle_node gauge
+duty_cycle_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+duty_cycle_node{accelerator_id="1234567890123456789-4",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+# HELP memory_total Total memory available on the TPU in bytes
+# TYPE memory_total gauge
+memory_total{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 2.03465670656e+11
+# HELP memory_used Allocated TPU memory in bytes
+# TYPE memory_used gauge
+memory_used{accelerator_id="1234567890123456789-4",container="vllm-worker",make="cloud-tpu",model="tpu7x",namespace="test-namespace",pod="test-workload-pod",tpu_topology="2x2x2"} 1.76938736128e+11
+# HELP memory_bandwidth_utilization_node Memory bandwidth utilization of the TPU device per node
+# TYPE memory_bandwidth_utilization_node gauge
+memory_bandwidth_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 42.5
+# HELP tensorcore_utilization_node Tensorcore percent utilization of the TPU device per node
+# TYPE tensorcore_utilization_node gauge
+tensorcore_utilization_node{accelerator_id="1234567890123456789-0",make="cloud-tpu",model="tpu7x",tpu_topology="2x2x2"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 34
+process_cpu_seconds_total 5699.87
+promhttp_metric_handler_requests_total{code="200"} 37730
+)PROM";
+
+// Returns a reference to the matching sample, or aborts the test via
+// GTEST fatal ADD_FAILURE + a throw. Return-by-reference avoids the
+// nullable-pointer deref pattern that NULLSAFECLANG flags after
+// ASSERT_NE (which the static analyzer cannot see through).
+const TpuSample& sampleByNameAndAccel(
+    const std::vector<TpuSample>& samples,
+    const std::string& name,
+    const std::string& accel_id) {
+  for (const auto& s : samples) {
+    if (s.name != name) {
+      continue;
+    }
+    auto it = s.labels.find("accelerator_id");
+    if (it != s.labels.end() && it->second == accel_id) {
+      return s;
+    }
+  }
+  ADD_FAILURE() << "sample not found: name=" << name
+                << " accelerator_id=" << accel_id;
+  throw std::runtime_error("sample not found");
+}
+
+bool hasSample(
+    const std::vector<TpuSample>& samples,
+    const std::string& name,
+    const std::string& accel_id) {
+  for (const auto& s : samples) {
+    if (s.name != name) {
+      continue;
+    }
+    auto it = s.labels.find("accelerator_id");
+    if (it != s.labels.end() && it->second == accel_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(ParsePrometheusTextTest, ParsesRealTpuDevicePluginExposition) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+
+  // Bound chip -4 should have BOTH the container-labelled duty_cycle and
+  // the node-labelled duty_cycle_node.
+  const auto& container_dc =
+      sampleByNameAndAccel(samples, "duty_cycle", "1234567890123456789-4");
+  EXPECT_EQ(container_dc.labels.at("container"), "vllm-worker");
+  EXPECT_EQ(container_dc.labels.at("namespace"), "test-namespace");
+  EXPECT_EQ(container_dc.labels.at("model"), "tpu7x");
+  EXPECT_EQ(container_dc.labels.at("make"), "cloud-tpu");
+  EXPECT_EQ(container_dc.value, 0.0);
+
+  const auto& node_dc =
+      sampleByNameAndAccel(samples, "duty_cycle_node", "1234567890123456789-4");
+  EXPECT_EQ(node_dc.labels.count("container"), 0u);
+  EXPECT_EQ(node_dc.labels.count("pod"), 0u);
+
+  // Unbound chip -0 should only have the node-labelled series.
+  EXPECT_FALSE(hasSample(samples, "duty_cycle", "1234567890123456789-0"));
+  EXPECT_TRUE(hasSample(samples, "duty_cycle_node", "1234567890123456789-0"));
+}
+
+TEST(ParsePrometheusTextTest, ScientificAndPlainNumericValues) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+
+  const auto& mem_total =
+      sampleByNameAndAccel(samples, "memory_total", "1234567890123456789-4");
+  EXPECT_DOUBLE_EQ(mem_total.value, 2.03465670656e+11);
+
+  const auto& mem_bw = sampleByNameAndAccel(
+      samples, "memory_bandwidth_utilization_node", "1234567890123456789-0");
+  EXPECT_DOUBLE_EQ(mem_bw.value, 42.5);
+}
+
+TEST(ParsePrometheusTextTest, SkipsCommentsAndBlankLines) {
+  const std::string body =
+      "# HELP foo bar\n"
+      "\n"
+      "# TYPE foo gauge\n"
+      "foo 1.5\n"
+      "\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 1u);
+  EXPECT_EQ(samples[0].name, "foo");
+  EXPECT_DOUBLE_EQ(samples[0].value, 1.5);
+}
+
+TEST(ParsePrometheusTextTest, DropsNonFiniteValues) {
+  const std::string body =
+      "good 1.0\n"
+      "posinf +Inf\n"
+      "neginf -Inf\n"
+      "notanumber NaN\n"
+      "good2 2.0\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 2u);
+  EXPECT_EQ(samples[0].name, "good");
+  EXPECT_EQ(samples[1].name, "good2");
+}
+
+TEST(ParsePrometheusTextTest, HandlesEscapedLabelValues) {
+  const std::string body =
+      "foo{key=\"line1\\nline2\",path=\"a\\\\b\",quote=\"say \\\"hi\\\"\"} 42\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 1u);
+  EXPECT_EQ(samples[0].labels.at("key"), "line1\nline2");
+  EXPECT_EQ(samples[0].labels.at("path"), "a\\b");
+  EXPECT_EQ(samples[0].labels.at("quote"), "say \"hi\"");
+}
+
+TEST(ParsePrometheusTextTest, HandlesCrlfLineEndings) {
+  const std::string body = "foo 1\r\nbar 2\r\n";
+  const auto samples = parsePrometheusText(body);
+  ASSERT_EQ(samples.size(), 2u);
+  EXPECT_EQ(samples[0].name, "foo");
+  EXPECT_EQ(samples[1].name, "bar");
+}
+
+TEST(TpuScraperAllowlistTest, DefaultAllowlistDropsGoRuntimeAndPromhttp) {
+  const auto samples = parsePrometheusText(kProbeOutputTpu7x);
+  // Sanity: parser preserves Go runtime and promhttp metrics.
+  bool found_go = false;
+  bool found_promhttp = false;
+  for (const auto& s : samples) {
+    if (s.name == "go_goroutines") {
+      found_go = true;
+    }
+    if (s.name == "promhttp_metric_handler_requests_total") {
+      found_promhttp = true;
+    }
+  }
+  EXPECT_TRUE(found_go);
+  EXPECT_TRUE(found_promhttp);
+
+  // Apply the same allowlist filtering logic as TpuScraper::scrape():
+  // keep a sample if its name starts with any prefix in
+  // kDefaultTpuMetricAllowlist.
+  const std::vector<std::string> allowlist(
+      std::begin(kDefaultTpuMetricAllowlist),
+      std::end(kDefaultTpuMetricAllowlist));
+  auto isAllowed = [&allowlist](const TpuSample& s) {
+    for (const auto& prefix : allowlist) {
+      if (s.name.rfind(prefix, 0) == 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  std::vector<TpuSample> filtered;
+  for (const auto& s : samples) {
+    if (isAllowed(s)) {
+      filtered.push_back(s);
+    }
+  }
+
+  // Go runtime and promhttp metrics must be dropped by the allowlist.
+  for (const auto& s : filtered) {
+    EXPECT_NE(s.name, "go_goroutines");
+    EXPECT_NE(s.name, "promhttp_metric_handler_requests_total");
+    EXPECT_NE(s.name, "process_cpu_seconds_total");
+  }
+
+  // At least one sample from each allowed family should survive.
+  bool has_duty = false;
+  bool has_tensorcore = false;
+  bool has_mem_total = false;
+  bool has_mem_used = false;
+  bool has_mem_bw = false;
+  for (const auto& s : filtered) {
+    if (s.name.rfind("duty_cycle", 0) == 0) {
+      has_duty = true;
+    } else if (s.name.rfind("tensorcore_utilization", 0) == 0) {
+      has_tensorcore = true;
+    } else if (s.name.rfind("memory_total", 0) == 0) {
+      has_mem_total = true;
+    } else if (s.name.rfind("memory_used", 0) == 0) {
+      has_mem_used = true;
+    } else if (s.name.rfind("memory_bandwidth_utilization", 0) == 0) {
+      has_mem_bw = true;
+    }
+  }
+  EXPECT_TRUE(has_duty);
+  EXPECT_TRUE(has_tensorcore);
+  EXPECT_TRUE(has_mem_total);
+  EXPECT_TRUE(has_mem_used);
+  EXPECT_TRUE(has_mem_bw);
+}
+
+} // namespace
+} // namespace dynolog::tpumon

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,10 @@
 set -eux -o pipefail
 BUILD_PROMETHEUS="${BUILD_PROMETHEUS:-0}"
 BUILD_OTLP="${BUILD_OTLP:-0}"
+BUILD_TPU="${BUILD_TPU:-0}"
 USE_PROMETHEUS="OFF"
 USE_OTLP="OFF"
+USE_TPU="OFF"
 
 # Check dependencies
 cmake --version || echo "Please install cmake for your platform using dnf/apt-get etc."
@@ -92,6 +94,18 @@ if [ "${BUILD_K8S_PODRESOURCES}" -eq 1 ]; then
   USE_K8S_PODRESOURCES="ON"
 fi
 
+## Build the TPU scraper if enabled.
+## Requires libcurl for scraping tpu-device-plugin's metrics endpoint.
+if [ "${BUILD_TPU}" -eq 1 ]; then
+  if ! pkg-config --exists libcurl 2>/dev/null; then
+    echo "Error: libcurl not found. Install with:"
+    echo "  apt-get install libcurl4-openssl-dev               # Debian/Ubuntu"
+    echo "  dnf install libcurl-devel                          # Fedora/RHEL"
+    exit 1
+  fi
+  USE_TPU="ON"
+fi
+
 ## Initialize opentelemetry-proto submodule if OTLP is enabled
 if [ "${BUILD_OTLP}" -eq 1 ]
 then
@@ -107,7 +121,7 @@ mkdir -p build; cd build;
 # note we can build without ninja if not available on this system
 cmake "-DUSE_PROMETHEUS=${USE_PROMETHEUS}" "-DUSE_OTEL=${USE_OTEL}" \
   "-DUSE_K8S_PODRESOURCES=${USE_K8S_PODRESOURCES}" \
-  "-DUSE_OTLP=${USE_OTLP}" \
+  "-DUSE_OTLP=${USE_OTLP}" "-DUSE_TPU=${USE_TPU}" \
   -DCMAKE_BUILD_TYPE=Release -G Ninja "$@" ..
 cmake --build .
 


### PR DESCRIPTION
Summary:

Adds TPU monitoring to dynolog, mirroring the existing GPU (DcgmGroupInfo) path. TpuGroupInfo scrapes the local tpu-device-plugin's Prometheus endpoint, pivots per-chip metrics (utilization, memory, model, vendor), and emits them through the Logger/OtlpLogger pipeline with the same row shape as GPU records.

Container-scoped metrics are preferred when available, with node-level fallbacks for unbound chips. Host-aggregate-only metrics (tensorcore, memory bandwidth) are intentionally excluded from per-chip rows to avoid misrepresenting per-chip activity.

New flags: `--enable_tpu_monitor`, `--tpu_reporting_interval_s`, `--tpu_scrape_timeout_ms`, `--tpu_device_plugin_url`.

Reviewed By: hmlee95070

Differential Revision: D112923242


