### PR TITLE
Add lossless StaticEventDef table representation

### DIFF
--- a/hbt/src/perf_event/EventConfigs.h
+++ b/hbt/src/perf_event/EventConfigs.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::hbt::perf_event {
+
+/// The configuration data passed to CpuEventsGroup to select the
+/// perf_event_attr in perf_event_open.
+struct EventConfigs {
+  uint32_t type; // The PMU type.
+  uint64_t config;
+  uint64_t config1 = 0;
+  uint64_t config2 = 0;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/EventScale.h
+++ b/hbt/src/perf_event/EventScale.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+namespace facebook::hbt::perf_event {
+
+enum class ScaleUnit {
+  Bytes, // Bytes
+  Joules, // Joules
+  MiB // MebiBytes
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -6,6 +6,9 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/EventConfigs.h"
+#include "hbt/src/perf_event/EventScale.h"
+#include "hbt/src/perf_event/PmuType.h"
 
 #include <linux/perf_event.h>
 
@@ -18,113 +21,8 @@
 
 namespace facebook::hbt::perf_event {
 
-/// Linux's perf_event has PMUs that are statically enumerated, present
-/// in linux/include/perf_event.h, and PMUs that are instantiated dynamically.
-/// /sys/devices exposes some of the statically enumerated PMUs and all of the
-/// dynamic ones.
-///
-/// This enumeration handles both static and dynamic PMUs.
-enum class PmuType : uint16_t {
-
-  generic_hardware, // Equivalent to PERF_TYPE_HARDWARE: architecture
-                    // independent CPU events
-  software, // Equivalent to PERF_TYPE_SOFTWARE
-  tracepoint, // Equivalent to PERF_TYPE_TRACEPOINT
-  generic_hw_cache, // Equivalent to PERF_TYPE_HW_CACHE
-  cpu, // Equivalent to PERF_TYPE_RAW: architecture specific CPU events
-  breakpoint, // Equivalent to PERF_TYPE_BREAKPOINT
-
-  kprobe,
-  uprobe,
-  power,
-
-  // Intel Uncore caching
-  uncore_cbox,
-  uncore_cha,
-  uncore_ha,
-  // In SRF, there is a Converged/Common Mesh Stop attached to each CHA
-  uncore_chacms,
-
-  // Intel Uncore
-  uncore_imc,
-  uncore_iio,
-  uncore_irp,
-  uncore_m2m,
-  uncore_m3upi,
-  uncore_pcu,
-  uncore_qpi,
-  uncore_r2pcie,
-  uncore_r3qpi,
-  uncore_sbox,
-  uncore_ubox,
-  uncore_upi,
-
-  // XXX: Below are Icelake PMUs, need to test them.
-  uncore_ncu, // Similar to cbox
-  uncore_arb, // Arbitration unit.
-  uncore_edc_uclk, // EDC is a memory controller for MCDRAM (3D-stacked)
-  uncore_edc_eclk,
-
-  // Memory controller.
-  uncore_imc_uclk,
-  uncore_imc_dclk,
-
-  // Memory to PCIe.
-  uncore_m2pcie,
-
-  // Intel PT
-  intel_pt,
-
-  // HBM Memory Controller
-  // XXX: Need to test them?
-  uncore_mchbm,
-
-  // Arm
-  armv8_pmuv3,
-
-  // Nvidia Uncores (Grace-Hopper)
-  nvidia_scf_pmu,
-  nvidia_nvlink_c2c0_pmu,
-  nvidia_nvlink_c2c1_pmu,
-  nvidia_pcie_pmu,
-
-  // Nvidia Uncores (Vera-Rubin / Vera). The sysfs names differ from
-  // Grace-Hopper: nvidia_ucf_pmu replaces nvidia_scf_pmu, a single
-  // nvidia_nvlink_c2c_pmu (per-socket instances) replaces c2c0/c2c1, and
-  // nvidia_pcie{,_tgt}_pmu are enumerated per root complex
-  // (<pmu>_<sock>_rc_<n>).
-  nvidia_ucf_pmu,
-  nvidia_nvlink_c2c_pmu,
-  nvidia_cmem_latency_pmu,
-  nvidia_nvclink_pmu,
-  nvidia_nvdlink_pmu,
-  nvidia_pcie_tgt_pmu,
-
-  // AMD L3
-  amd_l3,
-
-  // AMD Zen5 UMC
-  amd_umc,
-
-  // AMD Data Fabric (used for Zen6/Venice CCM CXL bandwidth counters)
-  amd_df,
-
-  // Arm
-  cs_etm,
-
-  // Arm uncores
-  arm_cspmu_mc,
-  arm_cmn,
-};
-
 std::string PmuTypeToStr(PmuType /*pmu_type*/);
 PmuType PmuTypeFromStr(const std::string& /*pmu_type_str*/);
-
-enum class ScaleUnit {
-  Bytes, // Bytes
-  Joules, // Joules
-  MiB // MebiBytes
-};
 
 ScaleUnit scaleUnitFromStr(const std::string& s);
 
@@ -249,15 +147,6 @@ struct EventExtraAttr {
 std::ostream& operator<<(std::ostream& /*os*/, const EventExtraAttr& /*attr*/);
 
 using EventExtraAttrs = std::vector<EventExtraAttr>;
-
-/// The configuration data passed to CpuEventsGroup to be used to
-/// select the perf_event_attr in perf_event_open.
-struct EventConfigs {
-  uint32_t type; // The PMU type.
-  uint64_t config;
-  uint64_t config1 = 0x0;
-  uint64_t config2 = 0x0;
-};
 
 std::ostream& operator<<(
     std::ostream& /*os*/,

--- a/hbt/src/perf_event/PmuType.h
+++ b/hbt/src/perf_event/PmuType.h
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::hbt::perf_event {
+
+/// Linux's perf_event has PMUs that are statically enumerated, present
+/// in linux/include/perf_event.h, and PMUs that are instantiated dynamically.
+/// /sys/devices exposes some of the statically enumerated PMUs and all of the
+/// dynamic ones.
+///
+/// This enumeration handles both static and dynamic PMUs.
+///
+/// Kept in its own header so that generated event tables can name PmuType
+/// without pulling in PmuEvent.h and its transitive includes.
+enum class PmuType : uint16_t {
+
+  generic_hardware, // Equivalent to PERF_TYPE_HARDWARE: architecture
+                    // independent CPU events
+  software, // Equivalent to PERF_TYPE_SOFTWARE
+  tracepoint, // Equivalent to PERF_TYPE_TRACEPOINT
+  generic_hw_cache, // Equivalent to PERF_TYPE_HW_CACHE
+  cpu, // Equivalent to PERF_TYPE_RAW: architecture specific CPU events
+  breakpoint, // Equivalent to PERF_TYPE_BREAKPOINT
+
+  kprobe,
+  uprobe,
+  power,
+
+  // Intel Uncore caching
+  uncore_cbox,
+  uncore_cha,
+  uncore_ha,
+  // In SRF, there is a Converged/Common Mesh Stop attached to each CHA
+  uncore_chacms,
+
+  // Intel Uncore
+  uncore_imc,
+  uncore_iio,
+  uncore_irp,
+  uncore_m2m,
+  uncore_m3upi,
+  uncore_pcu,
+  uncore_qpi,
+  uncore_r2pcie,
+  uncore_r3qpi,
+  uncore_sbox,
+  uncore_ubox,
+  uncore_upi,
+
+  // XXX: Below are Icelake PMUs, need to test them.
+  uncore_ncu, // Similar to cbox
+  uncore_arb, // Arbitration unit.
+  uncore_edc_uclk, // EDC is a memory controller for MCDRAM (3D-stacked)
+  uncore_edc_eclk,
+
+  // Memory controller.
+  uncore_imc_uclk,
+  uncore_imc_dclk,
+
+  // Memory to PCIe.
+  uncore_m2pcie,
+
+  // Intel PT
+  intel_pt,
+
+  // HBM Memory Controller
+  // XXX: Need to test them?
+  uncore_mchbm,
+
+  // Arm
+  armv8_pmuv3,
+
+  // Nvidia Uncores (Grace-Hopper)
+  nvidia_scf_pmu,
+  nvidia_nvlink_c2c0_pmu,
+  nvidia_nvlink_c2c1_pmu,
+  nvidia_pcie_pmu,
+
+  // Nvidia Uncores (Vera-Rubin / Vera). The sysfs names differ from
+  // Grace-Hopper: nvidia_ucf_pmu replaces nvidia_scf_pmu, a single
+  // nvidia_nvlink_c2c_pmu (per-socket instances) replaces c2c0/c2c1, and
+  // nvidia_pcie{,_tgt}_pmu are enumerated per root complex
+  // (<pmu>_<sock>_rc_<n>).
+  nvidia_ucf_pmu,
+  nvidia_nvlink_c2c_pmu,
+  nvidia_cmem_latency_pmu,
+  nvidia_nvclink_pmu,
+  nvidia_nvdlink_pmu,
+  nvidia_pcie_tgt_pmu,
+
+  // AMD L3
+  amd_l3,
+
+  // AMD Zen5 UMC
+  amd_umc,
+
+  // AMD Data Fabric (used for Zen6/Venice CCM CXL bandwidth counters)
+  amd_df,
+
+  // Arm
+  cs_etm,
+
+  // Arm uncores
+  arm_cspmu_mc,
+  arm_cmn,
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/StaticEventDef.cpp
+++ b/hbt/src/perf_event/StaticEventDef.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "hbt/src/perf_event/StaticEventDef.h"
+
+#include "hbt/src/perf_event/PmuEvent.h"
+
+#include <string>
+#include <vector>
+
+namespace facebook::hbt::perf_event {
+namespace {
+
+std::vector<uint64_t> materializeMsrValues(
+    const std::variant<std::monostate, uint64_t, std::array<uint64_t, 2>>&
+        msr_values) {
+  if (std::holds_alternative<std::monostate>(msr_values)) {
+    return {};
+  }
+  if (const auto* value = std::get_if<uint64_t>(&msr_values)) {
+    return {*value};
+  }
+  const auto& values = std::get<std::array<uint64_t, 2>>(msr_values);
+  return {values[0], values[1]};
+}
+
+EventDef::Encoding materializeEncoding(
+    const StaticEventDef::Encoding& encoding) {
+  return EventDef::Encoding{
+      .code = encoding.code,
+      .umask = encoding.umask,
+      .umaskExt = encoding.umask_ext,
+      .edge = encoding.edge,
+      .any = encoding.any,
+      .inv = encoding.inv,
+      .cmask = encoding.cmask,
+      .msr_values = materializeMsrValues(encoding.msr_values)};
+}
+
+std::optional<EventDef::ScaleData> materializeScaleData(
+    const std::optional<StaticEventDef::ScaleData>& scale_data) {
+  if (!scale_data.has_value()) {
+    return std::nullopt;
+  }
+  return EventDef::ScaleData{
+      .scale_factor = scale_data->scale_factor,
+      .scale_unit = scale_data->scale_unit};
+}
+
+std::optional<EventDef::IntelFeatures> materializeIntelFeatures(
+    const std::optional<StaticEventDef::IntelFeatures>& features) {
+  if (!features.has_value()) {
+    return std::nullopt;
+  }
+  return EventDef::IntelFeatures{
+      .data_la = features->data_la,
+      .l1_hit_indication = features->l1_hit_indication,
+      .ellc = features->ellc,
+      .pebs = features->pebs};
+}
+
+std::optional<std::string> materializeErrata(
+    const std::optional<std::string_view>& errata) {
+  if (!errata.has_value()) {
+    return std::nullopt;
+  }
+  return std::string{*errata};
+}
+
+} // namespace
+
+EventDef materializeEventDef(const StaticEventDef& event) {
+  return EventDef{
+      event.pmu_type,
+      std::string{event.id},
+      materializeEncoding(event.encoding),
+      std::string{event.brief_desc},
+      std::string{event.full_desc},
+      event.default_sampling_period,
+      materializeScaleData(event.scale_data),
+      materializeIntelFeatures(event.features),
+      materializeErrata(event.errata)};
+}
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/StaticEventDef.h
+++ b/hbt/src/perf_event/StaticEventDef.h
@@ -1,0 +1,135 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/perf_event/EventConfigs.h"
+#include "hbt/src/perf_event/EventScale.h"
+#include "hbt/src/perf_event/PmuType.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <variant>
+
+namespace facebook::hbt::perf_event {
+
+struct EventDef;
+
+/// Non-owning event definition for generated constexpr catalogs.
+///
+/// Strings must refer to static storage. Runtime-created definitions continue
+/// to use the owning EventDef representation.
+struct StaticEventDef {
+  struct Encoding {
+    uint64_t code;
+    uint64_t umask = 0;
+    uint64_t umask_ext = 0;
+    bool edge = false;
+    bool any = false;
+    bool inv = false;
+    uint64_t cmask = 0;
+    std::variant<std::monostate, uint64_t, std::array<uint64_t, 2>> msr_values;
+  };
+
+  struct ScaleData {
+    std::variant<int, double> scale_factor;
+    ScaleUnit scale_unit;
+  };
+
+  struct IntelFeatures {
+    bool data_la = false;
+    bool l1_hit_indication = false;
+    bool ellc = false;
+    uint8_t pebs = 0;
+  };
+
+  PmuType pmu_type;
+  std::string_view id;
+  Encoding encoding;
+  std::optional<ScaleData> scale_data = std::nullopt;
+  std::optional<IntelFeatures> features = std::nullopt;
+  std::string_view brief_desc;
+  std::string_view full_desc;
+  std::optional<uint64_t> default_sampling_period = std::nullopt;
+  std::optional<std::string_view> errata = std::nullopt;
+};
+
+/// Whether a table has unique entries sorted by (pmu_type, id).
+constexpr bool isStaticEventDefTableSorted(
+    std::span<const StaticEventDef> events) noexcept {
+  for (size_t i = 1; i < events.size(); ++i) {
+    const StaticEventDef& prev = events[i - 1];
+    const StaticEventDef& current = events[i];
+    if (prev.pmu_type > current.pmu_type) {
+      return false;
+    }
+    if (prev.pmu_type == current.pmu_type && !(prev.id < current.id)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Binary-search a generated table sorted by (pmu_type, id).
+constexpr const StaticEventDef* findStaticEventDef(
+    std::span<const StaticEventDef> events,
+    PmuType pmu_type,
+    std::string_view id) noexcept {
+  size_t lo = 0;
+  size_t hi = events.size();
+  while (lo < hi) {
+    const size_t mid = lo + (hi - lo) / 2;
+    const StaticEventDef& event = events[mid];
+    if (event.pmu_type < pmu_type ||
+        (event.pmu_type == pmu_type && event.id < id)) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  if (lo == events.size() || events[lo].pmu_type != pmu_type ||
+      events[lo].id != id) {
+    return nullptr;
+  }
+  return &events[lo];
+}
+
+/// Encode a static definition exactly as EventDef::makeConfigs() does.
+constexpr EventConfigs makeEventConfigs(
+    const StaticEventDef& event,
+    uint32_t new_pmu_type) {
+  const uint64_t config = (event.encoding.umask_ext << 32) |
+      (event.encoding.cmask << 24) |
+      (static_cast<uint64_t>(event.encoding.inv) << 23) |
+      (static_cast<uint64_t>(event.encoding.any) << 21) |
+      (static_cast<uint64_t>(event.encoding.edge) << 18) |
+      (event.encoding.umask << 8) | event.encoding.code;
+
+  uint64_t config1 = 0;
+  uint64_t config2 = 0;
+  if (const auto* value = std::get_if<uint64_t>(&event.encoding.msr_values)) {
+    config1 = *value;
+  } else if (
+      const auto* values =
+          std::get_if<std::array<uint64_t, 2>>(&event.encoding.msr_values)) {
+    config1 = (*values)[0];
+    config2 = (*values)[1];
+  }
+
+  return EventConfigs{
+      .type = new_pmu_type,
+      .config = config,
+      .config1 = config1,
+      .config2 = config2};
+}
+
+/// Convert a static definition to the existing owning representation.
+EventDef materializeEventDef(const StaticEventDef& event);
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/tests/StaticEventDefTest.cpp
+++ b/hbt/src/perf_event/tests/StaticEventDefTest.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "hbt/src/perf_event/PmuEvent.h"
+#include "hbt/src/perf_event/StaticEventDef.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+using namespace facebook::hbt::perf_event;
+
+namespace {
+
+constexpr std::array<StaticEventDef, 4> kEvents{{
+    {
+        .pmu_type = PmuType::cpu,
+        .id = "ALPHA",
+        .encoding =
+            {
+                .code = 0x11,
+                .umask = 0x22,
+                .cmask = 3,
+            },
+        .features = StaticEventDef::IntelFeatures{},
+        .brief_desc = "alpha brief",
+        .full_desc = "alpha full",
+        .default_sampling_period = 100003,
+    },
+    {
+        .pmu_type = PmuType::cpu,
+        .id = "ZULU",
+        .encoding =
+            {
+                .code = 0xB7,
+                .umask = 0x01,
+                .edge = true,
+                .any = true,
+                .inv = true,
+                .msr_values = std::array<uint64_t, 2>{0x8003C07F7ULL, 0xA5ULL},
+            },
+        .scale_data =
+            StaticEventDef::ScaleData{
+                .scale_factor = 0.5,
+                .scale_unit = ScaleUnit::MiB,
+            },
+        .features =
+            StaticEventDef::IntelFeatures{
+                .data_la = true,
+                .l1_hit_indication = true,
+                .ellc = true,
+                .pebs = 2,
+            },
+        .brief_desc = "zulu brief",
+        .full_desc = "zulu full",
+        .errata = "BDM69",
+    },
+    {
+        .pmu_type = PmuType::uncore_cha,
+        .id = "BRAVO",
+        .encoding =
+            {
+                .code = 0x35,
+                .umask_ext = 0x78CC6FFE,
+                .msr_values = uint64_t{0},
+            },
+        .scale_data =
+            StaticEventDef::ScaleData{
+                .scale_factor = 64,
+                .scale_unit = ScaleUnit::Bytes,
+            },
+        .brief_desc = "bravo brief",
+        .full_desc = "bravo full",
+    },
+    {
+        .pmu_type = PmuType::uncore_cha,
+        .id = "CHARLIE",
+        .encoding =
+            {
+                .code = 0x36,
+                .umask = 0x01,
+            },
+        .brief_desc = "charlie brief",
+        .full_desc = "charlie full",
+    },
+}};
+
+static_assert(isStaticEventDefTableSorted(kEvents));
+static_assert(findStaticEventDef(kEvents, PmuType::cpu, "ALPHA") != nullptr);
+static_assert(
+    findStaticEventDef(kEvents, PmuType::cpu, "ALPHA")
+        ->default_sampling_period == 100003);
+static_assert(makeEventConfigs(kEvents[1], 7).config1 == 0x8003C07F7ULL);
+static_assert(makeEventConfigs(kEvents[1], 7).config2 == 0xA5ULL);
+
+void expectConfigsEqual(
+    const EventConfigs& expected,
+    const EventConfigs& actual) {
+  EXPECT_EQ(actual.type, expected.type);
+  EXPECT_EQ(actual.config, expected.config);
+  EXPECT_EQ(actual.config1, expected.config1);
+  EXPECT_EQ(actual.config2, expected.config2);
+}
+
+} // namespace
+
+TEST(StaticEventDefTest, FindsDefinitionsAndReturnsNullptrOnMiss) {
+  const StaticEventDef* alpha =
+      findStaticEventDef(kEvents, PmuType::cpu, "ALPHA");
+  ASSERT_NE(alpha, nullptr);
+  EXPECT_EQ(alpha->brief_desc, "alpha brief");
+
+  EXPECT_EQ(findStaticEventDef(kEvents, PmuType::cpu, "NOPE"), nullptr);
+  EXPECT_EQ(findStaticEventDef(kEvents, PmuType::uncore_cha, "ALPHA"), nullptr);
+  EXPECT_NE(findStaticEventDef(kEvents, PmuType::uncore_cha, "BRAVO"), nullptr);
+  EXPECT_EQ(findStaticEventDef({}, PmuType::cpu, "ALPHA"), nullptr);
+}
+
+TEST(StaticEventDefTest, SortednessCheckRejectsOrderAndDuplicateKeys) {
+  constexpr std::array<StaticEventDef, 2> misordered{{kEvents[2], kEvents[0]}};
+  constexpr std::array<StaticEventDef, 2> duplicate{{kEvents[0], kEvents[0]}};
+
+  EXPECT_FALSE(isStaticEventDefTableSorted(misordered));
+  EXPECT_FALSE(isStaticEventDefTableSorted(duplicate));
+  EXPECT_TRUE(isStaticEventDefTableSorted(kEvents));
+}
+
+TEST(StaticEventDefTest, ConfigEncodingMatchesOwningDefinition) {
+  for (const StaticEventDef& event : kEvents) {
+    const EventDef owning = materializeEventDef(event);
+    expectConfigsEqual(owning.makeConfigs(7), makeEventConfigs(event, 7));
+  }
+
+  const EventConfigs twoMsrs = makeEventConfigs(kEvents[1], 7);
+  EXPECT_EQ(twoMsrs.config1, 0x8003C07F7ULL);
+  EXPECT_EQ(twoMsrs.config2, 0xA5ULL);
+
+  const EventConfigs explicitZeroMsr = makeEventConfigs(kEvents[2], 7);
+  EXPECT_EQ(explicitZeroMsr.config1, 0);
+  EXPECT_EQ(explicitZeroMsr.config2, 0);
+}
+
+TEST(StaticEventDefTest, MaterializationPreservesAllMetadata) {
+  const EventDef event = materializeEventDef(kEvents[1]);
+
+  EXPECT_EQ(event.pmu_type, PmuType::cpu);
+  EXPECT_EQ(event.id, "ZULU");
+  EXPECT_EQ(event.encoding.code, 0xB7);
+  EXPECT_EQ(event.encoding.umask, 0x01);
+  EXPECT_TRUE(event.encoding.edge);
+  EXPECT_TRUE(event.encoding.any);
+  EXPECT_TRUE(event.encoding.inv);
+  EXPECT_EQ(
+      event.encoding.msr_values,
+      (std::vector<uint64_t>{0x8003C07F7ULL, 0xA5ULL}));
+  ASSERT_TRUE(event.scale_data.has_value());
+  EXPECT_DOUBLE_EQ(std::get<double>(event.scale_data->scale_factor), 0.5);
+  EXPECT_EQ(event.scale_data->scale_unit, ScaleUnit::MiB);
+  ASSERT_TRUE(event.features.has_value());
+  EXPECT_TRUE(event.features->data_la);
+  EXPECT_TRUE(event.features->l1_hit_indication);
+  EXPECT_TRUE(event.features->ellc);
+  EXPECT_EQ(event.features->pebs, 2);
+  EXPECT_EQ(event.isPrecise(), std::optional<bool>{true});
+  EXPECT_EQ(event.brief_desc, "zulu brief");
+  EXPECT_EQ(event.full_desc, "zulu full");
+  EXPECT_EQ(event.default_sampling_period, std::nullopt);
+  EXPECT_EQ(event.errata, std::optional<std::string>{"BDM69"});
+}
+
+TEST(StaticEventDefTest, MaterializationPreservesOptionalStates) {
+  const EventDef absent = materializeEventDef(kEvents[3]);
+  EXPECT_TRUE(absent.encoding.msr_values.empty());
+  EXPECT_EQ(absent.scale_data, std::nullopt);
+  EXPECT_EQ(absent.features, std::nullopt);
+  EXPECT_EQ(absent.isPrecise(), std::nullopt);
+  EXPECT_EQ(absent.default_sampling_period, std::nullopt);
+  EXPECT_EQ(absent.errata, std::nullopt);
+
+  const EventDef explicitZeroMsr = materializeEventDef(kEvents[2]);
+  EXPECT_EQ(explicitZeroMsr.encoding.msr_values, std::vector<uint64_t>{0});
+  ASSERT_TRUE(explicitZeroMsr.scale_data.has_value());
+  EXPECT_EQ(std::get<int>(explicitZeroMsr.scale_data->scale_factor), 64);
+
+  const EventDef knownNotPrecise = materializeEventDef(kEvents[0]);
+  EXPECT_EQ(knownNotPrecise.isPrecise(), std::optional<bool>{false});
+  EXPECT_EQ(
+      knownNotPrecise.default_sampling_period, std::optional<uint64_t>{100003});
+}


### PR DESCRIPTION
Summary:
Groundwork for migrating HBT's generated Intel event definitions from ~28k
runtime std::make_shared<EventDef>() calls to constexpr static tables.

- Add StaticEventDef, a non-owning literal representation with lossless parity
  for event encodings, zero/one/two MSR values, scale data, Intel features,
  sampling periods, descriptions, and errata.
- Provide constexpr sorted-table lookup and EventConfigs encoding, plus an
  out-of-line conversion to the existing owning EventDef representation.
- Extract PmuType, EventConfigs, and ScaleUnit into lightweight headers so
  generated tables do not need the full PmuEvent dependency surface.
- Cover constexpr lookup/configuration, explicit-zero and two-MSR encodings,
  integer/double scales, optional metadata states, precision, and complete
  EventDef materialization.

This diff only establishes the representation contract. It does not attach
static catalogs to PmuDevice or change generated production output; those
changes will follow in child diffs.

Reviewed By: hmlee95070

Differential Revision: D117262579


