### PR TITLE
add store-to-load conflicts and success events for AMD

### DIFF
--- a/hbt/src/perf_event/AmdEvents.cpp
+++ b/hbt/src/perf_event/AmdEvents.cpp
@@ -282,6 +282,28 @@ void addCoreEvents(PmuDeviceManager& pmu_manager) {
           "Load-store miss address buffer allocated to pipes."),
       std::vector<EventId>({"ls-mab-alloc-pipes"}));
 
+  // Store-to-load forwarding
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_bad_status2.stli_other",
+          EventDef::Encoding{.code = amd_msr::kLsBadStatus2StliOther.val},
+          "Store-to-load conflicts (non-forwardable).",
+          "Store-to-load interlock: a load was unable to complete due to a "
+          "non-forwardable conflict with an older store. AMD equivalent of "
+          "Intel LD_BLOCKS.STORE_FORWARD."),
+      std::vector<EventId>({"ls-bad-status2.stli-other"}));
+
+  pmu_manager.addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "ls_stlf",
+          EventDef::Encoding{.code = amd_msr::kLsStlf.val},
+          "Store-to-load forwards (STLF hits).",
+          "Number of successful store-to-load forwards; complement of "
+          "ls_bad_status2.stli_other."),
+      std::vector<EventId>({"ls-stlf"}));
+
   pmu_manager.addEvent(
       std::make_shared<EventDef>(
           PmuType::cpu,

--- a/hbt/src/perf_event/AmdEvents.h
+++ b/hbt/src/perf_event/AmdEvents.h
@@ -139,6 +139,10 @@ constexpr PmuMsr kLsInefSwPref{.amdCore = {.event = 0x52, .unitMask = 0x3}};
 constexpr PmuMsr kLsHwPfDcFillsDramIoFar{
     .amdCore = {.event = 0x5a, .unitMask = 0x40}};
 
+constexpr PmuMsr kLsBadStatus2StliOther{
+    .amdCore = {.event = 0x24, .unitMask = 0x02}};
+constexpr PmuMsr kLsStlf{.amdCore = {.event = 0x35}};
+
 // L1 iCache
 constexpr PmuMsr kL1ICacheFillMisses{
     .amdCore = {.event = 0x64, .unitMask = 0x7}}; // Same as e=0x60,u=0x10

--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -668,6 +668,48 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
           std::vector<std::string>{},
           getRateReducer()));
 
+  if (cpu_info.cpu_family == CpuFamily::INTEL) {
+    metrics->add(
+        std::make_shared<MetricDesc>(
+            "store_forward_blocks",
+            "Loads blocked by failed store-to-load forwarding.",
+            "Number of loads that could not receive their data via "
+            "store-to-load forwarding and had to wait for the older store to "
+            "retire.",
+            std::map<TOptCpuArch, EventRefs>{
+                {std::nullopt,
+                 EventRefs{EventRef{
+                     "store_forward_blocks",
+                     PmuType::cpu,
+                     "LD_BLOCKS.STORE_FORWARD",
+                     EventExtraAttr{},
+                     {}}}}},
+            1'000'000,
+            System::Permissions{},
+            std::vector<std::string>{}));
+  } else if (
+      cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
+      cpu_info.cpu_family == CpuFamily::AMDZEN6) {
+    metrics->add(
+        std::make_shared<MetricDesc>(
+            "store_forward_blocks",
+            "Loads blocked by failed store-to-load forwarding.",
+            "Number of loads that could not complete due to a non-forwardable "
+            "conflict with an older store.",
+            std::map<TOptCpuArch, EventRefs>{
+                {std::nullopt,
+                 EventRefs{EventRef{
+                     "store_forward_blocks",
+                     PmuType::cpu,
+                     "ls_bad_status2.stli_other",
+                     EventExtraAttr{},
+                     {}}}}},
+            1'000'000,
+            System::Permissions{},
+            std::vector<std::string>{}));
+  }
+
   // l2_cache_misses replaces DynoPerfCounterType::L2CACHE_MISS
   if (cpu_info.cpu_family == CpuFamily::INTEL) {
     metrics->add(


### PR DESCRIPTION
Summary:
ls-bad-status2.stli-other is the equivalent of Intel's LD_BLOCKS.STORE_FORWARD. Also added the successful event as a compliment.

Also made a common event to join the two: `store_forward_blocks`.

Reviewed By: marksantaniello, sonntex

Differential Revision: D113927962


