### PR TITLE
make the idx assignment to task local storage atomic

### DIFF
--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -406,10 +406,17 @@ int BPF_PROG(bperf_register_thread, struct bpf_map *map,
 
   bperf_thread_data_init(data);
 
-  task_idx = bpf_task_storage_get(&per_thread_idx, task, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+  /* Publish the index as part of the storage creation. Assigning it after
+   * bpf_task_storage_get() returns leaves a window in which the storage
+   * exists but still holds 0: a PMU hardirq on this CPU runs
+   * _pmu_enable_exit() for this same task, and get_bperf_thread_data()
+   * would resolve to element 0 and let the leader overwrite
+   * bperf_thread_metadata with bperf_thread_data.
+   */
+  idx_t new_idx = idx;
+  task_idx = bpf_task_storage_get(&per_thread_idx, task, &new_idx, BPF_LOCAL_STORAGE_GET_F_CREATE);
   if (!task_idx)
     return 0;
-  *task_idx = idx;
   bperf_leader_prog(task, task);
   return 0;
 }


### PR DESCRIPTION
Summary:
```
 SubscriberWorke-2689297 [066] ..... 3304276.372704: bpf_trace_printk: bperf_register_thread: pid=2689297 idx=1395 first_free=354

 SubscriberWorke-2689297 [066] d.h.. 3304276.372707: bpf_trace_printk: get_bperf_thread_data: pid=2689297 resolved to idx 0!
```

The current implementation first zero initializes task local storage, then assigns the actual index.

However, a BPF prog might yield in cases like a hardware irq before the actual index is assigned, and then trigger an inner bperf bpf prog, which will use the incorrect 0 as the index to update bperf-related data (as shown in the above log). Updating with the incorrect index will pollute the BPF map and cause undefined behavior later on.

Fix this by initializing the local storage with the assigned index.

Differential Revision: D114680780


