### PR TITLE
Add keyed per-device uncore count read (#596)

### DIFF
--- a/hbt/src/mon/Monitor.h
+++ b/hbt/src/mon/Monitor.h
@@ -342,6 +342,22 @@ class Monitor {
     return rvs;
   }
 
+  // Read counts for the uncore metric given by elem_id, keyed by PMU device
+  // id (PerUncoreCountReader::UncoreDeviceId::toInt()).
+  std::optional<std::map<int, TUncoreCountReader::ReadValues>>
+  readUncoreCountsPerDevice(const ElemId& elem_id) const {
+    std::lock_guard<std::mutex> lock{mutex_};
+
+    if (auto it = uncore_count_readers_.find(elem_id);
+        it != uncore_count_readers_.end()) {
+      HBT_THROW_ASSERT_IF(it->second == nullptr);
+      return it->second->readPerPerfEventsGroupKeyed();
+    }
+    HBT_LOG_WARNING() << fmt::format(
+        "No UncoreCountReader with id {}", elem_id);
+    return std::nullopt;
+  }
+
  private:
   // Helper function that does the CPU reading and returns per-CPU results
   // This is the core implementation that both simple and grouped methods use

--- a/hbt/src/perf_event/PerUncoreCountReader.h
+++ b/hbt/src/perf_event/PerUncoreCountReader.h
@@ -210,6 +210,18 @@ class PerUncoreCountReader : public PerPerfEventsGroupBase<UncoreCountReader> {
     return rvs;
   }
 
+  // The key is UncoreDeviceId::toInt(), so callers can recover the cpu and
+  // pmu_id of the device that produced each value and attribute it to a
+  // hardware domain (e.g. the CCX behind an amd_l3 device).
+  virtual std::optional<std::map<int, ReadValues>> readPerPerfEventsGroupKeyed()
+      const {
+    std::map<int, ReadValues> res;
+    if (!TBase::readPerPerfEventsGroup(res, getNumEvents())) {
+      return std::nullopt;
+    }
+    return res;
+  }
+
   virtual std::map<int, ReadValues> readPerPerfEventsGroupOnCpu(
       CpuId cpu) const {
     return TBase::readPerPerfEventsGroupOnCpu(cpu);


### PR DESCRIPTION
Summary:

`PerUncoreCountReader::readPerPerfEventsGroup()` flattens the per-device
results into a `std::vector`, discarding the map key that identifies which
PMU device produced each value. The underlying
`PerPerfEventsGroupBase::readPerPerfEventsGroup()` already fills a keyed map,
so the identity is available and only dropped by that convenience wrapper.

Add `readPerPerfEventsGroupKeyed()`, which returns the keyed map as-is, and
`Monitor::readUncoreCountsPerDevice()` to expose it for a single metric. The
key is `UncoreDeviceId::toInt()`, so callers can recover the cpu and pmu_id
and attribute each value to a hardware domain -- for example the CCX behind an
`amd_l3` device, which is needed to report per NUMA node memory latency.

Purely additive: no existing caller or code path changes, and the existing
flattening API is untouched.

Differential Revision: D116695667


