### PR TITLE
Integrate static event tables with PMU devices (#608)

### DIFF
--- a/hbt/src/perf_event/CMakeLists.txt
+++ b/hbt/src/perf_event/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(CpuArch PUBLIC CpuArchGen)
 add_library(PmuEvent PmuEvent.h PmuEvent.cpp)
 target_link_libraries(PmuEvent PUBLIC System)
 
+add_library(StaticEventDef StaticEventDef.h StaticEventDef.cpp)
+target_link_libraries(StaticEventDef PUBLIC PmuEvent)
+
 add_library(AmdEvents AmdEvents.h AmdEvents.cpp)
 target_link_libraries(AmdEvents PUBLIC PmuDevices)
 
@@ -31,6 +34,7 @@ add_library(PmuDevices PmuDevices.h PmuDevices.cpp)
 target_link_libraries(PmuDevices PUBLIC PerfEventsGroup)
 target_link_libraries(PmuDevices PUBLIC stdc++fs)
 target_link_libraries(PmuDevices PUBLIC PmuEvent)
+target_link_libraries(PmuDevices PUBLIC StaticEventDef)
 target_link_libraries(PmuDevices PUBLIC CpuArch)
 
 add_library(Metrics Metrics.h Metrics.cpp)

--- a/hbt/src/perf_event/EventConfigs.h
+++ b/hbt/src/perf_event/EventConfigs.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::hbt::perf_event {
+
+/// The configuration data passed to CpuEventsGroup to select the
+/// perf_event_attr in perf_event_open.
+struct EventConfigs {
+  uint32_t type; // The PMU type.
+  uint64_t config;
+  uint64_t config1 = 0;
+  uint64_t config2 = 0;
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/EventScale.h
+++ b/hbt/src/perf_event/EventScale.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+namespace facebook::hbt::perf_event {
+
+enum class ScaleUnit {
+  Bytes, // Bytes
+  Joules, // Joules
+  MiB // MebiBytes
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/PmuDevices.cpp
+++ b/hbt/src/perf_event/PmuDevices.cpp
@@ -9,16 +9,242 @@
 #include <string>
 
 #include <filesystem>
+#include <map>
+#include <mutex>
+#include <set>
+#include <string_view>
 
 namespace fs = std::filesystem;
 namespace facebook::hbt::perf_event {
+
+class StaticEventDefTableState {
+ public:
+  explicit StaticEventDefTableState(std::span<const StaticEventDef> events)
+      : events_{events} {}
+
+  std::span<const StaticEventDef> events() const noexcept {
+    return events_;
+  }
+
+  std::shared_ptr<EventDef> materialize(const StaticEventDef& event) {
+    std::lock_guard lock{mutex_};
+    if (const auto it = materialized_.find(&event); it != materialized_.end()) {
+      return it->second;
+    }
+
+    auto materialized = std::make_shared<EventDef>(materializeEventDef(event));
+    materialized_.emplace(&event, materialized);
+    return materialized;
+  }
+
+ private:
+  const std::span<const StaticEventDef> events_;
+  std::mutex mutex_;
+  std::map<const StaticEventDef*, std::shared_ptr<EventDef>> materialized_;
+};
+
+std::optional<EventId> PmuDevice::findEventIdByAlias_(
+    const EventId& ev_id) const {
+  const auto it = aliases_.find(ev_id);
+  if (it == aliases_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+const StaticEventDef* PmuDevice::findStaticEventDef_(
+    const EventId& ev_id) const {
+  for (const auto& state : static_event_defs_) {
+    if (const auto* event = perf_event::findStaticEventDef(
+            state->events(), getPmuType(), ev_id)) {
+      return event;
+    }
+  }
+  return nullptr;
+}
+
+bool PmuDevice::hasPrimaryEventId_(std::string_view ev_id) const {
+  const EventId id{ev_id};
+  return event_defs_.count(id) != 0 || findStaticEventDef_(id) != nullptr;
+}
+
+std::optional<EventId> PmuDevice::findPrimaryEventId_(
+    const EventId& ev_id) const {
+  if (hasPrimaryEventId_(ev_id)) {
+    return ev_id;
+  }
+  auto primary = findEventIdByAlias_(ev_id);
+  if (primary.has_value() && hasPrimaryEventId_(*primary)) {
+    return primary;
+  }
+  return std::nullopt;
+}
+
+std::shared_ptr<EventDef> PmuDevice::materializeStaticEventDef_(
+    const StaticEventDef& ev_def) const {
+  for (const auto& state : static_event_defs_) {
+    const auto* event = perf_event::findStaticEventDef(
+        state->events(), getPmuType(), ev_def.id);
+    if (event == &ev_def) {
+      return state->materialize(ev_def);
+    }
+  }
+  HBT_THROW_ASSERT_IF(true)
+      << "Static event definition is not registered with PMU " << getFullName();
+  __builtin_unreachable();
+}
+
+std::shared_ptr<EventDef> PmuDevice::findEventDef(const EventId& ev_id) const {
+  const auto primary = findPrimaryEventId_(ev_id);
+  if (!primary.has_value()) {
+    return nullptr;
+  }
+
+  if (const auto it = event_defs_.find(*primary); it != event_defs_.end()) {
+    HBT_ARG_CHECK_EQ(it->first, *primary);
+    return it->second;
+  }
+  return materializeStaticEventDef_(*findStaticEventDef_(*primary));
+}
+
+const std::map<EventId, std::shared_ptr<EventDef>>& PmuDevice::getEventDefs()
+    const {
+  for (const auto& state : static_event_defs_) {
+    for (const StaticEventDef& event : state->events()) {
+      event_defs_.try_emplace(EventId{event.id}, state->materialize(event));
+    }
+  }
+  return event_defs_;
+}
+
+void PmuDevice::validateStaticEventDefs_(
+    const std::shared_ptr<StaticEventDefTableState>& state) const {
+  std::set<EventId> incoming_primary_ids;
+  std::set<EventId> incoming_aliases;
+  for (const StaticEventDef& event : state->events()) {
+    HBT_ARG_CHECK(event.pmu_type == getPmuType());
+    HBT_ARG_CHECK(!event.id.empty());
+    HBT_ARG_CHECK(
+        std::none_of(
+            event.id.begin(),
+            event.id.end(),
+            [](unsigned char c) { return std::isblank(c); }))
+        << "Spaces not allowed in event_id \"" << event.id << "\"";
+    HBT_ARG_CHECK(!event.brief_desc.empty())
+        << "event_id: " << event.id << " missing brief description";
+    HBT_ARG_CHECK(!event.full_desc.empty())
+        << "event_id: " << event.id << " missing full description";
+    HBT_ARG_CHECK(!event.errata.has_value() || !event.errata->empty());
+
+    const EventId id{event.id};
+    HBT_ARG_CHECK(!hasPrimaryEventId_(id))
+        << "An event with id \"" << id << "\" already exists in PMU with id: \""
+        << getPmuId() << "\" and name: \"" << getFullName() << "\"";
+    HBT_ARG_CHECK_EQ(aliases_.count(id), 0)
+        << "Event ID \"" << id << "\" collides with an existing alias in PMU "
+        << getFullName();
+    HBT_ARG_CHECK(incoming_primary_ids.insert(id).second);
+
+    const EventId canonical_id = toCanonicalEventId(id);
+    if (canonical_id != id) {
+      HBT_ARG_CHECK(!hasPrimaryEventId_(canonical_id))
+          << "Canonical alias \"" << canonical_id
+          << "\" collides with an existing event in PMU " << getFullName();
+      HBT_ARG_CHECK_EQ(aliases_.count(canonical_id), 0)
+          << "Canonical alias \"" << canonical_id << "\" already exists in PMU "
+          << getFullName();
+      HBT_ARG_CHECK(incoming_aliases.insert(canonical_id).second)
+          << "Duplicate canonical alias \"" << canonical_id << "\"";
+    }
+  }
+
+  for (const auto& alias : incoming_aliases) {
+    HBT_ARG_CHECK_EQ(incoming_primary_ids.count(alias), 0)
+        << "Canonical alias \"" << alias
+        << "\" collides with an event in the same static table";
+  }
+}
+
+void PmuDevice::addStaticEventDefs_(
+    std::shared_ptr<StaticEventDefTableState> state) {
+  for (const StaticEventDef& event : state->events()) {
+    const EventId id{event.id};
+    const EventId canonical_id = toCanonicalEventId(id);
+    if (canonical_id != id) {
+      aliases_.emplace(canonical_id, id);
+    }
+  }
+  static_event_defs_.push_back(std::move(state));
+}
+
+void PmuDevice::addEvent(
+    std::shared_ptr<EventDef> ev_def,
+    std::optional<std::vector<EventId>> aliases) {
+  HBT_ARG_CHECK(!hasPrimaryEventId_(ev_def->id))
+      << "An event with id \"" << ev_def->id
+      << "\" already exists in PMU with id: \"" << getPmuId()
+      << "\" and name: \"" << getFullName() << "\"";
+  HBT_ARG_CHECK_EQ(aliases_.count(ev_def->id), 0)
+      << "Event ID \"" << ev_def->id
+      << "\" collides with an existing alias in PMU with id: \"" << getPmuId()
+      << "\" and name: \"" << getFullName() << "\"";
+
+  const bool has_dashes = ev_def->id.find('-') != std::string::npos;
+  const bool has_upper =
+      std::any_of(ev_def->id.begin(), ev_def->id.end(), ::isupper);
+  if (has_dashes || has_upper) {
+    aliases = std::vector<EventId>{toCanonicalEventId(ev_def->id)};
+  }
+
+  if (aliases.has_value()) {
+    for (const auto& alias : *aliases) {
+      HBT_ARG_CHECK(ev_def->id != alias && !hasPrimaryEventId_(alias))
+          << "Tried to register an alias equal to an already existing event id. "
+          << "Event ID: \"" << alias << "\" "
+          << "already exists in PMU with id: \"" << getPmuId() << "\""
+          << " and name: \"" << getFullName() << "\"";
+      HBT_ARG_CHECK_EQ(aliases_.count(alias), 0)
+          << "Alias \"" << alias << "\" already exists in PMU with id: \""
+          << getPmuId() << "\" and name: \"" << getFullName() << "\"";
+    }
+  }
+
+  auto [_, added] = event_defs_.emplace(ev_def->id, ev_def);
+  HBT_DCHECK(added);
+  if (aliases.has_value()) {
+    addAliases(ev_def->id, *aliases);
+  }
+}
+
+EventConf PmuDevice::makeConf(
+    const EventId& ev_id,
+    EventExtraAttr extra_attr,
+    EventValueTransforms transforms) const {
+  const auto primary = findPrimaryEventId_(ev_id);
+  HBT_ARG_CHECK(primary.has_value())
+      << "No event with ev_id \"" << ev_id
+      << "\" in PMU with id:  " << getPmuId() << " and name: \""
+      << getFullName() << "\"";
+
+  EventConfigs configs{};
+  if (const auto it = event_defs_.find(*primary); it != event_defs_.end()) {
+    configs = it->second->makeConfigs(getPmuId());
+  } else {
+    configs = makeEventConfigs(*findStaticEventDef_(*primary), getPmuId());
+  }
+  return {
+      .id = ev_id,
+      .configs = configs,
+      .extra_attr = extra_attr,
+      .transforms = transforms};
+}
 
 /// Get EventDefs grouped by preffix of event_id until first dot.
 /// If no dot, then take the full name.
 std::unique_ptr<LibPfm4EventGroups> PmuDevice::makeLibPfm4Groups() const {
   auto groups = std::make_unique<LibPfm4EventGroups>();
 
-  for (const auto& [ev_id, ev_def] : event_defs_) {
+  for (const auto& [ev_id, ev_def] : getEventDefs()) {
     HBT_THROW_ASSERT_IF(ev_def == nullptr);
     uint64_t code = ev_def->encoding.code;
     auto gkey = LibPfm4EventGroup::groupKeyFromEventId(ev_id);
@@ -516,15 +742,76 @@ int PmuDeviceManager::addEvent(
   return 0;
 }
 
+int PmuDeviceManager::addStaticEventDefs(
+    std::span<const StaticEventDef> events) {
+  if (events.empty()) {
+    return 0;
+  }
+  HBT_ARG_CHECK(isStaticEventDefTableSorted(events))
+      << "Static event definitions must be unique and sorted by PMU type and ID";
+
+  struct ApplicablePartition {
+    std::shared_ptr<StaticEventDefTableState> state;
+    TPmuGroup* devices;
+  };
+  std::vector<ApplicablePartition> applicable;
+
+  size_t begin = 0;
+  while (begin < events.size()) {
+    size_t end = begin + 1;
+    while (end < events.size() &&
+           events[end].pmu_type == events[begin].pmu_type) {
+      ++end;
+    }
+
+    if (auto it = pmu_groups_.find(events[begin].pmu_type);
+        it != pmu_groups_.end()) {
+      auto state = std::make_shared<StaticEventDefTableState>(
+          events.subspan(begin, end - begin));
+      applicable.push_back(
+          ApplicablePartition{
+              .state = std::move(state), .devices = &it->second});
+    }
+    begin = end;
+  }
+
+  if (applicable.empty()) {
+    return -ENXIO;
+  }
+
+  for (const auto& partition : applicable) {
+    for (const auto& [_, device] : *partition.devices) {
+      device->validateStaticEventDefs_(partition.state);
+    }
+  }
+  for (auto& partition : applicable) {
+    for (auto& [_, device] : *partition.devices) {
+      device->addStaticEventDefs_(partition.state);
+    }
+  }
+  return 0;
+}
+
 int PmuDeviceManager::addAliases(
     const EventId& ev_id,
     const std::vector<EventId>& aliases) {
-  auto ev = findEventDef(ev_id, std::nullopt);
-  if (!ev) {
-    return -EINVAL;
+  const EventId canonical_id = toCanonicalEventId(ev_id);
+  for (auto& [_, pmu_devices] : pmu_groups_) {
+    for (const auto& [__, device] : pmu_devices) {
+      auto primary = device->findPrimaryEventId_(ev_id);
+      if (!primary.has_value()) {
+        primary = device->findPrimaryEventId_(canonical_id);
+      }
+      if (!primary.has_value()) {
+        continue;
+      }
+      for (auto& [___, target] : pmu_devices) {
+        target->addAliases(*primary, aliases);
+      }
+      return 0;
+    }
   }
-
-  return addAliases(ev, aliases);
+  return -EINVAL;
 }
 
 int PmuDeviceManager::addAliases(

--- a/hbt/src/perf_event/PmuDevices.h
+++ b/hbt/src/perf_event/PmuDevices.h
@@ -7,16 +7,20 @@
 
 #include "hbt/src/perf_event/CpuArch.h"
 #include "hbt/src/perf_event/PmuEvent.h"
+#include "hbt/src/perf_event/StaticEventDef.h"
 
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <numeric>
+#include <span>
 #include <utility>
 #include <variant>
 #include <vector>
 
 namespace facebook::hbt::perf_event {
+
+class StaticEventDefTableState;
 
 namespace uncore_scope {
 struct Host {
@@ -153,9 +157,7 @@ class PmuDevice {
     return cpu_mask_;
   }
 
-  const auto& getEventDefs() const noexcept {
-    return event_defs_;
-  }
+  const std::map<EventId, std::shared_ptr<EventDef>>& getEventDefs() const;
 
   // perf_event_attr config fields.
   enum class ConfigType {
@@ -187,19 +189,7 @@ class PmuDevice {
   /// If no dot, then take the full name.
   std::unique_ptr<LibPfm4EventGroups> makeLibPfm4Groups() const;
 
-  std::shared_ptr<EventDef> findEventDef(const EventId& ev_id) const {
-    auto it = event_defs_.find(ev_id);
-    if (it == event_defs_.end()) {
-      auto opt_ev_id = findEventIdByAlias_(ev_id);
-      if (opt_ev_id.has_value()) {
-        return findEventDef(*opt_ev_id);
-      } else {
-        return nullptr;
-      }
-    }
-    HBT_ARG_CHECK_EQ(it->first, ev_id);
-    return it->second;
-  }
+  std::shared_ptr<EventDef> findEventDef(const EventId& ev_id) const;
 
   /// If aliases is nullopt, add default aliases.
   /// Default aliases are non-empty iff the event id contains a '-' or a '_'.
@@ -208,46 +198,7 @@ class PmuDevice {
   ///  - A version of event_id with all '_' as '-' (if distinct to event id).
   void addEvent(
       std::shared_ptr<EventDef> ev_def,
-      std::optional<std::vector<EventId>> aliases = std::nullopt) {
-    // Validate before adding so there is no need to rollback in error.
-    HBT_ARG_CHECK(event_defs_.count(ev_def->id) == 0)
-        << "An event with id \"" << ev_def->id
-        << "\" already exists in PMU with id: \"" << getPmuId()
-        << "\" and name: \"" << getFullName() << "\"";
-
-    if (aliases.has_value()) {
-      for (const auto& alias : *aliases) {
-        HBT_ARG_CHECK(ev_def->id != alias && event_defs_.count(alias) == 0)
-            << "Tried to register an alias equal to an already existing event id. "
-            << "Event ID: \"" << alias << "\" "
-            << "already exists in PMU with id: \"" << getPmuId() << "\""
-            << " and name: \"" << getFullName() << "\"";
-
-        HBT_ARG_CHECK_EQ(aliases_.count(alias), 0)
-            << "Alias \"" << alias << "\" already exists in PMU with "
-            << "id: \"" << getPmuId() << "\" and name: \"" << getFullName()
-            << "\"";
-      }
-    }
-
-    bool has_dashes = ev_def->id.find('-') != std::string::npos;
-    bool has_upper =
-        std::any_of(ev_def->id.begin(), ev_def->id.end(), ::isupper);
-    if (has_dashes || has_upper) {
-      aliases = std::vector<EventId>();
-      // Make a copy to hold replaced values.
-      auto s = toCanonicalEventId(ev_def->id);
-      HBT_DCHECK_NE(s, ev_def->id);
-      aliases->push_back(s);
-    }
-
-    // Now add, validation already happened so there should be no errors.
-    auto [_, added] = event_defs_.emplace(ev_def->id, ev_def);
-    HBT_DCHECK(added);
-    if (aliases.has_value()) {
-      addAliases(ev_def->id, *aliases);
-    }
-  }
+      std::optional<std::vector<EventId>> aliases = std::nullopt);
 
   void addAliases(const EventId& ev_id, const std::vector<EventId>& aliases);
 
@@ -256,18 +207,7 @@ class PmuDevice {
   EventConf makeConf(
       const EventId& ev_id,
       EventExtraAttr extra_attr,
-      EventValueTransforms transforms) const {
-    auto evdef = this->findEventDef(ev_id);
-    HBT_ARG_CHECK(evdef != nullptr) << "No event with ev_id \"" << ev_id
-                                    << "\" in PMU with id:  " << getPmuId()
-                                    << " and name: \"" << getFullName() << "\"";
-    auto configs = evdef->makeConfigs(getPmuId());
-    return {
-        .id = ev_id,
-        .configs = configs,
-        .extra_attr = extra_attr,
-        .transforms = transforms};
-  }
+      EventValueTransforms transforms) const;
 
  protected:
   const std::string pmu_name_;
@@ -292,21 +232,26 @@ class PmuDevice {
   bool in_sysfs_;
 
   // Alias as key, original event ID as value.
-  std::map<EventId, std::shared_ptr<EventDef>> event_defs_;
+  mutable std::map<EventId, std::shared_ptr<EventDef>> event_defs_;
   std::map<EventId, EventId> aliases_;
+  std::vector<std::shared_ptr<StaticEventDefTableState>> static_event_defs_;
 
   // PMUs that are not per-core can be opened for any
   // CPU within a CPU group. In uncore PMUs, this is
   // equivalent to the cpu_mask attr in its sys fs entry.
   std::optional<cpu_set_t> cpu_mask_ = std::nullopt;
 
-  std::optional<EventId> findEventIdByAlias_(const EventId& ev_id) const {
-    auto it = aliases_.find(ev_id);
-    if (it == aliases_.end()) {
-      return std::nullopt;
-    }
-    return it->second;
-  }
+  std::optional<EventId> findEventIdByAlias_(const EventId& ev_id) const;
+  std::optional<EventId> findPrimaryEventId_(const EventId& ev_id) const;
+  const StaticEventDef* findStaticEventDef_(const EventId& ev_id) const;
+  std::shared_ptr<EventDef> materializeStaticEventDef_(
+      const StaticEventDef& ev_def) const;
+  bool hasPrimaryEventId_(std::string_view ev_id) const;
+  void validateStaticEventDefs_(
+      const std::shared_ptr<StaticEventDefTableState>& state) const;
+  void addStaticEventDefs_(std::shared_ptr<StaticEventDefTableState> state);
+
+  friend class PmuDeviceManager;
 };
 
 /// CpuId and PmuDevice info can uniquely identify a PMU device in perf.
@@ -358,6 +303,12 @@ class PmuDeviceManager {
   int addEvent(
       std::shared_ptr<EventDef> ev,
       std::optional<std::vector<EventId>> aliases = std::nullopt);
+
+  /// Register a sorted static catalog with every existing PMU of each matching
+  /// type. The span and all strings referenced by its entries must remain valid
+  /// for the lifetime of the PMU devices and are expected to have static
+  /// storage.
+  int addStaticEventDefs(std::span<const StaticEventDef> events);
 
   /// List all static tracepoint categories defined
   /// in /sys/kernel/debug/tracing/events.

--- a/hbt/src/perf_event/PmuEvent.h
+++ b/hbt/src/perf_event/PmuEvent.h
@@ -6,6 +6,9 @@
 #pragma once
 
 #include "hbt/src/common/System.h"
+#include "hbt/src/perf_event/EventConfigs.h"
+#include "hbt/src/perf_event/EventScale.h"
+#include "hbt/src/perf_event/PmuType.h"
 
 #include <linux/perf_event.h>
 
@@ -18,113 +21,8 @@
 
 namespace facebook::hbt::perf_event {
 
-/// Linux's perf_event has PMUs that are statically enumerated, present
-/// in linux/include/perf_event.h, and PMUs that are instantiated dynamically.
-/// /sys/devices exposes some of the statically enumerated PMUs and all of the
-/// dynamic ones.
-///
-/// This enumeration handles both static and dynamic PMUs.
-enum class PmuType : uint16_t {
-
-  generic_hardware, // Equivalent to PERF_TYPE_HARDWARE: architecture
-                    // independent CPU events
-  software, // Equivalent to PERF_TYPE_SOFTWARE
-  tracepoint, // Equivalent to PERF_TYPE_TRACEPOINT
-  generic_hw_cache, // Equivalent to PERF_TYPE_HW_CACHE
-  cpu, // Equivalent to PERF_TYPE_RAW: architecture specific CPU events
-  breakpoint, // Equivalent to PERF_TYPE_BREAKPOINT
-
-  kprobe,
-  uprobe,
-  power,
-
-  // Intel Uncore caching
-  uncore_cbox,
-  uncore_cha,
-  uncore_ha,
-  // In SRF, there is a Converged/Common Mesh Stop attached to each CHA
-  uncore_chacms,
-
-  // Intel Uncore
-  uncore_imc,
-  uncore_iio,
-  uncore_irp,
-  uncore_m2m,
-  uncore_m3upi,
-  uncore_pcu,
-  uncore_qpi,
-  uncore_r2pcie,
-  uncore_r3qpi,
-  uncore_sbox,
-  uncore_ubox,
-  uncore_upi,
-
-  // XXX: Below are Icelake PMUs, need to test them.
-  uncore_ncu, // Similar to cbox
-  uncore_arb, // Arbitration unit.
-  uncore_edc_uclk, // EDC is a memory controller for MCDRAM (3D-stacked)
-  uncore_edc_eclk,
-
-  // Memory controller.
-  uncore_imc_uclk,
-  uncore_imc_dclk,
-
-  // Memory to PCIe.
-  uncore_m2pcie,
-
-  // Intel PT
-  intel_pt,
-
-  // HBM Memory Controller
-  // XXX: Need to test them?
-  uncore_mchbm,
-
-  // Arm
-  armv8_pmuv3,
-
-  // Nvidia Uncores (Grace-Hopper)
-  nvidia_scf_pmu,
-  nvidia_nvlink_c2c0_pmu,
-  nvidia_nvlink_c2c1_pmu,
-  nvidia_pcie_pmu,
-
-  // Nvidia Uncores (Vera-Rubin / Vera). The sysfs names differ from
-  // Grace-Hopper: nvidia_ucf_pmu replaces nvidia_scf_pmu, a single
-  // nvidia_nvlink_c2c_pmu (per-socket instances) replaces c2c0/c2c1, and
-  // nvidia_pcie{,_tgt}_pmu are enumerated per root complex
-  // (<pmu>_<sock>_rc_<n>).
-  nvidia_ucf_pmu,
-  nvidia_nvlink_c2c_pmu,
-  nvidia_cmem_latency_pmu,
-  nvidia_nvclink_pmu,
-  nvidia_nvdlink_pmu,
-  nvidia_pcie_tgt_pmu,
-
-  // AMD L3
-  amd_l3,
-
-  // AMD Zen5 UMC
-  amd_umc,
-
-  // AMD Data Fabric (used for Zen6/Venice CCM CXL bandwidth counters)
-  amd_df,
-
-  // Arm
-  cs_etm,
-
-  // Arm uncores
-  arm_cspmu_mc,
-  arm_cmn,
-};
-
 std::string PmuTypeToStr(PmuType /*pmu_type*/);
 PmuType PmuTypeFromStr(const std::string& /*pmu_type_str*/);
-
-enum class ScaleUnit {
-  Bytes, // Bytes
-  Joules, // Joules
-  MiB // MebiBytes
-};
 
 ScaleUnit scaleUnitFromStr(const std::string& s);
 
@@ -249,15 +147,6 @@ struct EventExtraAttr {
 std::ostream& operator<<(std::ostream& /*os*/, const EventExtraAttr& /*attr*/);
 
 using EventExtraAttrs = std::vector<EventExtraAttr>;
-
-/// The configuration data passed to CpuEventsGroup to be used to
-/// select the perf_event_attr in perf_event_open.
-struct EventConfigs {
-  uint32_t type; // The PMU type.
-  uint64_t config;
-  uint64_t config1 = 0x0;
-  uint64_t config2 = 0x0;
-};
 
 std::ostream& operator<<(
     std::ostream& /*os*/,

--- a/hbt/src/perf_event/PmuType.h
+++ b/hbt/src/perf_event/PmuType.h
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::hbt::perf_event {
+
+/// Linux's perf_event has PMUs that are statically enumerated, present
+/// in linux/include/perf_event.h, and PMUs that are instantiated dynamically.
+/// /sys/devices exposes some of the statically enumerated PMUs and all of the
+/// dynamic ones.
+///
+/// This enumeration handles both static and dynamic PMUs.
+///
+/// Kept in its own header so that generated event tables can name PmuType
+/// without pulling in PmuEvent.h and its transitive includes.
+enum class PmuType : uint16_t {
+
+  generic_hardware, // Equivalent to PERF_TYPE_HARDWARE: architecture
+                    // independent CPU events
+  software, // Equivalent to PERF_TYPE_SOFTWARE
+  tracepoint, // Equivalent to PERF_TYPE_TRACEPOINT
+  generic_hw_cache, // Equivalent to PERF_TYPE_HW_CACHE
+  cpu, // Equivalent to PERF_TYPE_RAW: architecture specific CPU events
+  breakpoint, // Equivalent to PERF_TYPE_BREAKPOINT
+
+  kprobe,
+  uprobe,
+  power,
+
+  // Intel Uncore caching
+  uncore_cbox,
+  uncore_cha,
+  uncore_ha,
+  // In SRF, there is a Converged/Common Mesh Stop attached to each CHA
+  uncore_chacms,
+
+  // Intel Uncore
+  uncore_imc,
+  uncore_iio,
+  uncore_irp,
+  uncore_m2m,
+  uncore_m3upi,
+  uncore_pcu,
+  uncore_qpi,
+  uncore_r2pcie,
+  uncore_r3qpi,
+  uncore_sbox,
+  uncore_ubox,
+  uncore_upi,
+
+  // XXX: Below are Icelake PMUs, need to test them.
+  uncore_ncu, // Similar to cbox
+  uncore_arb, // Arbitration unit.
+  uncore_edc_uclk, // EDC is a memory controller for MCDRAM (3D-stacked)
+  uncore_edc_eclk,
+
+  // Memory controller.
+  uncore_imc_uclk,
+  uncore_imc_dclk,
+
+  // Memory to PCIe.
+  uncore_m2pcie,
+
+  // Intel PT
+  intel_pt,
+
+  // HBM Memory Controller
+  // XXX: Need to test them?
+  uncore_mchbm,
+
+  // Arm
+  armv8_pmuv3,
+
+  // Nvidia Uncores (Grace-Hopper)
+  nvidia_scf_pmu,
+  nvidia_nvlink_c2c0_pmu,
+  nvidia_nvlink_c2c1_pmu,
+  nvidia_pcie_pmu,
+
+  // Nvidia Uncores (Vera-Rubin / Vera). The sysfs names differ from
+  // Grace-Hopper: nvidia_ucf_pmu replaces nvidia_scf_pmu, a single
+  // nvidia_nvlink_c2c_pmu (per-socket instances) replaces c2c0/c2c1, and
+  // nvidia_pcie{,_tgt}_pmu are enumerated per root complex
+  // (<pmu>_<sock>_rc_<n>).
+  nvidia_ucf_pmu,
+  nvidia_nvlink_c2c_pmu,
+  nvidia_cmem_latency_pmu,
+  nvidia_nvclink_pmu,
+  nvidia_nvdlink_pmu,
+  nvidia_pcie_tgt_pmu,
+
+  // AMD L3
+  amd_l3,
+
+  // AMD Zen5 UMC
+  amd_umc,
+
+  // AMD Data Fabric (used for Zen6/Venice CCM CXL bandwidth counters)
+  amd_df,
+
+  // Arm
+  cs_etm,
+
+  // Arm uncores
+  arm_cspmu_mc,
+  arm_cmn,
+};
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/StaticEventDef.cpp
+++ b/hbt/src/perf_event/StaticEventDef.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "hbt/src/perf_event/StaticEventDef.h"
+
+#include "hbt/src/perf_event/PmuEvent.h"
+
+#include <string>
+#include <vector>
+
+namespace facebook::hbt::perf_event {
+namespace {
+
+std::vector<uint64_t> materializeMsrValues(
+    const std::variant<std::monostate, uint64_t, std::array<uint64_t, 2>>&
+        msr_values) {
+  if (std::holds_alternative<std::monostate>(msr_values)) {
+    return {};
+  }
+  if (const auto* value = std::get_if<uint64_t>(&msr_values)) {
+    return {*value};
+  }
+  const auto& values = std::get<std::array<uint64_t, 2>>(msr_values);
+  return {values[0], values[1]};
+}
+
+EventDef::Encoding materializeEncoding(
+    const StaticEventDef::Encoding& encoding) {
+  return EventDef::Encoding{
+      .code = encoding.code,
+      .umask = encoding.umask,
+      .umaskExt = encoding.umask_ext,
+      .edge = encoding.edge,
+      .any = encoding.any,
+      .inv = encoding.inv,
+      .cmask = encoding.cmask,
+      .msr_values = materializeMsrValues(encoding.msr_values)};
+}
+
+std::optional<EventDef::ScaleData> materializeScaleData(
+    const std::optional<StaticEventDef::ScaleData>& scale_data) {
+  if (!scale_data.has_value()) {
+    return std::nullopt;
+  }
+  return EventDef::ScaleData{
+      .scale_factor = scale_data->scale_factor,
+      .scale_unit = scale_data->scale_unit};
+}
+
+std::optional<EventDef::IntelFeatures> materializeIntelFeatures(
+    const std::optional<StaticEventDef::IntelFeatures>& features) {
+  if (!features.has_value()) {
+    return std::nullopt;
+  }
+  return EventDef::IntelFeatures{
+      .data_la = features->data_la,
+      .l1_hit_indication = features->l1_hit_indication,
+      .ellc = features->ellc,
+      .pebs = features->pebs};
+}
+
+std::optional<std::string> materializeErrata(
+    const std::optional<std::string_view>& errata) {
+  if (!errata.has_value()) {
+    return std::nullopt;
+  }
+  return std::string{*errata};
+}
+
+} // namespace
+
+EventDef materializeEventDef(const StaticEventDef& event) {
+  return EventDef{
+      event.pmu_type,
+      std::string{event.id},
+      materializeEncoding(event.encoding),
+      std::string{event.brief_desc},
+      std::string{event.full_desc},
+      event.default_sampling_period,
+      materializeScaleData(event.scale_data),
+      materializeIntelFeatures(event.features),
+      materializeErrata(event.errata)};
+}
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/StaticEventDef.h
+++ b/hbt/src/perf_event/StaticEventDef.h
@@ -1,0 +1,135 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "hbt/src/perf_event/EventConfigs.h"
+#include "hbt/src/perf_event/EventScale.h"
+#include "hbt/src/perf_event/PmuType.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <variant>
+
+namespace facebook::hbt::perf_event {
+
+struct EventDef;
+
+/// Non-owning event definition for generated constexpr catalogs.
+///
+/// Strings must refer to static storage. Runtime-created definitions continue
+/// to use the owning EventDef representation.
+struct StaticEventDef {
+  struct Encoding {
+    uint64_t code;
+    uint64_t umask = 0;
+    uint64_t umask_ext = 0;
+    bool edge = false;
+    bool any = false;
+    bool inv = false;
+    uint64_t cmask = 0;
+    std::variant<std::monostate, uint64_t, std::array<uint64_t, 2>> msr_values;
+  };
+
+  struct ScaleData {
+    std::variant<int, double> scale_factor;
+    ScaleUnit scale_unit;
+  };
+
+  struct IntelFeatures {
+    bool data_la = false;
+    bool l1_hit_indication = false;
+    bool ellc = false;
+    uint8_t pebs = 0;
+  };
+
+  PmuType pmu_type;
+  std::string_view id;
+  Encoding encoding;
+  std::optional<ScaleData> scale_data = std::nullopt;
+  std::optional<IntelFeatures> features = std::nullopt;
+  std::string_view brief_desc;
+  std::string_view full_desc;
+  std::optional<uint64_t> default_sampling_period = std::nullopt;
+  std::optional<std::string_view> errata = std::nullopt;
+};
+
+/// Whether a table has unique entries sorted by (pmu_type, id).
+constexpr bool isStaticEventDefTableSorted(
+    std::span<const StaticEventDef> events) noexcept {
+  for (size_t i = 1; i < events.size(); ++i) {
+    const StaticEventDef& prev = events[i - 1];
+    const StaticEventDef& current = events[i];
+    if (prev.pmu_type > current.pmu_type) {
+      return false;
+    }
+    if (prev.pmu_type == current.pmu_type && !(prev.id < current.id)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Binary-search a generated table sorted by (pmu_type, id).
+constexpr const StaticEventDef* findStaticEventDef(
+    std::span<const StaticEventDef> events,
+    PmuType pmu_type,
+    std::string_view id) noexcept {
+  size_t lo = 0;
+  size_t hi = events.size();
+  while (lo < hi) {
+    const size_t mid = lo + (hi - lo) / 2;
+    const StaticEventDef& event = events[mid];
+    if (event.pmu_type < pmu_type ||
+        (event.pmu_type == pmu_type && event.id < id)) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  if (lo == events.size() || events[lo].pmu_type != pmu_type ||
+      events[lo].id != id) {
+    return nullptr;
+  }
+  return &events[lo];
+}
+
+/// Encode a static definition exactly as EventDef::makeConfigs() does.
+constexpr EventConfigs makeEventConfigs(
+    const StaticEventDef& event,
+    uint32_t new_pmu_type) {
+  const uint64_t config = (event.encoding.umask_ext << 32) |
+      (event.encoding.cmask << 24) |
+      (static_cast<uint64_t>(event.encoding.inv) << 23) |
+      (static_cast<uint64_t>(event.encoding.any) << 21) |
+      (static_cast<uint64_t>(event.encoding.edge) << 18) |
+      (event.encoding.umask << 8) | event.encoding.code;
+
+  uint64_t config1 = 0;
+  uint64_t config2 = 0;
+  if (const auto* value = std::get_if<uint64_t>(&event.encoding.msr_values)) {
+    config1 = *value;
+  } else if (
+      const auto* values =
+          std::get_if<std::array<uint64_t, 2>>(&event.encoding.msr_values)) {
+    config1 = (*values)[0];
+    config2 = (*values)[1];
+  }
+
+  return EventConfigs{
+      .type = new_pmu_type,
+      .config = config,
+      .config1 = config1,
+      .config2 = config2};
+}
+
+/// Convert a static definition to the existing owning representation.
+EventDef materializeEventDef(const StaticEventDef& event);
+
+} // namespace facebook::hbt::perf_event

--- a/hbt/src/perf_event/tests/PmuDevicesTest.cpp
+++ b/hbt/src/perf_event/tests/PmuDevicesTest.cpp
@@ -8,8 +8,92 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <future>
+
 using namespace facebook::hbt;
 using namespace facebook::hbt::perf_event;
+
+namespace {
+
+constexpr std::array<StaticEventDef, 3> kStaticSoftwareEvents{{
+    {
+        .pmu_type = PmuType::software,
+        .id = "STATIC-ALPHA",
+        .encoding = {.code = 0x11},
+        .brief_desc = "static alpha",
+        .full_desc = "static alpha full",
+    },
+    {
+        .pmu_type = PmuType::software,
+        .id = "STATIC_BRAVO",
+        .encoding = {.code = 0x22, .msr_values = uint64_t{0x1234}},
+        .brief_desc = "static bravo",
+        .full_desc = "static bravo full",
+    },
+    {
+        .pmu_type = PmuType::software,
+        .id = "static.charlie",
+        .encoding =
+            {
+                .code = 0x33,
+                .msr_values = std::array<uint64_t, 2>{0x5678, 0x9abc},
+            },
+        .brief_desc = "static charlie",
+        .full_desc = "static charlie full",
+    },
+}};
+
+constexpr std::array<StaticEventDef, 2> kMixedStaticEvents{{
+    {
+        .pmu_type = PmuType::software,
+        .id = "mixed_software",
+        .encoding = {.code = 0x44},
+        .brief_desc = "mixed software",
+        .full_desc = "mixed software full",
+    },
+    {
+        .pmu_type = PmuType::cpu,
+        .id = "mixed_cpu",
+        .encoding = {.code = 0x55},
+        .brief_desc = "mixed cpu",
+        .full_desc = "mixed cpu full",
+    },
+}};
+
+constexpr std::array<StaticEventDef, 1> kAdditionalStaticEvents{{
+    {
+        .pmu_type = PmuType::software,
+        .id = "static_delta",
+        .encoding = {.code = 0x66},
+        .brief_desc = "static delta",
+        .full_desc = "static delta full",
+    },
+}};
+
+static_assert(isStaticEventDefTableSorted(kStaticSoftwareEvents));
+static_assert(isStaticEventDefTableSorted(kMixedStaticEvents));
+static_assert(isStaticEventDefTableSorted(kAdditionalStaticEvents));
+
+std::shared_ptr<PmuDevice> makePmu(
+    std::string name,
+    PmuType type,
+    std::optional<unsigned> enumeration,
+    uint32_t perf_pmu_id) {
+  return std::make_shared<PmuDevice>(
+      std::move(name),
+      type,
+      enumeration,
+      perf_pmu_id,
+      "A Dummy PMU device",
+      false);
+}
+
+std::shared_ptr<PmuDeviceManager> makePmuManager() {
+  return std::make_shared<PmuDeviceManager>(CpuInfo::load());
+}
+
+} // namespace
 
 class PmuDevicesTest : public ::testing::Test {};
 
@@ -139,6 +223,283 @@ TEST_F(PmuDevicesTest, Aliases) {
   auto ev_def_alias2 = pmu_manager->findEventDef("alias-2", std::nullopt);
   EXPECT_TRUE(ev_def_alias2 != nullptr);
   EXPECT_EQ(ev_def_alias1->id, ev_def_alias2->id);
+}
+
+TEST_F(PmuDevicesTest, StaticMakeConfDoesNotRequireMaterialization) {
+  auto pmu_manager = makePmuManager();
+  auto pmu =
+      makePmu("dummy_pmu", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(pmu);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+
+  const EventConf noMsr =
+      pmu->makeConf("static_alpha", EventExtraAttr{}, EventValueTransforms{});
+  EXPECT_EQ(noMsr.id, "static_alpha");
+  EXPECT_EQ(noMsr.configs.type, PERF_TYPE_SOFTWARE);
+  EXPECT_EQ(noMsr.configs.config, 0x11);
+  EXPECT_EQ(noMsr.configs.config1, 0);
+  EXPECT_EQ(noMsr.configs.config2, 0);
+
+  const EventConf oneMsr =
+      pmu->makeConf("STATIC_BRAVO", EventExtraAttr{}, EventValueTransforms{});
+  EXPECT_EQ(oneMsr.configs.config, 0x22);
+  EXPECT_EQ(oneMsr.configs.config1, 0x1234);
+  EXPECT_EQ(oneMsr.configs.config2, 0);
+
+  const EventConf twoMsrs =
+      pmu->makeConf("static.charlie", EventExtraAttr{}, EventValueTransforms{});
+  EXPECT_EQ(twoMsrs.configs.config, 0x33);
+  EXPECT_EQ(twoMsrs.configs.config1, 0x5678);
+  EXPECT_EQ(twoMsrs.configs.config2, 0x9abc);
+}
+
+TEST_F(PmuDevicesTest, StaticLookupSharesLazyMaterializationAcrossDevices) {
+  auto pmu_manager = makePmuManager();
+  auto pmu0 = makePmu("software_0", PmuType::software, 0, 101);
+  auto pmu1 = makePmu("software_1", PmuType::software, 1, 102);
+  pmu_manager->addPmu(pmu0);
+  pmu_manager->addPmu(pmu1);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+
+  auto primary = pmu0->findEventDef("STATIC-ALPHA");
+  auto alias = pmu0->findEventDef("static_alpha");
+  auto other_device = pmu1->findEventDef("STATIC-ALPHA");
+  ASSERT_NE(primary, nullptr);
+  EXPECT_EQ(primary, alias);
+  EXPECT_EQ(primary, other_device);
+  EXPECT_EQ(primary->id, "STATIC-ALPHA");
+}
+
+TEST_F(PmuDevicesTest, StaticConcurrentFirstLookupSharesOnePointer) {
+  auto pmu_manager = makePmuManager();
+  auto pmu0 = makePmu("software_0", PmuType::software, 0, 101);
+  auto pmu1 = makePmu("software_1", PmuType::software, 1, 102);
+  pmu_manager->addPmu(pmu0);
+  pmu_manager->addPmu(pmu1);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+
+  constexpr size_t kNumLookups = 16;
+  std::array<std::future<std::shared_ptr<EventDef>>, kNumLookups> futures;
+  for (size_t i = 0; i < futures.size(); ++i) {
+    const auto& pmu = i % 2 == 0 ? pmu0 : pmu1;
+    futures[i] = std::async(std::launch::async, [pmu, i] {
+      return pmu->findEventDef(i % 3 == 0 ? "static_alpha" : "STATIC-ALPHA");
+    });
+  }
+
+  const auto expected = futures[0].get();
+  ASSERT_NE(expected, nullptr);
+  for (size_t i = 1; i < futures.size(); ++i) {
+    EXPECT_EQ(futures[i].get(), expected);
+  }
+}
+
+TEST_F(PmuDevicesTest, StaticRegistrationSupportsMultipleSpansAndPmuTypes) {
+  auto pmu_manager = makePmuManager();
+  auto software =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  auto cpu = makePmu("cpu", PmuType::cpu, std::nullopt, PERF_TYPE_RAW);
+  pmu_manager->addPmu(software);
+  pmu_manager->addPmu(cpu);
+
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kAdditionalStaticEvents), 0);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kMixedStaticEvents), 0);
+
+  EXPECT_NE(software->findEventDef("static_delta"), nullptr);
+  EXPECT_NE(software->findEventDef("mixed_software"), nullptr);
+  EXPECT_EQ(software->findEventDef("mixed_cpu"), nullptr);
+  EXPECT_NE(cpu->findEventDef("mixed_cpu"), nullptr);
+  EXPECT_EQ(cpu->findEventDef("mixed_software"), nullptr);
+}
+
+TEST_F(PmuDevicesTest, StaticAndOwningEventsCoexistAndEnumerate) {
+  auto pmu_manager = makePmuManager();
+  auto pmu =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(pmu);
+  auto owning = std::make_shared<EventDef>(
+      PmuType::software,
+      "owning.event",
+      EventDef::Encoding{.code = 0x77},
+      "owning",
+      "owning full");
+  ASSERT_EQ(pmu_manager->addEvent(owning), 0);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+
+  const auto& event_defs = pmu->getEventDefs();
+  EXPECT_EQ(event_defs.size(), 4);
+  EXPECT_EQ(event_defs.at("owning.event"), owning);
+  const auto static_event = event_defs.at("static.charlie");
+  EXPECT_EQ(static_event, pmu->findEventDef("static.charlie"));
+  EXPECT_EQ(&pmu->getEventDefs(), &event_defs);
+  EXPECT_EQ(pmu->getEventDefs().at("static.charlie"), static_event);
+
+  const auto groups = pmu->makeLibPfm4Groups();
+  EXPECT_EQ(groups->size(), 4);
+  EXPECT_EQ(groups->at("static").ev_defs.size(), 1);
+}
+
+TEST_F(PmuDevicesTest, AddsExplicitAliasesWithoutMaterializingStaticEvent) {
+  auto pmu_manager = makePmuManager();
+  auto pmu =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(pmu);
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+
+  EXPECT_EQ(
+      pmu_manager->addAliases(
+          "static_alpha", {"explicit_alias", "explicit_alias"}),
+      0);
+  const EventConf conf =
+      pmu->makeConf("explicit_alias", EventExtraAttr{}, EventValueTransforms{});
+  EXPECT_EQ(conf.id, "explicit_alias");
+  EXPECT_EQ(conf.configs.config, 0x11);
+  EXPECT_EQ(
+      pmu->findEventDef("explicit_alias"), pmu->findEventDef("STATIC-ALPHA"));
+}
+
+TEST_F(PmuDevicesTest, RejectsInvalidStaticTablesWithoutPartialRegistration) {
+  auto pmu_manager = makePmuManager();
+  auto software =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  auto cpu = makePmu("cpu", PmuType::cpu, std::nullopt, PERF_TYPE_RAW);
+  pmu_manager->addPmu(software);
+  pmu_manager->addPmu(cpu);
+  cpu->addEvent(
+      std::make_shared<EventDef>(
+          PmuType::cpu,
+          "mixed_cpu",
+          EventDef::Encoding{.code = 0x99},
+          "collision",
+          "collision full"));
+
+  constexpr std::array<StaticEventDef, 2> unsorted{{
+      kMixedStaticEvents[1],
+      kMixedStaticEvents[0],
+  }};
+  EXPECT_THROW(
+      pmu_manager->addStaticEventDefs(unsorted), std::invalid_argument);
+  EXPECT_EQ(software->findEventDef("mixed_software"), nullptr);
+
+  EXPECT_THROW(
+      pmu_manager->addStaticEventDefs(kMixedStaticEvents),
+      std::invalid_argument);
+  EXPECT_EQ(software->findEventDef("mixed_software"), nullptr);
+  EXPECT_EQ(cpu->findEventDef("mixed_cpu")->encoding.code, 0x99);
+
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kStaticSoftwareEvents), 0);
+  EXPECT_THROW(
+      pmu_manager->addStaticEventDefs(kStaticSoftwareEvents),
+      std::invalid_argument);
+  EXPECT_THROW(
+      software->addEvent(
+          std::make_shared<EventDef>(
+              PmuType::software,
+              "STATIC-ALPHA",
+              EventDef::Encoding{.code = 0xaa},
+              "primary collision",
+              "primary collision full")),
+      std::invalid_argument);
+  EXPECT_THROW(
+      software->addEvent(
+          std::make_shared<EventDef>(
+              PmuType::software,
+              "owning_with_alias",
+              EventDef::Encoding{.code = 0xab},
+              "explicit alias collision",
+              "explicit alias collision full"),
+          std::vector<EventId>{"STATIC_BRAVO"}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      software->addEvent(
+          std::make_shared<EventDef>(
+              PmuType::software,
+              "STATIC-BRAVO",
+              EventDef::Encoding{.code = 0xac},
+              "canonical alias collision",
+              "canonical alias collision full")),
+      std::invalid_argument);
+  EXPECT_EQ(software->getEventDefs().size(), kStaticSoftwareEvents.size());
+}
+
+TEST_F(PmuDevicesTest, RejectsStaticPrimaryAndCanonicalAliasCollisions) {
+  auto pmu_manager = makePmuManager();
+  auto software =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(software);
+  software->addEvent(
+      std::make_shared<EventDef>(
+          PmuType::software,
+          "owning_event",
+          EventDef::Encoding{.code = 0x88},
+          "owning",
+          "owning full"),
+      std::vector<EventId>{"existing_alias"});
+
+  constexpr std::array<StaticEventDef, 1> primaryAliasCollision{{
+      {
+          .pmu_type = PmuType::software,
+          .id = "existing_alias",
+          .encoding = {.code = 0x89},
+          .brief_desc = "primary alias collision",
+          .full_desc = "primary alias collision full",
+      },
+  }};
+  EXPECT_THROW(
+      pmu_manager->addStaticEventDefs(primaryAliasCollision),
+      std::invalid_argument);
+
+  constexpr std::array<StaticEventDef, 1> canonicalPrimaryCollision{{
+      {
+          .pmu_type = PmuType::software,
+          .id = "OWNING-EVENT",
+          .encoding = {.code = 0x8a},
+          .brief_desc = "canonical primary collision",
+          .full_desc = "canonical primary collision full",
+      },
+  }};
+  EXPECT_THROW(
+      pmu_manager->addStaticEventDefs(canonicalPrimaryCollision),
+      std::invalid_argument);
+  EXPECT_EQ(software->getEventDefs().size(), 1);
+}
+
+TEST_F(PmuDevicesTest, SkipsUnavailablePmuTypes) {
+  auto pmu_manager = makePmuManager();
+  auto software =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(software);
+
+  ASSERT_EQ(pmu_manager->addStaticEventDefs(kMixedStaticEvents), 0);
+  EXPECT_NE(software->findEventDef("mixed_software"), nullptr);
+  EXPECT_EQ(software->findEventDef("mixed_cpu"), nullptr);
+
+  constexpr std::array<StaticEventDef, 1> unavailable{{
+      kMixedStaticEvents[1],
+  }};
+  EXPECT_EQ(pmu_manager->addStaticEventDefs(unavailable), -ENXIO);
+  EXPECT_EQ(software->getEventDefs().count("mixed_cpu"), 0);
+  EXPECT_EQ(pmu_manager->addStaticEventDefs({}), 0);
+}
+
+TEST_F(PmuDevicesTest, RejectsStaticDefinitionsThatCannotMaterialize) {
+  auto pmu_manager = makePmuManager();
+  auto software =
+      makePmu("software", PmuType::software, std::nullopt, PERF_TYPE_SOFTWARE);
+  pmu_manager->addPmu(software);
+
+  constexpr std::array<StaticEventDef, 1> invalid{{
+      {
+          .pmu_type = PmuType::software,
+          .id = "invalid event",
+          .encoding = {.code = 0x77},
+          .brief_desc = "invalid",
+          .full_desc = "invalid full",
+      },
+  }};
+  EXPECT_THROW(pmu_manager->addStaticEventDefs(invalid), std::invalid_argument);
+  EXPECT_EQ(software->findEventDef("invalid event"), nullptr);
 }
 
 TEST_F(PmuDevicesTest, PerfEventAttr) {

--- a/hbt/src/perf_event/tests/StaticEventDefTest.cpp
+++ b/hbt/src/perf_event/tests/StaticEventDefTest.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "hbt/src/perf_event/PmuEvent.h"
+#include "hbt/src/perf_event/StaticEventDef.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+using namespace facebook::hbt::perf_event;
+
+namespace {
+
+constexpr std::array<StaticEventDef, 4> kEvents{{
+    {
+        .pmu_type = PmuType::cpu,
+        .id = "ALPHA",
+        .encoding =
+            {
+                .code = 0x11,
+                .umask = 0x22,
+                .cmask = 3,
+            },
+        .features = StaticEventDef::IntelFeatures{},
+        .brief_desc = "alpha brief",
+        .full_desc = "alpha full",
+        .default_sampling_period = 100003,
+    },
+    {
+        .pmu_type = PmuType::cpu,
+        .id = "ZULU",
+        .encoding =
+            {
+                .code = 0xB7,
+                .umask = 0x01,
+                .edge = true,
+                .any = true,
+                .inv = true,
+                .msr_values = std::array<uint64_t, 2>{0x8003C07F7ULL, 0xA5ULL},
+            },
+        .scale_data =
+            StaticEventDef::ScaleData{
+                .scale_factor = 0.5,
+                .scale_unit = ScaleUnit::MiB,
+            },
+        .features =
+            StaticEventDef::IntelFeatures{
+                .data_la = true,
+                .l1_hit_indication = true,
+                .ellc = true,
+                .pebs = 2,
+            },
+        .brief_desc = "zulu brief",
+        .full_desc = "zulu full",
+        .errata = "BDM69",
+    },
+    {
+        .pmu_type = PmuType::uncore_cha,
+        .id = "BRAVO",
+        .encoding =
+            {
+                .code = 0x35,
+                .umask_ext = 0x78CC6FFE,
+                .msr_values = uint64_t{0},
+            },
+        .scale_data =
+            StaticEventDef::ScaleData{
+                .scale_factor = 64,
+                .scale_unit = ScaleUnit::Bytes,
+            },
+        .brief_desc = "bravo brief",
+        .full_desc = "bravo full",
+    },
+    {
+        .pmu_type = PmuType::uncore_cha,
+        .id = "CHARLIE",
+        .encoding =
+            {
+                .code = 0x36,
+                .umask = 0x01,
+            },
+        .brief_desc = "charlie brief",
+        .full_desc = "charlie full",
+    },
+}};
+
+static_assert(isStaticEventDefTableSorted(kEvents));
+static_assert(findStaticEventDef(kEvents, PmuType::cpu, "ALPHA") != nullptr);
+static_assert(
+    findStaticEventDef(kEvents, PmuType::cpu, "ALPHA")
+        ->default_sampling_period == 100003);
+static_assert(makeEventConfigs(kEvents[1], 7).config1 == 0x8003C07F7ULL);
+static_assert(makeEventConfigs(kEvents[1], 7).config2 == 0xA5ULL);
+
+void expectConfigsEqual(
+    const EventConfigs& expected,
+    const EventConfigs& actual) {
+  EXPECT_EQ(actual.type, expected.type);
+  EXPECT_EQ(actual.config, expected.config);
+  EXPECT_EQ(actual.config1, expected.config1);
+  EXPECT_EQ(actual.config2, expected.config2);
+}
+
+} // namespace
+
+TEST(StaticEventDefTest, FindsDefinitionsAndReturnsNullptrOnMiss) {
+  const StaticEventDef* alpha =
+      findStaticEventDef(kEvents, PmuType::cpu, "ALPHA");
+  ASSERT_NE(alpha, nullptr);
+  EXPECT_EQ(alpha->brief_desc, "alpha brief");
+
+  EXPECT_EQ(findStaticEventDef(kEvents, PmuType::cpu, "NOPE"), nullptr);
+  EXPECT_EQ(findStaticEventDef(kEvents, PmuType::uncore_cha, "ALPHA"), nullptr);
+  EXPECT_NE(findStaticEventDef(kEvents, PmuType::uncore_cha, "BRAVO"), nullptr);
+  EXPECT_EQ(findStaticEventDef({}, PmuType::cpu, "ALPHA"), nullptr);
+}
+
+TEST(StaticEventDefTest, SortednessCheckRejectsOrderAndDuplicateKeys) {
+  constexpr std::array<StaticEventDef, 2> misordered{{kEvents[2], kEvents[0]}};
+  constexpr std::array<StaticEventDef, 2> duplicate{{kEvents[0], kEvents[0]}};
+
+  EXPECT_FALSE(isStaticEventDefTableSorted(misordered));
+  EXPECT_FALSE(isStaticEventDefTableSorted(duplicate));
+  EXPECT_TRUE(isStaticEventDefTableSorted(kEvents));
+}
+
+TEST(StaticEventDefTest, ConfigEncodingMatchesOwningDefinition) {
+  for (const StaticEventDef& event : kEvents) {
+    const EventDef owning = materializeEventDef(event);
+    expectConfigsEqual(owning.makeConfigs(7), makeEventConfigs(event, 7));
+  }
+
+  const EventConfigs twoMsrs = makeEventConfigs(kEvents[1], 7);
+  EXPECT_EQ(twoMsrs.config1, 0x8003C07F7ULL);
+  EXPECT_EQ(twoMsrs.config2, 0xA5ULL);
+
+  const EventConfigs explicitZeroMsr = makeEventConfigs(kEvents[2], 7);
+  EXPECT_EQ(explicitZeroMsr.config1, 0);
+  EXPECT_EQ(explicitZeroMsr.config2, 0);
+}
+
+TEST(StaticEventDefTest, MaterializationPreservesAllMetadata) {
+  const EventDef event = materializeEventDef(kEvents[1]);
+
+  EXPECT_EQ(event.pmu_type, PmuType::cpu);
+  EXPECT_EQ(event.id, "ZULU");
+  EXPECT_EQ(event.encoding.code, 0xB7);
+  EXPECT_EQ(event.encoding.umask, 0x01);
+  EXPECT_TRUE(event.encoding.edge);
+  EXPECT_TRUE(event.encoding.any);
+  EXPECT_TRUE(event.encoding.inv);
+  EXPECT_EQ(
+      event.encoding.msr_values,
+      (std::vector<uint64_t>{0x8003C07F7ULL, 0xA5ULL}));
+  ASSERT_TRUE(event.scale_data.has_value());
+  EXPECT_DOUBLE_EQ(std::get<double>(event.scale_data->scale_factor), 0.5);
+  EXPECT_EQ(event.scale_data->scale_unit, ScaleUnit::MiB);
+  ASSERT_TRUE(event.features.has_value());
+  EXPECT_TRUE(event.features->data_la);
+  EXPECT_TRUE(event.features->l1_hit_indication);
+  EXPECT_TRUE(event.features->ellc);
+  EXPECT_EQ(event.features->pebs, 2);
+  EXPECT_EQ(event.isPrecise(), std::optional<bool>{true});
+  EXPECT_EQ(event.brief_desc, "zulu brief");
+  EXPECT_EQ(event.full_desc, "zulu full");
+  EXPECT_EQ(event.default_sampling_period, std::nullopt);
+  EXPECT_EQ(event.errata, std::optional<std::string>{"BDM69"});
+}
+
+TEST(StaticEventDefTest, MaterializationPreservesOptionalStates) {
+  const EventDef absent = materializeEventDef(kEvents[3]);
+  EXPECT_TRUE(absent.encoding.msr_values.empty());
+  EXPECT_EQ(absent.scale_data, std::nullopt);
+  EXPECT_EQ(absent.features, std::nullopt);
+  EXPECT_EQ(absent.isPrecise(), std::nullopt);
+  EXPECT_EQ(absent.default_sampling_period, std::nullopt);
+  EXPECT_EQ(absent.errata, std::nullopt);
+
+  const EventDef explicitZeroMsr = materializeEventDef(kEvents[2]);
+  EXPECT_EQ(explicitZeroMsr.encoding.msr_values, std::vector<uint64_t>{0});
+  ASSERT_TRUE(explicitZeroMsr.scale_data.has_value());
+  EXPECT_EQ(std::get<int>(explicitZeroMsr.scale_data->scale_factor), 64);
+
+  const EventDef knownNotPrecise = materializeEventDef(kEvents[0]);
+  EXPECT_EQ(knownNotPrecise.isPrecise(), std::optional<bool>{false});
+  EXPECT_EQ(
+      knownNotPrecise.default_sampling_period, std::optional<uint64_t>{100003});
+}


### PR DESCRIPTION
Summary:

Wire constexpr StaticEventDef tables into the existing PmuDevice and
PmuDeviceManager APIs without eagerly allocating owning EventDef objects.

- Register sorted mixed-PMU tables atomically across existing applicable PMUs.
- Resolve owning and static definitions through existing lookup, alias,
  configuration, and enumeration APIs.
- Share synchronized lazy materialization across devices of the same PMU type.
- Preserve direct static EventConfigs generation and compatibility materialization.
- Cover partitioning, aliases, collisions, pointer identity, concurrency, and
  unavailable PMU behavior with synthetic constexpr catalogs.

Reviewed By: hmlee95070

Differential Revision: D117603687


