### PR TITLE
Populate cpu_l3_cache_misses on ARM in dyno_twtask_stats

### DIFF
--- a/hbt/src/perf_event/BuiltinMetrics.cpp
+++ b/hbt/src/perf_event/BuiltinMetrics.cpp
@@ -515,6 +515,22 @@ void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager) {
                       << e.what() << "\"";
     }
 #endif // USE_JSON_GENERATED_PERF_EVENTS
+    if (cpu_info.cpu_arch == CpuArch::SRF) {
+      pmu_manager->addEvent(
+          std::make_shared<EventDef>(
+              PmuType::cpu,
+              "L1D.REPLACEMENT",
+              EventDef::Encoding{.code = 0x51, .umask = 0x01},
+              "L1 data cache line replacements.",
+              "Counts cache lines replaced in the L1 data cache on Sierra Forest."));
+      pmu_manager->addEvent(
+          std::make_shared<EventDef>(
+              PmuType::cpu,
+              "L2_LINES_IN.ALL",
+              EventDef::Encoding{.code = 0x25, .umask = 0x1e},
+              "L2 cache lines entering the E, F, M, or S state.",
+              "Counts L2 cache lines entering the E, F, M, or S state on Sierra Forest."));
+    }
   } else if (cpu_info.cpu_family == CpuFamily::ARM) {
     addArmEvents(cpu_info, *pmu_manager);
   } else {
@@ -570,6 +586,49 @@ void populatePmuDeviceManager(std::shared_ptr<PmuDeviceManager>& pmu_manager) {
         "ex_ret_brn_tkn",
         std::vector<EventId>({"branch-instructions-ret-tkn"}));
   }
