### PR TITLE
Detect ROCm version in the integrated RDC build

### DIFF
--- a/dynolog/src/gpumon/amd/CMakeLists.txt
+++ b/dynolog/src/gpumon/amd/CMakeLists.txt
@@ -57,7 +57,50 @@ endif ()
 
 if (rdc_FOUND AND amd_smi_FOUND AND LIBCAP_FOUND)
     message(STATUS "RDC package found at ${ROCM_RDC_INCLUDE_DIR}")
+
+    # The RDC metric list compiled into RdcWrapper.cpp and the example is gated
+    # on DYNOLOG_ROCM_VERSION (e.g. 70000 == ROCm 7.0.x). If it is left
+    # undefined, every metric is preprocessed out, leaving an empty metric set
+    # that makes the example abort at runtime ("enabledMetrics is empty"). The
+    # standalone build above sets it explicitly; detect it here for the
+    # integrated build. Pass -DROCM_VERSION=<code> to override the detection.
+    if (NOT DEFINED ROCM_VERSION)
+        # Derive the ROCm root from the RDC package that was actually found so
+        # this honours CMAKE_PREFIX_PATH and versioned paths like
+        # /opt/rocm-10.0.0.
+        get_filename_component(_dynolog_rocm_root "${rdc_DIR}/../../.." ABSOLUTE)
+        set(_dynolog_rocm_version_file "${_dynolog_rocm_root}/.info/version")
+        if (NOT EXISTS "${_dynolog_rocm_version_file}" AND DEFINED ENV{ROCM_PATH})
+            set(_dynolog_rocm_version_file "$ENV{ROCM_PATH}/.info/version")
+        endif ()
+        if (EXISTS "${_dynolog_rocm_version_file}")
+            file(STRINGS "${_dynolog_rocm_version_file}"
+                 _dynolog_rocm_version_raw LIMIT_COUNT 1)
+            string(REGEX MATCHALL "[0-9]+"
+                   _dynolog_rocm_parts "${_dynolog_rocm_version_raw}")
+            list(LENGTH _dynolog_rocm_parts _dynolog_rocm_nparts)
+            if (_dynolog_rocm_nparts GREATER_EQUAL 3)
+                list(GET _dynolog_rocm_parts 0 _dynolog_rocm_major)
+                list(GET _dynolog_rocm_parts 1 _dynolog_rocm_minor)
+                list(GET _dynolog_rocm_parts 2 _dynolog_rocm_patch)
+                math(EXPR ROCM_VERSION
+                     "${_dynolog_rocm_major} * 10000 + ${_dynolog_rocm_minor} * 100 + ${_dynolog_rocm_patch}")
+            endif ()
+        endif ()
+    endif ()
+    if (NOT DEFINED ROCM_VERSION)
+        message(WARNING
+            "dynolog: unable to determine the ROCm version for the RDC "
+            "integration; RDC metrics will be empty. Pass -DROCM_VERSION=<code> "
+            "(e.g. 70000 for ROCm 7.0.x) to set it explicitly.")
+        set(ROCM_VERSION 0)
+    endif ()
+    message(STATUS
+        "dynolog RDC integration using DYNOLOG_ROCM_VERSION=${ROCM_VERSION}")
+
     add_library(dynolog_rdc_lib RdcWrapper.cpp RdcWrapper.h)
+    target_compile_definitions(
+        dynolog_rdc_lib PUBLIC DYNOLOG_ROCM_VERSION=${ROCM_VERSION})
     target_link_libraries(dynolog_rdc_lib rdc glog::glog)
 
     add_library(dynolog_amd_device_lib AmdDeviceTopology.cpp AmdDeviceTopology.h)

--- a/dynolog/src/gpumon/amd/examples/RdcWrapperExample.cpp
+++ b/dynolog/src/gpumon/amd/examples/RdcWrapperExample.cpp
@@ -10,6 +10,7 @@
 #include <gflags/gflags.h>
 #include <unistd.h>
 #include <chrono>
+#include <exception>
 #include <iostream>
 #include <thread>
 #include <variant>
@@ -130,42 +131,51 @@ int main(int argc, char** argv) {
               << ")" << std::endl;
   }
 
