### PR TITLE
handle 48 bit PMU counter overflow

### DIFF
--- a/hbt/src/perf_event/BPerfPerThreadReader.cpp
+++ b/hbt/src/perf_event/BPerfPerThreadReader.cpp
@@ -325,7 +325,13 @@ int BPerfPerThreadReader::read(struct BPerfThreadData* data) {
     data->values[i].enabled += time_after_offset_update;
 
     if (raw_event_data[i].idx) {
-      data->values[i].counter += pmc_val[i] - raw_event_data[i].offset;
+      // The PMC is BPERF_PMC_WIDTH bits wide and the leader records offset
+      // masked to the same width, so the hardware counter can wrap between
+      // the leader's snapshot and rdpmc() below. Mask the difference to the
+      // counter width: a wrap then yields the true delta instead of
+      // underflowing __u64 into a ~2^64 reading.
+      data->values[i].counter +=
+          (pmc_val[i] - raw_event_data[i].offset) & BPERF_PMC_MASK;
       data->values[i].running += time_after_offset_update;
     }
   }

--- a/hbt/src/perf_event/bpf/bperf.h
+++ b/hbt/src/perf_event/bpf/bperf.h
@@ -43,6 +43,34 @@ struct bperf_perf_event_data {
   __u32 idx;
 };
 
+/* Width, in bits, of the hardware PMC that the leader snapshots into
+ * `offset` and the reader samples with rdpmc(). Both sides mask to this
+ * width so a counter wrap yields the true delta instead of underflowing a
+ * __u64, so the two must agree -- hence the shared definition.
+ *
+ * x86: x86_pmu.cntval_bits, fixed at 48 for general-purpose counters
+ * (arch/x86/events/core.c).
+ *
+ * aarch64: 32, NOT 64. PMUv3 event counters only count in the low 32 bits
+ * unless PMCR_EL0.LP is set AND the event is opened with attr.config1:0
+ * ("long"). BPerfEventsGroup leaves config1 at 0, so even on FEAT_PMUv3p5
+ * parts (Neoverse V2/V3) the kernel biases the counter to overflow at 32
+ * bits -- armv8pmu_event_needs_bias() ORs in GENMASK_ULL(63, 32), and
+ * arch_perf_update_userpage() reports pmc_width = 32. Both in
+ * drivers/perf/arm_pmuv3.c. Masking wider than 32 there would leave the
+ * bias bits in the delta.
+ *
+ * TODO @alston64 turning on 64 bits reporting before onboarding to arm hosts
+ */
+#if __x86_64__
+#define BPERF_PMC_WIDTH 48
+#elif __aarch64__
+#define BPERF_PMC_WIDTH 32
+#else
+#error "BPERF_PMC_WIDTH is not defined for this architecture"
+#endif
+#define BPERF_PMC_MASK ((1ULL << BPERF_PMC_WIDTH) - 1)
+
 struct bperf_thread_metadata {
   __u32 metadata_size; /* sizeof(bperf_thread_metadata) */
   __u32 thread_data_size; /* sizeof(bperf_thread_data) */

--- a/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
+++ b/hbt/src/perf_event/bpf/bperf_leader_cgroup.bpf.c
@@ -74,12 +74,7 @@ int cpu_cnt = 0;
 int cgroup_update_level = 0;
 
 static __always_inline __u64 event_prev_count(struct perf_event *event) {
-  /*
-   * X86 perf event counter is fixed to be 48 bits (x86_pmu.cntval_bits).
-   * arch/x86/events/core.c?lines=121
-   * TODO: verify this for aarch64 architecture
-   */
-  return 0xffffffffffff & event->hw.prev_count.a.a.counter;
+  return BPERF_PMC_MASK & event->hw.prev_count.a.a.counter;
 }
 
 #define PF_IDLE 0x00000002


### PR DESCRIPTION
Summary:
x86 has a fixed 48 bits PMC counter. so it can wrap earlier than the u64 accumulated value in the bperf

aarch64 can be either 32 bits, or 64 bits based on the perf config on modern CPU (https://www.internalfb.com/code/kernel-linux/[linus-upstream%3A0d839570765118029aa8bf4a95444c6a11aacf85]/drivers/perf/arm_pmu.c?lines=112-122). use 32 bit mask for now without changing the perf config.

Differential Revision: D114956096