+}
+
+static void addAmdL1CacheMissMetrics(std::shared_ptr<Metrics>& metrics) {
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_L1_ICACHE_FILL_MISSES",
+          "L1 instruction cache fill misses",
+          "Counts any instruction fill misses in the cache.",
+          std::map<TOptCpuArch, EventRefs>{
+              {std::nullopt,
+               EventRefs{EventRef{
+                   "l1_icache_fill_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "CORE_L1_DCACHE_MISSES",
+          "L1 data cache misses",
+          "L1 data cache misses.",
+          std::map<TOptCpuArch, EventRefs>{
+              {std::nullopt,
+               EventRefs{EventRef{
+                   "l1_dcache_misses",
+                   PmuType::cpu,
+                   "l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "l1_dcache_misses",
+                   PmuType::cpu,
+                   "zen6::l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
 }
 
 /// Add Builtin-Metrics, other metrics can be added dynamically.
@@ -710,6 +769,147 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
             std::vector<std::string>{}));
   }
 
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "l1d_cache_misses",
+          "L1 data cache misses.",
+          "Counts L1 data cache replacements on Intel, L1 data cache misses "
+          "on AMD, and L1 data cache refills on ARM.",
+          std::map<TOptCpuArch, EventRefs>{
+              {std::nullopt,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "L1D.REPLACEMENT",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::MILAN,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::GENOA,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::BERGAMO,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::TURIN,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::cpu,
+                   "zen6::l1_dcache_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::armv8_pmuv3,
+                   "l1d_cache_refill",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "l1d_cache_misses",
+                   PmuType::armv8_pmuv3,
+                   "l1d_cache_refill",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
+  metrics->add(
+      std::make_shared<MetricDesc>(
+          "l1i_cache_misses",
+          "L1 instruction cache misses.",
+          "Counts L2 code requests on Intel, L1 instruction cache fill "
+          "misses on AMD, and L1 instruction cache refills on ARM.",
+          std::map<TOptCpuArch, EventRefs>{
+              {std::nullopt,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "L2_RQSTS.ALL_CODE_RD",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::SRF,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "ICACHE.MISSES",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::MILAN,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::GENOA,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::BERGAMO,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::TURIN,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::VENICE,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::cpu,
+                   "l1_icache_fill_misses",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V2,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::armv8_pmuv3,
+                   "l1i_cache_refill",
+                   EventExtraAttr{},
+                   {}}}},
+              {CpuArch::NEOVERSE_V3,
+               EventRefs{EventRef{
+                   "l1i_cache_misses",
+                   PmuType::armv8_pmuv3,
+                   "l1i_cache_refill",
+                   EventExtraAttr{},
+                   {}}}}},
+          100'000'000,
+          System::Permissions{},
+          std::vector<std::string>{}));
+
   // l2_cache_misses replaces DynoPerfCounterType::L2CACHE_MISS
   if (cpu_info.cpu_family == CpuFamily::INTEL) {
     metrics->add(
@@ -725,6 +925,13 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
                      PmuType::cpu,
                      "l2_cache_misses",
                      EventExtraAttr{},
+                     {}}}},
+                {CpuArch::SRF,
+                 EventRefs{EventRef{
+                     "l2_cache_misses",
+                     PmuType::cpu,
+                     "L2_LINES_IN.ALL",
+                     EventExtraAttr{},
                      {}}}}},
             100'000'000,
             System::Permissions{},
@@ -733,6 +940,7 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
       cpu_info.cpu_family == CpuFamily::AMDZEN3 ||
       cpu_info.cpu_family == CpuFamily::AMDZEN5 ||
       cpu_info.cpu_family == CpuFamily::AMDZEN6) {
+    addAmdL1CacheMissMetrics(metrics);
     metrics->add(
         std::make_shared<MetricDesc>(
             "l2_cache_misses",
@@ -1692,30 +1900,21 @@ std::shared_ptr<Metrics> makeAvailableMetricsForCpu(const CpuInfo& cpu_info) {
 
   if (cpu_info.cpu_family == CpuFamily::ARM) {
     addArmCoreMetrics(metrics);
+  } else if (cpu_info.cpu_family == CpuFamily::INTEL) {
+    // The config-events catalog exposes Intel L1 cache metrics under these
+    // existing host IDs. Include the same definitions in the compiled task
+    // snapshot so task-key resolution is identical with or without config
+    // events. SPR and SRF also reuse the host IDs for L2 and L3.
+    addIntelCoreMetrics(metrics);
   }
 
   return metrics;
 }
 
 void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
-  // L1 Instruction Cache Metrics
-  metrics->add(
-      std::make_shared<MetricDesc>(
-          "CORE_L1_ICACHE_FILL_MISSES",
-          "L1 instruction cache fill misses",
-          "Counts any instruction fill misses in the cache.",
-          std::map<TOptCpuArch, EventRefs>{
-              {std::nullopt,
-               EventRefs{EventRef{
-                   "l1_icache_fill_misses",
-                   PmuType::cpu,
-                   "l1_icache_fill_misses",
-                   EventExtraAttr{},
-                   {}}}}},
-          100'000'000,
-          System::Permissions{},
-          std::vector<std::string>{}));
+  addAmdL1CacheMissMetrics(metrics);
 
+  // L1 Instruction Cache Metrics
   metrics->add(
       std::make_shared<MetricDesc>(
           "CORE_L1_ICACHE_INSTR_FETCHES",
@@ -1751,30 +1950,6 @@ void addAmdCoreMetrics(std::shared_ptr<Metrics>& metrics) {
           std::vector<std::string>{}));
 
   // L1 Data Cache Metrics
-  metrics->add(
-      std::make_shared<MetricDesc>(
-          "CORE_L1_DCACHE_MISSES",
-          "L1 data cache misses",
-          "L1 data cache misses.",
-          std::map<TOptCpuArch, EventRefs>{
-              {std::nullopt,
-               EventRefs{EventRef{
-                   "l1_dcache_misses",
-                   PmuType::cpu,
-                   "l1_dcache_misses",
-                   EventExtraAttr{},
-                   {}}}},
-              {CpuArch::VENICE,
-               EventRefs{EventRef{
-                   "l1_dcache_misses",
-                   PmuType::cpu,
-                   "zen6::l1_dcache_misses",
-                   EventExtraAttr{},
-                   {}}}}},
-          100'000'000,
-          System::Permissions{},
-          std::vector<std::string>{}));
-
   metrics->add(
       std::make_shared<MetricDesc>(
           "CORE_L1_DCACHE_ACCESSES",

--- a/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
+++ b/hbt/src/perf_event/tests/BuiltinMetricsTest.cpp
@@ -55,6 +55,245 @@ TEST_F(BuiltinMetricsTest, ArmCpuIncludesArmCoreMetrics) {
   EXPECT_EQ(eventRefs->at(0).event_id, "ll_cache_miss_rd");
 }
 
+TEST_F(BuiltinMetricsTest, CommonL1CacheMissesResolveByArchitecture) {
+  struct TestCase {
+    CpuFamily family;
+    CpuArch arch;
+    PmuType pmuType;
+    const char* l1dEvent;
+    const char* l1iEvent;
+  };
+
+  const std::vector<TestCase> testCases{
+      {CpuFamily::INTEL,
+       CpuArch::SPR,
+       PmuType::cpu,
+       "L1D.REPLACEMENT",
+       "L2_RQSTS.ALL_CODE_RD"},
+      {CpuFamily::INTEL,
+       CpuArch::ICL,
+       PmuType::cpu,
+       "L1D.REPLACEMENT",
+       "L2_RQSTS.ALL_CODE_RD"},
+      {CpuFamily::INTEL,
+       CpuArch::EMR,
+       PmuType::cpu,
+       "L1D.REPLACEMENT",
+       "L2_RQSTS.ALL_CODE_RD"},
+      {CpuFamily::INTEL,
+       CpuArch::SRF,
+       PmuType::cpu,
+       "L1D.REPLACEMENT",
+       "ICACHE.MISSES"},
+      {CpuFamily::AMDZEN3,
+       CpuArch::BERGAMO,
+       PmuType::cpu,
+       "l1_dcache_misses",
+       "l1_icache_fill_misses"},
+      {CpuFamily::AMDZEN6,
+       CpuArch::VENICE,
+       PmuType::cpu,
+       "zen6::l1_dcache_misses",
+       "l1_icache_fill_misses"},
+      {CpuFamily::ARM,
+       CpuArch::NEOVERSE_V2,
+       PmuType::armv8_pmuv3,
+       "l1d_cache_refill",
+       "l1i_cache_refill"},
+      {CpuFamily::ARM,
+       CpuArch::NEOVERSE_V3,
+       PmuType::armv8_pmuv3,
+       "l1d_cache_refill",
+       "l1i_cache_refill"},
+  };
+
+  for (const auto& testCase : testCases) {
+    auto cpuInfo = facebook::hbt::CpuInfo::load();
+    cpuInfo.cpu_family = testCase.family;
+    cpuInfo.cpu_arch = testCase.arch;
+    auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+    for (const auto& [metricId, eventId] :
+         std::vector<std::pair<const char*, const char*>>{
+             {"l1d_cache_misses", testCase.l1dEvent},
+             {"l1i_cache_misses", testCase.l1iEvent}}) {
+      auto desc = availableMetrics->getMetricDesc(metricId);
+      ASSERT_NE(desc, nullptr) << metricId;
+      auto refs = desc->getEventRefs(cpuInfo);
+      ASSERT_TRUE(refs.has_value()) << metricId;
+      ASSERT_EQ(refs->size(), 1u) << metricId;
+      EXPECT_EQ(refs->at(0).pmu_type, testCase.pmuType) << metricId;
+      EXPECT_EQ(refs->at(0).event_id, eventId) << metricId;
+    }
+  }
+}
+
+TEST_F(BuiltinMetricsTest, BergamoTaskL1MetricsReuseAmdCoreCatalog) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::AMDZEN3;
+  cpuInfo.cpu_arch = CpuArch::BERGAMO;
+  auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  for (const auto& [metricId, eventId] :
+       std::vector<std::pair<const char*, const char*>>{
+           {"CORE_L1_DCACHE_MISSES", "l1_dcache_misses"},
+           {"CORE_L1_ICACHE_FILL_MISSES", "l1_icache_fill_misses"}}) {
+    auto desc = availableMetrics->getMetricDesc(metricId);
+    ASSERT_NE(desc, nullptr) << metricId;
+    auto refs = desc->getEventRefs(cpuInfo);
+    ASSERT_TRUE(refs.has_value()) << metricId;
+    ASSERT_EQ(refs->size(), 1u) << metricId;
+    EXPECT_EQ(refs->at(0).event_id, eventId) << metricId;
+  }
+
+  auto l2 = availableMetrics->getMetricDesc("l2_cache_misses");
+  auto l2Refs = l2->getEventRefs(cpuInfo);
+  ASSERT_TRUE(l2Refs.has_value());
+  ASSERT_EQ(l2Refs->size(), 3u);
+  EXPECT_EQ(l2Refs->at(0).event_id, "l2_cache_misses_no_prefetcher");
+  EXPECT_EQ(l2Refs->at(1).event_id, "l1_l2_pf_hit_in_l3");
+  EXPECT_EQ(l2Refs->at(2).event_id, "l1_l2_pf_miss_in_l3");
+
+  auto l3 = availableMetrics->getMetricDesc("l3_cache_misses");
+  auto l3Refs = l3->getEventRefs(cpuInfo);
+  ASSERT_TRUE(l3Refs.has_value());
+  ASSERT_EQ(l3Refs->size(), 1u);
+  EXPECT_EQ(l3Refs->at(0).event_id, "LONGEST_LAT_CACHE.MISS");
+}
+
+TEST_F(BuiltinMetricsTest, VeniceTaskCacheProxyMetricsResolve) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::AMDZEN6;
+  cpuInfo.cpu_arch = CpuArch::VENICE;
+  auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  auto l2 = availableMetrics->getMetricDesc("l2_cache_misses");
+  auto l2Refs = l2->getEventRefs(cpuInfo);
+  ASSERT_TRUE(l2Refs.has_value());
+  ASSERT_EQ(l2Refs->size(), 3u);
+  EXPECT_EQ(l2Refs->at(0).event_id, "l2_cache_misses_no_prefetcher");
+  EXPECT_EQ(l2Refs->at(1).event_id, "l1_l2_pf_hit_in_l3");
+  EXPECT_EQ(l2Refs->at(2).event_id, "l1_l2_pf_miss_in_l3");
+
+  for (const auto& [metricId, eventId] :
+       std::vector<std::pair<const char*, const char*>>{
+           {"l2_cache_fills_l3_misses_responses", "l2_fill_l3_miss_resp"},
+           {"l2_cache_fills_dram_responses", "l2_fill_dram_resp"}}) {
+    auto desc = availableMetrics->getMetricDesc(metricId);
+    auto refs = desc->getEventRefs(cpuInfo);
+    ASSERT_TRUE(refs.has_value()) << metricId;
+    ASSERT_EQ(refs->size(), 1u) << metricId;
+    EXPECT_EQ(refs->at(0).event_id, eventId) << metricId;
+  }
+}
+
+TEST_F(BuiltinMetricsTest, IclAndEmrTaskL1MetricsReuseIntelCoreCatalog) {
+  for (const auto arch : {CpuArch::ICL, CpuArch::EMR}) {
+    auto cpuInfo = facebook::hbt::CpuInfo::load();
+    cpuInfo.cpu_family = CpuFamily::INTEL;
+    cpuInfo.cpu_arch = arch;
+    auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+    for (const auto& [metricId, eventId] :
+         std::vector<std::pair<const char*, const char*>>{
+             {"HW_CORE_DCACHE_MISSES", "L1D.REPLACEMENT"},
+             {"HW_CORE_ICACHE_MISSES", "L2_RQSTS.ALL_CODE_RD"}}) {
+      auto desc = availableMetrics->getMetricDesc(metricId);
+      ASSERT_NE(desc, nullptr) << metricId << " on " << arch;
+      auto refs = desc->getEventRefs(cpuInfo);
+      ASSERT_TRUE(refs.has_value()) << metricId << " on " << arch;
+      ASSERT_EQ(refs->size(), 1u) << metricId << " on " << arch;
+      EXPECT_EQ(refs->at(0).event_id, eventId) << metricId << " on " << arch;
+    }
+  }
+}
+
+TEST_F(BuiltinMetricsTest, SprTaskCacheMetricsReuseIntelCoreCatalog) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::INTEL;
+  cpuInfo.cpu_arch = CpuArch::SPR;
+  auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  const std::vector<std::pair<const char*, const char*>> expected{
+      {"HW_CORE_DCACHE_MISSES", "L1D.REPLACEMENT"},
+      {"HW_CORE_ICACHE_MISSES", "L2_RQSTS.ALL_CODE_RD"},
+      {"HW_CORE_L2_MISSES", "L2_LINES_IN.ALL"},
+      {"HW_CORE_LLC_MISSES", "LONGEST_LAT_CACHE.MISS"},
+  };
+  for (const auto& [metricId, eventId] : expected) {
+    auto desc = availableMetrics->getMetricDesc(metricId);
+    ASSERT_NE(desc, nullptr) << metricId;
+    auto refs = desc->getEventRefs(cpuInfo);
+    ASSERT_TRUE(refs.has_value()) << metricId;
+    ASSERT_EQ(refs->size(), 1u) << metricId;
+    EXPECT_EQ(refs->at(0).pmu_type, PmuType::cpu) << metricId;
+    EXPECT_EQ(refs->at(0).event_id, eventId) << metricId;
+  }
+}
+
+TEST_F(BuiltinMetricsTest, SrfTaskCacheMetricsReuseIntelCoreCatalog) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::INTEL;
+  cpuInfo.cpu_arch = CpuArch::SRF;
+  auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  const std::vector<std::pair<const char*, const char*>> expected{
+      {"HW_CORE_DCACHE_MISSES", "L1D.REPLACEMENT"},
+      {"HW_CORE_ICACHE_MISSES", "ICACHE.MISSES"},
+      {"HW_CORE_L2_MISSES", "L2_LINES_IN.ALL"},
+      {"HW_CORE_LLC_MISSES", "LONGEST_LAT_CACHE.MISS"},
+  };
+  for (const auto& [metricId, eventId] : expected) {
+    auto desc = availableMetrics->getMetricDesc(metricId);
+    ASSERT_NE(desc, nullptr) << metricId;
+    auto refs = desc->getEventRefs(cpuInfo);
+    ASSERT_TRUE(refs.has_value()) << metricId;
+    ASSERT_EQ(refs->size(), 1u) << metricId;
+    EXPECT_EQ(refs->at(0).pmu_type, PmuType::cpu) << metricId;
+    EXPECT_EQ(refs->at(0).event_id, eventId) << metricId;
+  }
+}
+
+TEST_F(BuiltinMetricsTest, SierraForestL2CacheMissesUseLinesIn) {
+  auto cpuInfo = facebook::hbt::CpuInfo::load();
+  cpuInfo.cpu_family = CpuFamily::INTEL;
+  cpuInfo.cpu_arch = CpuArch::SRF;
+  auto availableMetrics = makeAvailableMetricsForCpu(cpuInfo);
+
+  auto desc = availableMetrics->getMetricDesc("l2_cache_misses");
+  ASSERT_NE(desc, nullptr);
+  auto refs = desc->getEventRefs(cpuInfo);
+  ASSERT_TRUE(refs.has_value());
+  ASSERT_EQ(refs->size(), 1u);
+  EXPECT_EQ(refs->at(0).pmu_type, PmuType::cpu);
+  EXPECT_EQ(refs->at(0).event_id, "L2_LINES_IN.ALL");
+
+  auto pmuManager = std::make_shared<PmuDeviceManager>(
+      facebook::hbt::CpuInfo("Intel", 6, 175, 0));
+  populatePmuDeviceManager(pmuManager);
+  auto eventDef = pmuManager->findEventDef("L2_LINES_IN.ALL");
+  ASSERT_NE(eventDef, nullptr);
+  EXPECT_EQ(eventDef->encoding.code, 0x25u);
+  EXPECT_EQ(eventDef->encoding.umask, 0x1eu);
+}
+
+TEST_F(BuiltinMetricsTest, VendorCoreMetricCatalogsRemainAvailable) {
+  auto intelMetrics = std::make_shared<Metrics>();
+  addIntelCoreMetrics(intelMetrics);
+  EXPECT_NE(intelMetrics->getMetricDesc("HW_CORE_DCACHE_MISSES"), nullptr);
+  EXPECT_NE(intelMetrics->getMetricDesc("HW_CORE_ICACHE_MISSES"), nullptr);
+
+  auto amdMetrics = std::make_shared<Metrics>();
+  addAmdCoreMetrics(amdMetrics);
+  EXPECT_NE(amdMetrics->getMetricDesc("CORE_L1_DCACHE_MISSES"), nullptr);
+  EXPECT_NE(amdMetrics->getMetricDesc("CORE_L1_ICACHE_FILL_MISSES"), nullptr);
+
+  auto armMetrics = std::make_shared<Metrics>();
+  addArmCoreMetrics(armMetrics);
+  EXPECT_NE(armMetrics->getMetricDesc("HW_CORE_L1_DCACHE_REFILL"), nullptr);
+  EXPECT_NE(armMetrics->getMetricDesc("HW_CORE_L1_ICACHE_REFILL"), nullptr);
+}
+
 TEST_F(BuiltinMetricsTest, VeraUncoreMetricsRegistered) {
   // addArmUncoreMetrics is arch-neutral C++ (only its call site in
   // addUncoreMetrics is __aarch64__-gated), so it can be exercised directly on


### PR DESCRIPTION
Summary:
- **Common cache descriptors.** Add architecture-aware `l1d_cache_misses` and `l1i_cache_misses` descriptors for Intel, AMD, and ARM. Add the SRF `L2_LINES_IN.ALL` override to `l2_cache_misses`.
- **Intel task path.** Preserve `HW_CORE_DCACHE_MISSES` and `HW_CORE_ICACHE_MISSES` for every Intel family, including ICL and EMR. SPR and SRF also reuse the established Intel host IDs for L2 and L3. The compiled registry registers the Intel core descriptors for every Intel family.
- **AMD task path.** Register AMD L1 metrics for Milan, Genoa, Bergamo, Turin, and Venice. Bergamo uses its production `AMDZEN3` classification. Venice L1D selects `zen6::l1_dcache_misses`.
- **ARM L3.** Reduce `HW_CORE_LL_CACHE_MISS_RD` and publish it as `cpu_l3_cache_misses` when the x86 L3 key is unavailable.
- **Venice proxy and bandwidth.** Extend the AMD L3 proxy and UMC bandwidth paths to Venice, then add Venice to the task and allotment metric catalogs. Configerator diff D117883686 supplies the matching Venice event and metric definitions.
- **SRF support.** Add compiled SRF L1D and L2 event definitions, including L2 encoding 0x25/0x1e. Configerator diff D117729783 supplies the matching config-events definitions.
- **Build dependencies.** Regenerate the affected dyno BUCK files with autodeps2. Use `libtwtaskcommon` as the single owner of `TwTaskCommon.cpp` to keep the generated graph acyclic. Pin the ambiguous `BuiltinMetrics.h` includes to `BuiltinMetricsLight`; the full and light targets compile the same source and cannot coexist in one link closure.

Differential Revision: D118145118