-  dynolog::gpumon::RdcWrapper rdcWrapper(
-      kEnabledMetrics,
-      std::chrono::milliseconds(FLAGS_update_interval_ms),
-      std::chrono::seconds(FLAGS_max_keep_age_seconds),
-      FLAGS_max_keep_samples);
+  // RdcWrapper reports fatal setup problems (an empty metric set, an
+  // unsupported field, an RDC error, ...) by throwing. Catch here so the
+  // example exits with a non-zero status instead of letting the exception
+  // escape main() and abort with a core dump.
+  try {
+    dynolog::gpumon::RdcWrapper rdcWrapper(
+        kEnabledMetrics,
+        std::chrono::milliseconds(FLAGS_update_interval_ms),
+        std::chrono::seconds(FLAGS_max_keep_age_seconds),
+        FLAGS_max_keep_samples);
 
-  const auto entities = rdcWrapper.getMonitoredEntities();
-  std::cout << "Monitoring " << entities.size()
-            << " entities (physical GPUs + partitions):" << std::endl;
-  for (const auto entity : entities) {
-    std::cout << "  entity index=" << entity << std::endl;
-  }
+    const auto entities = rdcWrapper.getMonitoredEntities();
+    std::cout << "Monitoring " << entities.size()
+              << " entities (physical GPUs + partitions):" << std::endl;
+    for (const auto entity : entities) {
+      std::cout << "  entity index=" << entity << std::endl;
+    }
 
-  // This example runs until killed (Ctrl-C / SIGTERM): the worker loops
-  // forever polling metrics, so worker.join() below never returns and there is
-  // no clean shutdown path by design.
-  auto worker = std::thread([&]() {
-    while (true) {
-      sleep(1);
-      for (const auto entity : entities) {
-        const auto metricMap = rdcWrapper.getRdcMetricsForDevice(entity);
-        std::cout << "entity " << entity << ": collected " << metricMap.size()
-                  << " metrics" << std::endl;
-        for (const auto& [field, value] : metricMap) {
-          std::visit(
-              [entity, field](auto&& arg) {
-                std::cout << "  entity " << entity << " "
-                          << field_id_string(field) << " (id=" << field
-                          << ")=" << arg << std::endl;
-              },
-              value);
+    // This example runs until killed (Ctrl-C / SIGTERM): the worker loops
+    // forever polling metrics, so worker.join() below never returns and there
+    // is no clean shutdown path by design.
+    auto worker = std::thread([&]() {
+      while (true) {
+        sleep(1);
+        for (const auto entity : entities) {
+          const auto metricMap = rdcWrapper.getRdcMetricsForDevice(entity);
+          std::cout << "entity " << entity << ": collected " << metricMap.size()
+                    << " metrics" << std::endl;
+          for (const auto& [field, value] : metricMap) {
+            std::visit(
+                [entity, field](auto&& arg) {
+                  std::cout << "  entity " << entity << " "
+                            << field_id_string(field) << " (id=" << field
+                            << ")=" << arg << std::endl;
+                },
+                value);
+          }
         }
       }
-    }
-  });
+    });
 
-  worker.join();
+    worker.join();
+  } catch (const std::exception& e) {
+    std::cerr << "RDC example failed: " << e.what() << std::endl;
+    return 1;
+  }
   return 0;
 }


### PR DESCRIPTION
## Problem

Building dynolog with the AMD RDC integration from the top level
(`cmake -S . -B build`, the "integrated" build) produces an `RdcWrapperExample`
that aborts at startup:

```
Initializing RDC example, ROCM version: 0
Collecting 0 metrics:
terminate called after throwing an instance of 'std::runtime_error'
  what():  enabledMetrics is empty
Aborted (core dumped)
```

The metric list in `RdcWrapper.cpp` and `RdcWrapperExample.cpp` is gated on
`DYNOLOG_ROCM_VERSION` (e.g. `70000` == ROCm 7.0.x). The standalone build of
`dynolog/src/gpumon/amd` defines it, but the integrated build path never did,
so with the macro undefined every metric is preprocessed out. The example then
reports "ROCM version: 0", collects 0 metrics, and `RdcWrapper` throws an
uncaught `std::runtime_error` -> `std::terminate` -> core dump. Because the
crash is at construction it is independent of the GPU.

## Fix

- `dynolog/src/gpumon/amd/CMakeLists.txt`: in the integrated build path, detect
  the installed ROCm version (parsed from `<rocm_root>/.info/version`, where the
  root is derived from the RDC package that `find_package(rdc)` located, so it
  honours `CMAKE_PREFIX_PATH` and versioned paths like `/opt/rocm-10.0.0`) and
  compile it into `dynolog_rdc_lib` as `DYNOLOG_ROCM_VERSION`. `-DROCM_VERSION=`
  still overrides the detection, matching the standalone build.
- `dynolog/src/gpumon/amd/examples/RdcWrapperExample.cpp`: wrap the RDC usage in
  `main()` in try/catch so any fatal setup error (empty metric set, unsupported
  field, RDC error) exits non-zero instead of terminating with a core dump.

## Testing

On a ROCm 7.3.0 host, integrated build (`cmake -S . -B build -G Ninja
-DCMAKE_PREFIX_PATH=/opt/rocm`):

- Before: `ROCM version: 0`, `Collecting 0 metrics`, `enabledMetrics is empty`,
  core dump.
- After: CMake logs `dynolog RDC integration using DYNOLOG_ROCM_VERSION=70300`;
  the example reports `ROCM version: 70300` and `Collecting 30 metrics`, and
  runs without aborting.
